### PR TITLE
The `build` directory is not created when running make, which yields an error. 

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ SYMBOLS=-DTEST -DUNITY_SUPPORT_64
 ifeq ($(OS),Windows_NT)
 	CLEANUP = del /F /Q build\* && del /F /Q $(TARGET)
 else
-	CLEANUP = rm -f build/*.o ; rm -f $(TARGET)
+	CLEANUP = rm -f build/*.o ; rm -f $(TARGET) ; mkdir -p build
 endif
 
 all: clean default


### PR DESCRIPTION
The `build` directory is not created when running make, which yields an error. 

My fix works, but there's probably a better place to create the directory if you know the code base/ruby.
