### PR TITLE
Print newline after each test, but not before

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -273,7 +273,6 @@ void UnityPrintOk(void)
 //-----------------------------------------------
 void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 {
-    UNITY_PRINT_EOL;
     UnityPrint(file);
     UNITY_OUTPUT_CHAR(':');
     UnityPrintNumber((_U_SINT)line);
@@ -309,6 +308,7 @@ void UnityConcludeTest(void)
 
     Unity.CurrentTestFailed = 0;
     Unity.CurrentTestIgnored = 0;
+    UNITY_PRINT_EOL;
 }
 
 //-----------------------------------------------
@@ -1164,5 +1164,3 @@ int UnityEnd(void)
 }
 
 //-----------------------------------------------
-
-


### PR DESCRIPTION
This change makes parsing the results easier for tools like ceedling,
which was choking when a test used stdout and there wasn't an
EOL after "PASS" (ThrowTheSwitch/Ceedling#41).
