### PR TITLE
Fix TEST_ASSERT_EQUAL_INT_ARRAY for int sizes other than 32 bits

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -425,7 +425,10 @@ void UnityAssertEqualIntArray(const _U_SINT* expected,
     if (UnityCheckArraysForNull((void*)expected, (void*)actual, lineNumber, msg) == 1)
         return;
 
-    switch(style)
+    // If style is UNITY_DISPLAY_STYLE_INT, we'll fall into the default case rather than the INT16 or INT32 (etc) case
+    // as UNITY_DISPLAY_STYLE_INT includes a flag for UNITY_DISPLAY_RANGE_AUTO, which the width-specific
+    // variants do not. Therefore remove this flag.
+    switch(style & ~UNITY_DISPLAY_RANGE_AUTO)
     {
         case UNITY_DISPLAY_STYLE_HEX8:
         case UNITY_DISPLAY_STYLE_INT8:


### PR DESCRIPTION
This patch fixes testEqualIntArrays in the unity test suite on 16-bit
architectures.

TEST_ASSERT_EQUAL_INT_ARRAY calls UnityAssertEqualIntArray with 'style'
set to UNITY_DISPLAY_STYLE_INT.

UNITY_DISPLAY_STYLE_INT is defined as UNITY_DISPLAY_STYLE_AUTO +
UNITY_DISPLAY_STYLE_INT{16,32,64} (depending on the int width).

However, the switch statement in UnityAssertEqualIntArray has special
cases for the width-specific display styles, but these comparisons
are carried out without clearing the UNITY_DISPLAY_STYLE_AUTO flag.
This means that if 'style' is UNITY_DISPLAY_STYLE_INT, and the int
width is, say, 16, bits, the default case will be hit, and elements
compared as if they were 32 bits wide. Unsurprisingly this causes
a failure in the test named above.
