### PR TITLE
Added "const" to one argv parameter that was missed when adding strict error checks.

### DIFF
--- a/examples/example_2/test/test_runners/all_tests.c
+++ b/examples/example_2/test/test_runners/all_tests.c
@@ -6,7 +6,7 @@ static void RunAllTests(void)
   RUN_TEST_GROUP(ProductionCode2);
 }
 
-int main(int argc, char * argv[])
+int main(int argc, const char * argv[])
 {
   return UnityMain(argc, argv, RunAllTests);
 }


### PR DESCRIPTION
One argv was missing a "const". It caused "example_2" to not compile properly.