### PR TITLE
 Print EOL after each test

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -288,6 +288,7 @@ void UnityConcludeTest(void)
 
     Unity.CurrentTestFailed = 0;
     Unity.CurrentTestIgnored = 0;
+    UNITY_PRINT_EOL;
 }
 
 //-----------------------------------------------


### PR DESCRIPTION
Adding EOL after each test makes parsing the results easier for tools
like ceedling, which was choking when a test used stdout and there wasn't an
EOL after "PASS" (ThrowTheSwitch/Ceedling#41).
