### PR TITLE
Adding global test fail/ignore message, using safe sprintf alternatives, adding configurable test result token delimiter minor clean up

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -195,7 +195,7 @@ class UnityTestRunnerGenerator
       end
       output.puts("}\n")
 
-      output.puts("void CMock_Verify(void)")
+      output.puts("static void CMock_Verify(void)")
       output.puts("{")
       mocks.each do |mock|
         mock_clean = mock.gsub(/(?:-|\s+)/, "_")

--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -195,7 +195,7 @@ class UnityTestRunnerGenerator
       end
       output.puts("}\n")
 
-      output.puts("static void CMock_Verify(void)")
+      output.puts("void CMock_Verify(void)")
       output.puts("{")
       mocks.each do |mock|
         mock_clean = mock.gsub(/(?:-|\s+)/, "_")
@@ -241,6 +241,7 @@ class UnityTestRunnerGenerator
     output.puts("  Unity.CurrentTestName = #TestFunc#{va_args2.empty? ? '' : " \"(\" ##{va_args2} \")\""}; \\")
     output.puts("  Unity.CurrentTestLineNumber = TestLineNum; \\")
     output.puts("  Unity.NumberOfTests++; \\")
+    output.puts("  TEST_RESET_GLOBAL_MESSAGE(); \\")
     output.puts("  CMock_Init(); \\") unless (used_mocks.empty?)
     output.puts("  if (TEST_PROTECT()) \\")
     output.puts("  { \\")

--- a/src/unity.c
+++ b/src/unity.c
@@ -7,6 +7,7 @@
 #include "unity.h"
 #include <stdio.h>
 #include <string.h>
+#ifdef UNITY_COLOR_OUTPUT
 #if defined(_MSC_VER)
 #include <Windows.h>
 #define FOREGROUND_YELLOW 6     /* For some reason Microsoft didn't define yellow */
@@ -15,15 +16,20 @@
 #define UNITY_SET_FAIL_COLORS    { SetConsoleTextAttribute(hConsoleOut, FOREGROUND_RED    | FOREGROUND_INTENSITY); }
 #define UNITY_SET_PASS_COLORS    { SetConsoleTextAttribute(hConsoleOut, FOREGROUND_GREEN  | FOREGROUND_INTENSITY); }
 #define UNITY_SET_IGNORE_COLORS  { SetConsoleTextAttribute(hConsoleOut, FOREGROUND_YELLOW | FOREGROUND_INTENSITY); }
-#define SAFE_SPRINTF sprintf_s
-#else
+HANDLE hConsoleOut;
+#else // defined (_MSC_VER)
 #define ANSI_ESC 0x1B           /* Escape character for setting ANSI terminal attributes */
 #define UNITY_SET_DEFAULT_COLORS { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('0');                         UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[0m" */
 #define UNITY_SET_FAIL_COLORS    { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('1'); UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[31m" */
 #define UNITY_SET_PASS_COLORS    { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('2'); UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[32m" */
 #define UNITY_SET_IGNORE_COLORS  { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[33m" */
-#define SAFE_SPRINTF snprintf
-#endif
+#endif // defined (_MSC_VER)
+#else // UNITY_COLOR_OUTPUT
+#define UNITY_SET_DEFAULT_COLORS
+#define UNITY_SET_FAIL_COLORS
+#define UNITY_SET_PASS_COLORS
+#define UNITY_SET_IGNORE_COLORS
+#endif // UNITY_COLOR_OUTPUT
 
 #define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
 #define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
@@ -32,11 +38,13 @@
 #define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\r'); UNITY_OUTPUT_CHAR('\n'); }
 // globals
 #if defined(_MSC_VER)
-HANDLE hConsoleOut;
+#define SAFE_SPRINTF sprintf_s
+#else
+#define SAFE_SPRINTF snprintf
 #endif
 
 #ifndef UNITY_RESULT_DELIMITER
-#define UNITY_RESULT_DELIMITER ';'
+#define UNITY_RESULT_DELIMITER ':'
 #endif
 
 struct _Unity Unity = { 0 };

--- a/src/unity.c
+++ b/src/unity.c
@@ -5,38 +5,13 @@
 ============================================================================ */
 
 #include "unity.h"
