### PR TITLE
Customizations our team has made

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -195,7 +195,7 @@ class UnityTestRunnerGenerator
       end
       output.puts("}\n")
 
-      output.puts("static void CMock_Verify(void)")
+      output.puts("void CMock_Verify(void)")
       output.puts("{")
       mocks.each do |mock|
         mock_clean = mock.gsub(/(?:-|\s+)/, "_")
@@ -241,6 +241,7 @@ class UnityTestRunnerGenerator
     output.puts("  Unity.CurrentTestName = #TestFunc#{va_args2.empty? ? '' : " \"(\" ##{va_args2} \")\""}; \\")
     output.puts("  Unity.CurrentTestLineNumber = TestLineNum; \\")
     output.puts("  Unity.NumberOfTests++; \\")
+    output.puts("  TEST_RESET_GLOBAL_MESSAGE(); \\")
     output.puts("  CMock_Init(); \\") unless (used_mocks.empty?)
     output.puts("  if (TEST_PROTECT()) \\")
     output.puts("  { \\")

--- a/src/unity.h
+++ b/src/unity.h
@@ -6,7 +6,16 @@
 
 #ifndef UNITY_FRAMEWORK_H
 #define UNITY_FRAMEWORK_H
-#define UNITY
+
+#define UNITY_EXCLUDE_STDINT_H // DGS: This prevents Unity from #including <stdint.h>
+
+// DGS: These override the Unity default types which are unsigned shorts
+#define UNITY_LINE_TYPE unsigned long
+#define UNITY_COUNTER_TYPE unsigned long
+
+// make floating point unit tests print the expected and actual values when they fail.
+#define UNITY_FLOAT_VERBOSE
+#define UNITY_FRAMEWORK
 
 #include "unity_internals.h"
 
@@ -267,6 +276,13 @@
 #define TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF_MESSAGE(actual, message)                                 UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, __LINE__, message)
 #define TEST_ASSERT_DOUBLE_IS_NOT_NAN_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, __LINE__, message)
 #define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, __LINE__, message)
+
+//-------------------------------------------------------
+// Utility Macros
+//-------------------------------------------------------
+#define NUMBER_OF_ARRAY_ELEMENTS(arr)   (sizeof(arr) / sizeof(arr[0]))
+#define TEST_SET_GLOBAL_MESSAGE(msg)    UnitySetGlobalMessage(msg)
+#define TEST_RESET_GLOBAL_MESSAGE()     UnitySetGlobalMessage(NULL)
 
 //end of UNITY_FRAMEWORK_H
 #endif

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -400,6 +400,7 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
 // Test Output
 //-------------------------------------------------------
 
+void UnitySetGlobalMessage(const char* msg);
 void UnityPrint(const char* string);
 void UnityPrintMask(const _U_UINT mask, const _U_UINT number);
 void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T style);


### PR DESCRIPTION
generate_test_runner.rb  
1. Removed 'static' from CMock_Verify() generation to allow calling CMock_Verify() from tests.  This is useful for verify mock calls (really the absence of) between test cases in a test cases lookup table style test.
2. Added call to TEST_RESET_GLOBAL_MESSAGE() in create_runtest() to clear a previously set global test message (see below).

unity.c/unity.h/unity_internals.h: 
1. Added Windows cmd.exe specific and generic ANSI terminal coloring of unity output.
2. Added UnitySetGlobalMessage(), TEST_SET_GLOBAL_MESSAGE(), TEST_RESET_GLOBAL_MESSAGE(), and const char\* UnityStrGlobalTestMsg to allow a test (again mostly useful for lookup table style tests) to specify a global message to be printed for any TEST_ASSERT/TEST_FAIL/TEST_IGNORE/CMock failure.  Implementation of this includes refactoring of UnityAddMsgIfSpecified() and addition of UnityAddLonelyMsgIfSpecified() to handle assert specified messages and the global message.
3. Added handy NUMBER_OF_ARRAY_ELEMENTS() macro
4. Replaced 13 and 10 magic numbers with '\r' and '\n' character respectively.
5. Abstracted usage of snprintf() vs. sprintf_s() via SAFE_SPRINTF() macro
6. Initialize struct _Unity Unity to 0 just to be safe
