### PR TITLE
Print an EOL before printing the TestResult while executing the spec

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -249,6 +249,7 @@ void UnityPrintOk(void)
 //-----------------------------------------------
 void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 {
+    UNITY_PRINT_EOL;
     UnityPrint(file);
     UNITY_OUTPUT_CHAR(':');
     UnityPrintNumber(line);


### PR DESCRIPTION
By printing this newline, the filepath of the failing assertion does not get
preceded by the dot which represents a running test.

This gives the advantage, that the complete output of unity can be used as it is
with a makefile in vim. Every error gets displayed in the quickfix and you can
jump appropiately.

This increased my productivity with Unity, make and vim by a magnitude.
