### PR TITLE
Fixing warnings thrown by PC-Lint and Clang (-Weverything)

### DIFF
--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -13,40 +13,39 @@
 #include "unity_fixture_malloc_overrides.h"
 #include "unity_fixture_internals.h"
 
-int UnityMain(int argc, char* argv[], void (*runAllTests)());
-
+int UnityMain(int argc, char* argv[], void (*runAllTests)(void));
 
 #define TEST_GROUP(group)\
-    int TEST_GROUP_##group = 0
+  static const char* TEST_GROUP_##group = #group
 
-#define TEST_SETUP(group) void TEST_##group##_SETUP()
+#define TEST_SETUP(group) void TEST_##group##_SETUP(void)
 
-#define TEST_TEAR_DOWN(group) void TEST_##group##_TEAR_DOWN()
-
+#define TEST_TEAR_DOWN(group) void TEST_##group##_TEAR_DOWN(void)
 
 #define TEST(group, name) \
-    void TEST_##group##_##name##_();\
-    void TEST_##group##_##name##_run()\
+    void TEST_##group##_##name##_(void);\
+    void TEST_##group##_##name##_run(void)\
     {\
         UnityTestRunner(TEST_##group##_SETUP,\
-             TEST_##group##_##name##_,\
-            TEST_##group##_TEAR_DOWN,\
-            "TEST(" #group ", " #name ")",\
-            #group, #name,\
-            __FILE__, __LINE__);\
+                        TEST_##group##_##name##_,\
+                        TEST_##group##_TEAR_DOWN,\
+                        "TEST(" #group ", " #name ")",\
+                        TEST_GROUP_##group, #name,\
+                        __FILE__, __LINE__);\
     }\
-    void  TEST_##group##_##name##_()
+    void  TEST_##group##_##name##_(void)
 
 #define IGNORE_TEST(group, name) \
-    void TEST_##group##_##name##_();\
-    void TEST_##group##_##name##_run()\
+    void TEST_##group##_##name##_(void);\
+    void TEST_##group##_##name##_run(void)\
     {\
-        UnityIgnoreTest("IGNORE_TEST(" #group ", " #name ")");\
+      (void)TEST_GROUP_##group;\
+      UnityIgnoreTest("IGNORE_TEST(" #group ", " #name ")");\
     }\
-    void  TEST_##group##_##name##_()
+    void TEST_##group##_##name##_(void)
 
 #define DECLARE_TEST_CASE(group, name) \
-    void TEST_##group##_##name##_run()
+    void TEST_##group##_##name##_run(void)
 
 #define RUN_TEST_CASE(group, name) \
     { DECLARE_TEST_CASE(group, name);\
@@ -54,16 +53,17 @@ int UnityMain(int argc, char* argv[], void (*runAllTests)());
 
 //This goes at the bottom of each test file or in a separate c file
 #define TEST_GROUP_RUNNER(group)\
-    void TEST_##group##_GROUP_RUNNER_runAll();\
-    void TEST_##group##_GROUP_RUNNER()\
+    void TEST_##group##_GROUP_RUNNER_runAll(void);\
+    void TEST_##group##_GROUP_RUNNER(void);\
+    void TEST_##group##_GROUP_RUNNER(void)\
     {\
         TEST_##group##_GROUP_RUNNER_runAll();\
     }\
-    void TEST_##group##_GROUP_RUNNER_runAll()
+    void TEST_##group##_GROUP_RUNNER_runAll(void)
 
 //Call this from main
 #define RUN_TEST_GROUP(group)\
-    { void TEST_##group##_GROUP_RUNNER();\
+    { void TEST_##group##_GROUP_RUNNER(void);\
       TEST_##group##_GROUP_RUNNER(); }
 
 //CppUTest Compatibility Macros

--- a/src/unity.c
+++ b/src/unity.c
@@ -401,8 +401,8 @@ void UnityAssertEqualNumber(const _U_SINT expected,
 }
 
 //-----------------------------------------------
-void UnityAssertEqualIntArray(const _U_SINT* expected,
-                              const _U_SINT* actual,
+void UnityAssertEqualIntArray(const void* expected,
+                              const void* actual,
                               const _UU32 num_elements,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber,

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -354,8 +354,8 @@ void UnityAssertEqualNumber(const _U_SINT expected,
                             const UNITY_LINE_TYPE lineNumber,
                             const UNITY_DISPLAY_STYLE_T style);
 
-void UnityAssertEqualIntArray(const _U_SINT* expected,
-                              const _U_SINT* actual,
+void UnityAssertEqualIntArray(const void* expected,
+                              const void* actual,
                               const _UU32 num_elements,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber,
@@ -486,18 +486,18 @@ void UnityAssertDoubleIsNaN(const _UD actual,
 #define UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, line, message)                          UnityAssertEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)line)
 #define UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, line, message)                     UnityAssertEqualMemory((void*)(expected), (void*)(actual), (_UU32)(len), 1, (message), (UNITY_LINE_TYPE)line)
 
-#define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT)
-#define UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT8)
-#define UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT16)
-#define UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT32)
-#define UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT)
-#define UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT8)
-#define UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT16)
-#define UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT32)
-#define UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_HEX8)
-#define UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_HEX16)
-#define UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const _U_SINT*)(expected), (const _U_SINT*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_HEX32)
-#define UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((const _U_SINT*)(_UP*)(expected), (const _U_SINT*)(_UP*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_POINTER)
+#define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((const void*)(expected), (const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((const void*)(_UP*)(expected), (const void*)(_UP*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_POINTER)
 #define UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualStringArray((const char**)(expected), (const char**)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line)
 #define UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements, line, message) UnityAssertEqualMemory((void*)(expected), (void*)(actual), (_UU32)(len), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line)
 


### PR DESCRIPTION
Fixing various warnings thrown by PC-Lint and Clang with -Weverything and -Werror.

Unity should now be Clang and PC-Lint friendly :)
