### PR TITLE
Output new-line char not only PASSed/IGNOREed but also FAILed under Verb...

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -390,6 +390,10 @@ void UnityConcludeFixtureTest(void)
     }
     else if (Unity.CurrentTestFailed)
     {
+        if (UnityFixture.Verbose)
+        {
+            UNITY_OUTPUT_CHAR('\n');
+        }
         Unity.TestFailures++;
     }
 


### PR DESCRIPTION
There's no new-line char after FAILed message under verbose mode.
Example:
```c

#include <stdio.h>
#include "Unity/src/unity.h"
#include "Unity/extras/fixture/src/unity_fixture.h"

TEST_GROUP(grp);
TEST_SETUP(grp){}
TEST_TEAR_DOWN(grp){}
TEST(grp, 1){ TEST_ASSERT_EQUAL(0,0); }
TEST(grp, 2){ TEST_IGNORE(); }
TEST(grp, 3){ TEST_FAIL(); }
TEST(grp, 4){ TEST_ASSERT_EQUAL(0,0); }
TEST_GROUP_RUNNER(grp)
{
    RUN_TEST_CASE(grp, 1);
    RUN_TEST_CASE(grp, 2);
    RUN_TEST_CASE(grp, 3);
    RUN_TEST_CASE(grp, 4);
}

void runAll(void)
{
    RUN_TEST_GROUP(grp);
}

int main(void)
{
    const char* args[] = {"", "-v"};
    UnityMain(sizeof(args)/sizeof(args[0]), args, runAll);
    return 0;
}
```

Result(current):
```
$ ./a.out
Unity test run 1 of 1
TEST(grp, 1) PASS
TEST(grp, 2)sample.c:9:TEST(grp, 2):IGNORE
TEST(grp, 3)sample.c:10:TEST(grp, 3):FAILTEST(grp, 4) PASS


-----------------------
4 Tests 1 Failures 1 Ignored
FAIL
```

Result(fixed):
```
$ ./a.out
Unity test run 1 of 1
TEST(grp, 1) PASS
TEST(grp, 2)sample.c:9:TEST(grp, 2):IGNORE
TEST(grp, 3)sample.c:10:TEST(grp, 3):FAIL
TEST(grp, 4) PASS


-----------------------
4 Tests 1 Failures 1 Ignored
FAIL
```