### PR TITLE
Move announceTestRun() after UnityBegin()

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -40,8 +40,8 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
 
     for (r = 0; r < UnityFixture.RepeatCount; r++)
     {
-        announceTestRun(r);
         UnityBegin(argv[0]);
+        announceTestRun(r);
         runAllTests();
         UNITY_OUTPUT_CHAR('\n');
         UnityEnd();


### PR DESCRIPTION
Move announceTestRun below UnityBegin.
announceTestRun uses UNITY_OUTPUT_CHAR(), but UNITY_OUTPUT_START() is called in UnityBegin.
I guess UNITY_OUTPUT_START should be called prior to call UNITY_OUTPUT_CHAR.