### PR TITLE
fixed makefile to testunity.out in root directory

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ all: clean default
 default:
 	ruby auto/generate_test_runner.rb test/testunity.c build/testunity_Runner.c
 	$(C_COMPILER) $(INC_DIRS) $(SYMBOLS) $(SRC_FILES) $(OUT_FILE)
-	$(TARGET)
+	./$(TARGET)
 
 clean:
 	$(CLEANUP)


### PR DESCRIPTION
testunity.out is being created in the
root directory and was being called from
the 'all' target incorrectly. This is
now fixed.
