### PR TITLE
undef defined callc/realloc macros

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -162,6 +162,14 @@ void UnityMalloc_MakeMallocFailAfterCount(int countdown)
 #undef free
 #endif
 
+#ifdef calloc
+#undef calloc
+#endif
+
+#ifdef realloc
+#undef realloc
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
undef defined calloc&realloc macros same as malloc&free.
MSVC says error when these macros are defined.