-#include <stdio.h>
-#include <string.h>
-#ifdef UNITY_COLOR_OUTPUT
-#if defined(_MSC_VER)
-#include <Windows.h>
-#define FOREGROUND_YELLOW 6     /* For some reason Microsoft didn't define yellow */
-#define FOREGROUND_WHITE  7     /* ... or white */
-#define UNITY_SET_DEFAULT_COLORS { SetConsoleTextAttribute(hConsoleOut, FOREGROUND_WHITE); }
-#define UNITY_SET_FAIL_COLORS    { SetConsoleTextAttribute(hConsoleOut, FOREGROUND_RED    | FOREGROUND_INTENSITY); }
-#define UNITY_SET_PASS_COLORS    { SetConsoleTextAttribute(hConsoleOut, FOREGROUND_GREEN  | FOREGROUND_INTENSITY); }
-#define UNITY_SET_IGNORE_COLORS  { SetConsoleTextAttribute(hConsoleOut, FOREGROUND_YELLOW | FOREGROUND_INTENSITY); }
-HANDLE hConsoleOut;
-#else // defined (_MSC_VER)
-#define ANSI_ESC 0x1B           /* Escape character for setting ANSI terminal attributes */
-#define UNITY_SET_DEFAULT_COLORS { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('0');                         UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[0m" */
-#define UNITY_SET_FAIL_COLORS    { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('1'); UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[31m" */
-#define UNITY_SET_PASS_COLORS    { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('2'); UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[32m" */
-#define UNITY_SET_IGNORE_COLORS  { UNITY_OUTPUT_CHAR(ANSI_ESC); UNITY_OUTPUT_CHAR('['); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('3'); UNITY_OUTPUT_CHAR('m'); } /* "<ESC>[33m" */
-#endif // defined (_MSC_VER)
-#else // UNITY_COLOR_OUTPUT
-#define UNITY_SET_DEFAULT_COLORS
-#define UNITY_SET_FAIL_COLORS
-#define UNITY_SET_PASS_COLORS
-#define UNITY_SET_IGNORE_COLORS
-#endif // UNITY_COLOR_OUTPUT
 
 #define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
 #define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
 /// return prematurely if we are already in failure or ignore state
 #define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} }
-#define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\r'); UNITY_OUTPUT_CHAR('\n'); }
-// globals
+#define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }
+
 #if defined(_MSC_VER)
 #define SAFE_SPRINTF sprintf_s
 #else
@@ -78,7 +53,7 @@ const char UnityStrResultsTests[]           = " Tests ";
 const char UnityStrResultsFailures[]        = " Failures ";
 const char UnityStrResultsIgnored[]         = " Ignored ";
 
-const char* UnityStrGlobalTestMsg = NULL;  // DGS: I added this as way to specify a global (per test) message printed on failed or ignored test
+const char* UnityStrGlobalTestMsg = NULL;
 
 #ifndef UNITY_EXCLUDE_FLOAT
 // Dividing by these constants produces +/- infinity.
