### PR TITLE
fix bug in target execsion in example makefile

### DIFF
--- a/examples/makefile
+++ b/examples/makefile
@@ -32,8 +32,8 @@ default:
 #	ruby auto/generate_test_runner.rb test/TestProductionCode2.c test/no_ruby/TestProductionCode2_Runner.c
 	$(C_COMPILER) $(INC_DIRS) $(SYMBOLS) $(SRC_FILES1) -o $(TARGET1)
 	$(C_COMPILER) $(INC_DIRS) $(SYMBOLS) $(SRC_FILES2) -o $(TARGET2)
-	$(TARGET1)
-	$(TARGET2)
+	./$(TARGET1)
+	./$(TARGET2)
 
 clean:
 	$(CLEANUP)


### PR DESCRIPTION
Normally, '.' is not included in $PATH. In example making, calling $(TAGGET1) $(TAGGET2) directly would return an error.  
