### PR TITLE
fix parameter type for runAllTests to match header

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -28,7 +28,7 @@ void announceTestRun(unsigned int runNumber)
     UNITY_OUTPUT_CHAR('\n');
 }
 
-int UnityMain(int argc, char* argv[], void (*runAllTests)())
+int UnityMain(int argc, char* argv[], void (*runAllTests)(void))
 {
     int result = UnityGetCommandLineOptions(argc, argv);
     unsigned int r;


### PR DESCRIPTION
At least in Microchip XC8 compiler, void (*runAllTests)(void) is treated as a different type from void (*runAllTests)().

Fix the definition of UnityMain to match the declaration by making the runAllTests's (void) parameter list explicit.
