### PR TITLE
New macros for controlling use of weak linkage

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1101,12 +1101,17 @@ void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
 }
 
 //-----------------------------------------------
-#ifdef UNITY_SUPPORT_WEAK
-UNITY_WEAK void setUp(void) { }
-UNITY_WEAK void tearDown(void) { }
+#if defined(UNITY_WEAK_ATTRIBUTE)
+    UNITY_WEAK_ATTRIBUTE void setUp(void) { }
+    UNITY_WEAK_ATTRIBUTE void tearDown(void) { }
+#elif defined(UNITY_WEAK_PRAGMA)
+#   pragma weak setUp
+    void setUp(void);
+#   pragma weak tearDown
+    void tearDown(void);
 #else
-void setUp(void);
-void tearDown(void);
+    void setUp(void);
+    void tearDown(void);
 #endif
 //-----------------------------------------------
 void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum)

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -292,22 +292,19 @@ extern int UNITY_OUTPUT_CHAR(int);
 //-------------------------------------------------------
 // Language Features Available
 //-------------------------------------------------------
-
-#ifdef __GNUC__
-#define UNITY_SUPPORT_WEAK __attribute__((weak))
+#if !defined(UNITY_WEAK_ATTRIBUTE) && !defined(UNITY_WEAK_PRAGMA)
+#   ifdef __GNUC__ // includes clang
+#       if !(defined(__WIN32__) && defined(__clang__))
+#           define UNITY_WEAK_ATTRIBUTE __attribute__((weak))
+#       endif
+#   endif
 #endif
 
-#ifdef __clang__
-#define UNITY_SUPPORT_WEAK __attribute__((weak))
+#ifdef UNITY_NO_WEAK
+#   undef UNITY_WEAK_ATTRIBUTE
+#   undef UNITY_WEAK_PRAGMA
 #endif
 
-#ifndef UNITY_WEAK
-#ifdef UNITY_SUPPORT_WEAK
-#define UNITY_WEAK UNITY_SUPPORT_WEAK
-#else
-#define UNITY_WEAK
-#endif
-#endif
 
 //-------------------------------------------------------
 // Internal Structs Needed


### PR DESCRIPTION
- `UNITY_WEAK_ATTRIBUTE`, if defined, is placed before declarations of weakly
  linked symbols. If not manually defined, it will be automatically set to
  `__attribute__((weak))` on GCC and Clang, except for Clang for Win32.
- `UNITY_WEAK_PRAGMA`, if defined, will cause preprocessor to emit
  `#pragma weak setUp`, etc. Ignored if `UNITY_WEAK_ATTRIBUTE` is defined.
- `UNITY_NO_WEAK` undefines both of the above resulting in no weakly
  linked symbols.

Work around for ThrowTheSwitch/Unity#93
