### PR TITLE
Fix missing #define when UNITY_EXCLUDE_FLOAT is used

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -32,11 +32,13 @@ const char* UnityStrInf      = "Infinity";
 const char* UnityStrNegInf   = "Negative Infinity";
 const char* UnityStrNaN      = "NaN";
 
+#ifndef UNITY_EXCLUDE_FLOAT
 // Dividing by these constants produces +/- infinity.
 // The rationale is given in UnityAssertFloatIsInf's body.
 static const _UF f_zero = 0.0f;
 #ifndef UNITY_EXCLUDE_DOUBLE
 static const _UD d_zero = 0.0;
+#endif
 #endif
 
 // compiler-generic print formatting masks


### PR DESCRIPTION
My unit test doesn't require float so I include the UNITY_EXCLUDE_FLOAT definition as part of my compilation process. But in this case, the compiler is throwing an error due _UF is not defined.

The modification is to wrap _UF and _UD with the "#ifndef UNITY_EXCLUDE_FLOAT" check.  So compiler will not fail at compilation time. 

No sure if there is a better way to do it, probably at different level, at _UF/_UD time(?).
