### PR TITLE
Update tests on +/- infinity to work with MSVC++ 2008

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -32,6 +32,13 @@ const char* UnityStrInf      = "Infinity";
 const char* UnityStrNegInf   = "Negative Infinity";
 const char* UnityStrNaN      = "NaN";
 
+// Dividing by these constants produces +/- infinity.
+// The rationale is given in UnityAssertFloatIsInf's body.
+static const _UF f_zero = 0.0f;
+#ifndef UNITY_EXCLUDE_DOUBLE
+static const _UD d_zero = 0.0;
+#endif
+
 // compiler-generic print formatting masks
 const _U_UINT UnitySizeMask[] = 
 {
@@ -607,7 +614,12 @@ void UnityAssertFloatIsInf(const _UF actual,
 {
     UNITY_SKIP_EXECUTION;
 
-    if ((1.0f / 0.0f) != actual)
+    // In Microsoft Visual C++ Express Edition 2008,
+    //   if ((1.0f / f_zero) != actual)
+    // produces
+    //   error C2124: divide or mod by zero
+    // As a workaround, place 0 into a variable.
+    if ((1.0f / f_zero) != actual)
     {
         UnityTestResultsFailBegin(lineNumber);
 #ifdef UNITY_FLOAT_VERBOSE
@@ -630,7 +642,8 @@ void UnityAssertFloatIsNegInf(const _UF actual,
 {
     UNITY_SKIP_EXECUTION;
 
-    if ((-1.0f / 0.0f) != actual)
+    // The rationale for not using 1.0f/0.0f is given in UnityAssertFloatIsInf's body.
+    if ((-1.0f / f_zero) != actual)
     {
         UnityTestResultsFailBegin(lineNumber);
 #ifdef UNITY_FLOAT_VERBOSE
@@ -773,7 +786,8 @@ void UnityAssertDoubleIsInf(const _UD actual,
 {
     UNITY_SKIP_EXECUTION;
 
-    if ((1.0 / 0.0) != actual)
+    // The rationale for not using 1.0/0.0 is given in UnityAssertFloatIsInf's body.
+    if ((1.0 / d_zero) != actual)
     {
         UnityTestResultsFailBegin(lineNumber);
 #ifdef UNITY_DOUBLE_VERBOSE
@@ -796,7 +810,8 @@ void UnityAssertDoubleIsNegInf(const _UD actual,
 {
     UNITY_SKIP_EXECUTION;
 
-    if ((-1.0 / 0.0) != actual)
+    // The rationale for not using 1.0/0.0 is given in UnityAssertFloatIsInf's body.
+    if ((-1.0 / d_zero) != actual)
     {
         UnityTestResultsFailBegin(lineNumber);
 #ifdef UNITY_DOUBLE_VERBOSE

--- a/test/testunity.c
+++ b/test/testunity.c
@@ -7,6 +7,13 @@
 #include <setjmp.h>
 #include "unity.h"
 
+// Dividing by these constants produces +/- infinity.
+// The rationale is given in UnityAssertFloatIsInf's body.
+static const _UF f_zero = 0.0f;
+#ifndef UNITY_EXCLUDE_DOUBLE
+static const _UD d_zero = 0.0;
+#endif
+
 #define EXPECT_ABORT_BEGIN \
     if (TEST_PROTECT())    \
     {
@@ -2232,7 +2239,7 @@ void testFloatsNotEqualActualNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(85.963f, 0.0f / 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(85.963f, 0.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2243,7 +2250,7 @@ void testFloatsNotEqualExpectedNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(0.0f / 0.0f, 85.963f);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f / f_zero, 85.963f);
     VERIFY_FAILS_END
 #endif
 }
@@ -2254,7 +2261,7 @@ void testFloatsNotEqualBothNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(0.0f / 0.0f, 0.0f / 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f / f_zero, 0.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2265,7 +2272,7 @@ void testFloatsNotEqualInfNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(1.0f / 0.0f, 0.0f / 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f / f_zero, 0.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2276,7 +2283,7 @@ void testFloatsNotEqualNaNInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(0.0f / 0.0f, 1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f / f_zero, 1.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2287,7 +2294,7 @@ void testFloatsNotEqualActualInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(321.642f, 1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(321.642f, 1.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2298,7 +2305,7 @@ void testFloatsNotEqualExpectedInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(1.0f / 0.0f, 321.642f);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f / f_zero, 321.642f);
     VERIFY_FAILS_END
 #endif
 }
@@ -2309,7 +2316,7 @@ void testFloatsNotEqualBothInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(1.0f / 0.0f, 1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f / f_zero, 1.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2320,7 +2327,7 @@ void testFloatsNotEqualPlusMinusInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_FLOAT(1.0f / 0.0f, -1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_FLOAT(1.0f / f_zero, -1.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2330,8 +2337,8 @@ void testFloatIsInf(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    TEST_ASSERT_FLOAT_IS_INF(2.0f / 0.0f);
-    TEST_ASSERT_FLOAT_IS_NEG_INF(-3.0f / 0.0f);
+    TEST_ASSERT_FLOAT_IS_INF(2.0f / f_zero);
+    TEST_ASSERT_FLOAT_IS_NEG_INF(-3.0f / f_zero);
 #endif
 }
 
@@ -2362,7 +2369,7 @@ void testFloatIsNan(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    TEST_ASSERT_FLOAT_IS_NAN(0.0f / 0.0f);    
+    TEST_ASSERT_FLOAT_IS_NAN(0.0f / f_zero);    
 #endif
 }
 
@@ -2383,7 +2390,7 @@ void testFloatInfIsNotNan(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_FLOAT_IS_NAN(1.0f / 0.0f);
+    TEST_ASSERT_FLOAT_IS_NAN(1.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2394,7 +2401,7 @@ void testFloatNanIsNotInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_FLOAT_IS_INF(0.0f / 0.0f);
+    TEST_ASSERT_FLOAT_IS_INF(0.0f / f_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2404,10 +2411,10 @@ void testEqualFloatArrays(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {1.0, -8.0,  25.4, -0.123};
-    float p1[] = {1.0, -8.0,  25.4, -0.123};
-    float p2[] = {1.0, -8.0,  25.4, -0.2};
-    float p3[] = {1.0, -23.0, 25.0, -0.26};
+    float p0[] = {1.0f, -8.0f,  25.4f, -0.123f};
+    float p1[] = {1.0f, -8.0f,  25.4f, -0.123f};
+    float p2[] = {1.0f, -8.0f,  25.4f, -0.2f};
+    float p3[] = {1.0f, -23.0f, 25.0f, -0.26f};
 
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p0, 4);
@@ -2423,7 +2430,7 @@ void testNotEqualFloatArraysExpectedNull(void)
     TEST_IGNORE();
 #else
     float* p0 = NULL;
-    float p1[] = {1.0, 8.0, 25.4, 0.252};
+    float p1[] = {1.0f, 8.0f, 25.4f, 0.252f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2436,7 +2443,7 @@ void testNotEqualFloatArraysActualNull(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {1.0, 8.0, 25.4, 0.253};
+    float p0[] = {1.0f, 8.0f, 25.4f, 0.253f};
     float* p1 = NULL;
 
     EXPECT_ABORT_BEGIN
@@ -2450,8 +2457,8 @@ void testNotEqualFloatArrays1(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {1.0, 8.0, 25.4, 0.253};
-    float p1[] = {1.0, 8.0, 25.4, 0.252};
+    float p0[] = {1.0f, 8.0f, 25.4f, 0.253f};
+    float p1[] = {1.0f, 8.0f, 25.4f, 0.252f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2464,8 +2471,8 @@ void testNotEqualFloatArrays2(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {1.0, 8.0, 25.4, 0.253};
-    float p1[] = {2.0, 8.0, 25.4, 0.253};
+    float p0[] = {1.0f, 8.0f, 25.4f, 0.253f};
+    float p1[] = {2.0f, 8.0f, 25.4f, 0.253f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2478,8 +2485,8 @@ void testNotEqualFloatArrays3(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {1.0, 8.0, 25.4, 0.253};
-    float p1[] = {1.0, 8.0, 25.5, 0.253};
+    float p0[] = {1.0f, 8.0f, 25.4f, 0.253f};
+    float p1[] = {1.0f, 8.0f, 25.5f, 0.253f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2492,8 +2499,8 @@ void testNotEqualFloatArraysNegative1(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {-1.0, -8.0, -25.4, -0.253};
-    float p1[] = {-1.0, -8.0, -25.4, -0.252};
+    float p0[] = {-1.0f, -8.0f, -25.4f, -0.253f};
+    float p1[] = {-1.0f, -8.0f, -25.4f, -0.252f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2506,8 +2513,8 @@ void testNotEqualFloatArraysNegative2(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {-1.0, -8.0, -25.4, -0.253};
-    float p1[] = {-2.0, -8.0, -25.4, -0.253};
+    float p0[] = {-1.0f, -8.0f, -25.4f, -0.253f};
+    float p1[] = {-2.0f, -8.0f, -25.4f, -0.253f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2520,8 +2527,8 @@ void testNotEqualFloatArraysNegative3(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {-1.0, -8.0, -25.4, -0.253};
-    float p1[] = {-1.0, -8.0, -25.5, -0.253};
+    float p0[] = {-1.0f, -8.0f, -25.4f, -0.253f};
+    float p1[] = {-1.0f, -8.0f, -25.5f, -0.253f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2534,8 +2541,8 @@ void testNotEqualFloatArraysNaN(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {1.0, 0.0 / 0.0, 25.4, 0.253};
-    float p1[] = {1.0, 0.0 / 0.0, 25.4, 0.253};
+    float p0[] = {1.0f, 0.0f / f_zero, 25.4f, 0.253f};
+    float p1[] = {1.0f, 0.0f / f_zero, 25.4f, 0.253f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2548,8 +2555,8 @@ void testNotEqualFloatArraysInf(void)
 #ifdef UNITY_EXCLUDE_FLOAT
     TEST_IGNORE();
 #else
-    float p0[] = {1.0, 1.0 / 0.0, 25.4, 0.253};
-    float p1[] = {1.0, 1.0 / 0.0, 25.4, 0.253};
+    float p0[] = {1.0f, 1.0f / f_zero, 25.4f, 0.253f};
+    float p1[] = {1.0f, 1.0f / f_zero, 25.4f, 0.253f};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
@@ -2634,7 +2641,7 @@ void testDoublesNotEqualActualNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(85.963f, 0.0f / 0.0f);
+    TEST_ASSERT_EQUAL_DOUBLE(85.963, 0.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2645,7 +2652,7 @@ void testDoublesNotEqualExpectedNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(0.0f / 0.0f, 85.963f);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0 / d_zero, 85.963);
     VERIFY_FAILS_END
 #endif
 }
@@ -2656,7 +2663,7 @@ void testDoublesNotEqualBothNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(0.0f / 0.0f, 0.0f / 0.0f);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0 / d_zero, 0.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2667,7 +2674,7 @@ void testDoublesNotEqualInfNaN(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(1.0f / 0.0f, 0.0f / 0.0f);
+    TEST_ASSERT_EQUAL_DOUBLE(1.0 / d_zero, 0.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2678,7 +2685,7 @@ void testDoublesNotEqualNaNInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(0.0f / 0.0f, 1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0 / d_zero, 1.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2689,7 +2696,7 @@ void testDoublesNotEqualActualInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(321.642f, 1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_DOUBLE(321.642, 1.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2700,7 +2707,7 @@ void testDoublesNotEqualExpectedInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(1.0f / 0.0f, 321.642f);
+    TEST_ASSERT_EQUAL_DOUBLE(1.0 / d_zero, 321.642);
     VERIFY_FAILS_END
 #endif
 }
@@ -2711,7 +2718,7 @@ void testDoublesNotEqualBothInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(1.0f / 0.0f, 1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_DOUBLE(1.0 / d_zero, 1.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2722,7 +2729,7 @@ void testDoublesNotEqualPlusMinusInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_DOUBLE(1.0f / 0.0f, -1.0f / 0.0f);
+    TEST_ASSERT_EQUAL_DOUBLE(1.0 / d_zero, -1.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2732,8 +2739,8 @@ void testDoubleIsInf(void)
 #ifdef UNITY_EXCLUDE_DOUBLE
     TEST_IGNORE();
 #else
-    TEST_ASSERT_DOUBLE_IS_INF(2.0f / 0.0f);
-    TEST_ASSERT_DOUBLE_IS_NEG_INF(-3.0f / 0.0f);
+    TEST_ASSERT_DOUBLE_IS_INF(2.0 / d_zero);
+    TEST_ASSERT_DOUBLE_IS_NEG_INF(-3.0 / d_zero);
 #endif
 }
 
@@ -2743,7 +2750,7 @@ void testDoubleIsNotInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_DOUBLE_IS_INF(2.0f);
+    TEST_ASSERT_DOUBLE_IS_INF(2.0);
     VERIFY_FAILS_END
 #endif
 }
@@ -2754,7 +2761,7 @@ void testDoubleIsNotNegInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_DOUBLE_IS_NEG_INF(-999.876f);
+    TEST_ASSERT_DOUBLE_IS_NEG_INF(-999.876);
     VERIFY_FAILS_END
 #endif
 }
@@ -2764,7 +2771,7 @@ void testDoubleIsNan(void)
 #ifdef UNITY_EXCLUDE_DOUBLE
     TEST_IGNORE();
 #else
-    TEST_ASSERT_DOUBLE_IS_NAN(0.0f / 0.0f);    
+    TEST_ASSERT_DOUBLE_IS_NAN(0.0 / d_zero);    
 #endif
 }
 
@@ -2774,7 +2781,7 @@ void testDoubleIsNotNan(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_DOUBLE_IS_NAN(234.9f);
+    TEST_ASSERT_DOUBLE_IS_NAN(234.9);
     VERIFY_FAILS_END
 #endif
 }
@@ -2785,7 +2792,7 @@ void testDoubleInfIsNotNan(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_DOUBLE_IS_NAN(1.0f / 0.0f);
+    TEST_ASSERT_DOUBLE_IS_NAN(1.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2796,7 +2803,7 @@ void testDoubleNanIsNotInf(void)
     TEST_IGNORE();
 #else
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_DOUBLE_IS_INF(0.0f / 0.0f);
+    TEST_ASSERT_DOUBLE_IS_INF(0.0 / d_zero);
     VERIFY_FAILS_END
 #endif
 }
@@ -2936,8 +2943,8 @@ void testNotEqualDoubleArraysNaN(void)
 #ifdef UNITY_EXCLUDE_DOUBLE
     TEST_IGNORE();
 #else
-    double p0[] = {1.0, 0.0 / 0.0, 25.4, 0.253};
-    double p1[] = {1.0, 0.0 / 0.0, 25.4, 0.253};
+    double p0[] = {1.0, 0.0 / d_zero, 25.4, 0.253};
+    double p1[] = {1.0, 0.0 / d_zero, 25.4, 0.253};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_DOUBLE_ARRAY(p0, p1, 4);
@@ -2950,8 +2957,8 @@ void testNotEqualDoubleArraysInf(void)
 #ifdef UNITY_EXCLUDE_DOUBLE
     TEST_IGNORE();
 #else
-    double p0[] = {1.0, 1.0 / 0.0, 25.4, 0.253};
-    double p1[] = {1.0, 1.0 / 0.0, 25.4, 0.253};
+    double p0[] = {1.0, 1.0 / d_zero, 25.4, 0.253};
+    double p1[] = {1.0, 1.0 / d_zero, 25.4, 0.253};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_DOUBLE_ARRAY(p0, p1, 4);


### PR DESCRIPTION
MSVC produces an error in `if (actual != (0.0 / 1.0))`. This patch works around this bug, and also updates correct single/double precision constant types in the tests.