@@ -315,9 +290,6 @@ void UnityPrintOk(void)
 //-----------------------------------------------
 void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 {
-    // Reset console text to white
-    UNITY_SET_DEFAULT_COLORS;
-
     UNITY_PRINT_EOL;
     UnityPrint(file);
     UNITY_OUTPUT_CHAR(UNITY_RESULT_DELIMITER);
@@ -325,28 +297,11 @@ void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
     UNITY_OUTPUT_CHAR(UNITY_RESULT_DELIMITER);
     UnityPrint(Unity.CurrentTestName);
     UNITY_OUTPUT_CHAR(UNITY_RESULT_DELIMITER);
-
-    if (Unity.CurrentTestFailed)
-    {
-        // Set console text to red
-        UNITY_SET_FAIL_COLORS;
-    }
-    else if(Unity.CurrentTestIgnored)
-    {
-        // Set console text to yellow
-        UNITY_SET_IGNORE_COLORS;
-    }
-    else
-    {
-        // Set console text to green
-        UNITY_SET_PASS_COLORS;
-    }
 }
 
 //-----------------------------------------------
 void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line)
 {
-    Unity.CurrentTestFailed = 1;        // DGS: Added to trigger color coding of test results. UNITY_FAIL_AND_BAIL sets this as well
     UnityTestResultsBegin(Unity.TestFile, line);
     UnityPrint(UnityStrFail);
     UNITY_OUTPUT_CHAR(UNITY_RESULT_DELIMITER);
@@ -1159,8 +1114,6 @@ void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
 {
     UNITY_SKIP_EXECUTION;
 
-    Unity.CurrentTestFailed = 1;        // DGS: Added to trigger color coding of test results. UNITY_FAIL_AND_BAIL sets this as well
-
     UnityTestResultsBegin(Unity.TestFile, line);
     UnityPrintFail();
     UnityAddLonelyMsgIfSpecified(msg);
@@ -1171,8 +1124,6 @@ void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
 void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
 {
     UNITY_SKIP_EXECUTION;
-
-    Unity.CurrentTestIgnored = 1;       // DGS: Added to trigger color coding of test results. UNITY_IGNORE_AND_BAIL sets this as well
 
     UnityTestResultsBegin(Unity.TestFile, line);
     UnityPrint(UnityStrIgnore);
@@ -1209,10 +1160,6 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
 //-----------------------------------------------
 void UnityBegin(const char* filename)
 {
-#if defined(_MSC_VER)
-    hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
-#endif
-
     Unity.TestFile = filename;
     Unity.CurrentTestName = NULL;
     Unity.CurrentTestLineNumber = 0;
@@ -1228,57 +1175,26 @@ void UnityBegin(const char* filename)
 //-----------------------------------------------
 int UnityEnd(void)
 {
-    // Reset console text to white
-    UNITY_SET_DEFAULT_COLORS;
-
     UNITY_PRINT_EOL;
     UnityPrint(UnityStrBreaker);
     UNITY_PRINT_EOL;
     UnityPrintNumber((_U_SINT)(Unity.NumberOfTests));
     UnityPrint(UnityStrResultsTests);
-
-    if(Unity.TestFailures > 0)
-    {
-        // Set console text to red
-        UNITY_SET_FAIL_COLORS;
-    }
-
     UnityPrintNumber((_U_SINT)(Unity.TestFailures));
     UnityPrint(UnityStrResultsFailures);
-
-    // Reset console text to white
-    UNITY_SET_DEFAULT_COLORS;
-
-    if(Unity.TestIgnores > 0)
-    {
-        // Set console text to yellow
-        UNITY_SET_IGNORE_COLORS;
-    }
-
     UnityPrintNumber((_U_SINT)(Unity.TestIgnores));
     UnityPrint(UnityStrResultsIgnored);
-
-    // Reset console text to white
-    UNITY_SET_DEFAULT_COLORS;
-
     UNITY_PRINT_EOL;
     if (Unity.TestFailures == 0U)
     {
-        // Set console text to green
-        UNITY_SET_PASS_COLORS;
         UnityPrintOk();
     }
     else
     {
-        // Set console text to red
-        UNITY_SET_FAIL_COLORS;
         UnityPrintFail();
     }
     UNITY_PRINT_EOL;
-
-    // Reset console text to white
-    UNITY_SET_DEFAULT_COLORS;
-
+    UNITY_OUTPUT_COMPLETE();
     return (int)(Unity.TestFailures);
 }
 

--- a/src/unity.h
+++ b/src/unity.h
@@ -7,16 +7,6 @@
 #ifndef UNITY_FRAMEWORK_H
 #define UNITY_FRAMEWORK_H
 
-#define UNITY_EXCLUDE_STDINT_H // DGS: This prevents Unity from #including <stdint.h>
-
-// DGS: These override the Unity default types which are unsigned shorts
-#define UNITY_LINE_TYPE unsigned long
-#define UNITY_COUNTER_TYPE unsigned long
-
-// make floating point unit tests print the expected and actual values when they fail.
-#define UNITY_FLOAT_VERBOSE
-#define UNITY_FRAMEWORK
-
 #include "unity_internals.h"
 
 //-------------------------------------------------------
@@ -280,7 +270,6 @@
 //-------------------------------------------------------
 // Utility Macros
 //-------------------------------------------------------
-#define NUMBER_OF_ARRAY_ELEMENTS(arr)   (sizeof(arr) / sizeof(arr[0]))
 #define TEST_SET_GLOBAL_MESSAGE(msg)    UnitySetGlobalMessage(msg)
 #define TEST_RESET_GLOBAL_MESSAGE()     UnitySetGlobalMessage(NULL)
 

--- a/src/unity.h
+++ b/src/unity.h
@@ -6,6 +6,7 @@
 
 #ifndef UNITY_FRAMEWORK_H
 #define UNITY_FRAMEWORK_H
+#define UNITY
 
 #include "unity_internals.h"
 

--- a/src/unity.h
+++ b/src/unity.h
@@ -6,7 +6,16 @@
 
 #ifndef UNITY_FRAMEWORK_H
 #define UNITY_FRAMEWORK_H
-#define UNITY
+
+#define UNITY_EXCLUDE_STDINT_H // DGS: This prevents Unity from #including <stdint.h>
+
+// DGS: These override the Unity default types which are unsigned shorts
+#define UNITY_LINE_TYPE unsigned long
+#define UNITY_COUNTER_TYPE unsigned long
+
+// make floating point unit tests print the expected and actual values when they fail.
+#define UNITY_FLOAT_VERBOSE
+#define UNITY_FRAMEWORK
 
 #include "unity_internals.h"
 
@@ -267,6 +276,13 @@
 #define TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF_MESSAGE(actual, message)                                 UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, __LINE__, message)
 #define TEST_ASSERT_DOUBLE_IS_NOT_NAN_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, __LINE__, message)
 #define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, __LINE__, message)
+
+//-------------------------------------------------------
+// Utility Macros
+//-------------------------------------------------------
+#define NUMBER_OF_ARRAY_ELEMENTS(arr)   (sizeof(arr) / sizeof(arr[0]))
+#define TEST_SET_GLOBAL_MESSAGE(msg)    UnitySetGlobalMessage(msg)
+#define TEST_RESET_GLOBAL_MESSAGE()     UnitySetGlobalMessage(NULL)
 
 //end of UNITY_FRAMEWORK_H
 #endif

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -400,6 +400,7 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
 // Test Output
 //-------------------------------------------------------
 
+void UnitySetGlobalMessage(const char* msg);
 void UnityPrint(const char* string);
 void UnityPrintMask(const _U_UINT mask, const _U_UINT number);
 void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T style);

--- a/test/expectdata/testsample_cmd.c
+++ b/test/expectdata/testsample_cmd.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
     CEXCEPTION_T e; \

--- a/test/expectdata/testsample_def.c
+++ b/test/expectdata/testsample_def.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
       setUp(); \

--- a/test/expectdata/testsample_mock_cmd.c
+++ b/test/expectdata/testsample_mock_cmd.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_mock_def.c
+++ b/test/expectdata/testsample_mock_def.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_mock_new1.c
+++ b/test/expectdata/testsample_mock_new1.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_mock_new2.c
+++ b/test/expectdata/testsample_mock_new2.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_mock_param.c
+++ b/test/expectdata/testsample_mock_param.c
@@ -7,6 +7,7 @@
   Unity.CurrentTestName = #TestFunc "(" #__VA_ARGS__ ")"; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_mock_run1.c
+++ b/test/expectdata/testsample_mock_run1.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_mock_run2.c
+++ b/test/expectdata/testsample_mock_run2.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_mock_yaml.c
+++ b/test/expectdata/testsample_mock_yaml.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   CMock_Init(); \
   if (TEST_PROTECT()) \
   { \

--- a/test/expectdata/testsample_new1.c
+++ b/test/expectdata/testsample_new1.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
     CEXCEPTION_T e; \

--- a/test/expectdata/testsample_new2.c
+++ b/test/expectdata/testsample_new2.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
       setUp(); \

--- a/test/expectdata/testsample_param.c
+++ b/test/expectdata/testsample_param.c
@@ -7,6 +7,7 @@
   Unity.CurrentTestName = #TestFunc "(" #__VA_ARGS__ ")"; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
       setUp(); \

--- a/test/expectdata/testsample_run1.c
+++ b/test/expectdata/testsample_run1.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
     CEXCEPTION_T e; \

--- a/test/expectdata/testsample_run2.c
+++ b/test/expectdata/testsample_run2.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
       setUp(); \

--- a/test/expectdata/testsample_yaml.c
+++ b/test/expectdata/testsample_yaml.c
@@ -6,6 +6,7 @@
   Unity.CurrentTestName = #TestFunc; \
   Unity.CurrentTestLineNumber = TestLineNum; \
   Unity.NumberOfTests++; \
+  TEST_RESET_GLOBAL_MESSAGE(); \
   if (TEST_PROTECT()) \
   { \
     CEXCEPTION_T e; \


### PR DESCRIPTION
1. Added UnitySetGlobalMessage(), TEST_SET_GLOBAL_MESSAGE(), TEST_RESET_GLOBAL_MESSAGE(), and const char* UnityStrGlobalTestMsg to allow a test (mostly useful for lookup table style tests) to specify a global message to be printed for any TEST_ASSERT/TEST_FAIL/TEST_IGNORE/CMock failure.  Implementation of this includes refactoring of UnityAddMsgIfSpecified() and addition of UnityAddLonelyMsgIfSpecified() to handle assert specified messages and the global message.
2. Added call to TEST_RESET_GLOBAL_MESSAGE() in create_runtest() to clear a previously set global test message.
3. Added UNITY_RESULT_DELIMITER #define which allows for delimiters other than ':'.  This was needed by our CI build because the Unity results were being detected as GCC warnings.
4. Added SAFE_SPRINTF() macro to abstract snprintf() vs sprintf_s() usage instead of the less safe sprintf()
5. Minor clean up for readability/defensive coding