### PR TITLE
Fixing wrong index on string array inequality

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -981,7 +981,7 @@ void UnityAssertEqualStringArray( const char** expected,
             if (num_elements > 1)
             {
                 UnityPrint(UnityStrElement);
-                UnityPrintNumberByStyle((num_elements - j - 1), UNITY_DISPLAY_STYLE_UINT);
+                UnityPrintNumberByStyle((j), UNITY_DISPLAY_STYLE_UINT);
             }
             UnityPrintExpectedAndActualStrings((const char*)(expected[j]), (const char*)(actual[j]));
             UnityAddMsgIfSpecified(msg);


### PR DESCRIPTION
Currently the index reported by the string array equality assertion is wrong (counting from the back). This fixes it.

I didn't see any tests that assert the message of the failure. I would have liked to added some but didn't see an easy way to capture the output.

if you have suggestions or pointers that would allow a test, let me know.

Thanks,
Jim
