### PR TITLE
C89 patch for MS Visual Studio 2008 Express Edition

### DIFF
--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -49,8 +49,8 @@ int UnityMain(int argc, char* argv[], void (*runAllTests)());
     void TEST_##group##_##name##_run()
 
 #define RUN_TEST_CASE(group, name) \
-        DECLARE_TEST_CASE(group, name);\
-    TEST_##group##_##name##_run();
+    { DECLARE_TEST_CASE(group, name);\
+      TEST_##group##_##name##_run(); }
 
 //This goes at the bottom of each test file or in a separate c file
 #define TEST_GROUP_RUNNER(group)\
@@ -63,8 +63,8 @@ int UnityMain(int argc, char* argv[], void (*runAllTests)());
 
 //Call this from main
 #define RUN_TEST_GROUP(group)\
-    void TEST_##group##_GROUP_RUNNER();\
-    TEST_##group##_GROUP_RUNNER();
+    { void TEST_##group##_GROUP_RUNNER();\
+      TEST_##group##_GROUP_RUNNER(); }
 
 //CppUTest Compatibility Macros
 #define UT_PTR_SET(ptr, newPointerValue)               UnityPointer_Set((void**)&ptr, (void*)newPointerValue)

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -49,10 +49,12 @@ TEST(UnityFixture, PointerSetting)
 
 TEST(UnityFixture, ForceMallocFail)
 {
+    void* m;
+    void* mfails;
     UnityMalloc_MakeMallocFailAfterCount(1);
-    void* m = malloc(10);
+    m = malloc(10);
     CHECK(m);
-    void* mfails = malloc(10);
+    mfails = malloc(10);
     TEST_ASSERT_POINTERS_EQUAL(0, mfails);
     free(m);
 }
@@ -76,8 +78,9 @@ TEST(UnityFixture, ReallocSameIsUnchanged)
 TEST(UnityFixture, ReallocLargerNeeded)
 {
     void* m1 = malloc(10);
+    void* m2;
     strcpy((char*)m1, "123456789");
-    void* m2 = realloc(m1, 15);
+    m2 = realloc(m1, 15);
     CHECK(m1 != m2);
     STRCMP_EQUAL("123456789", m2);
     free(m2);


### PR DESCRIPTION
- Declare all variables before statements in a function.
- Likewise, place all function prototypes before statements.

These changes support Microsoft Visual Studio 2008 Express Edition, which follows C89-style rules.
