### PR TITLE
Added assertions counter.

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1145,6 +1145,7 @@ void UnityBegin(const char* filename)
     Unity.TestIgnores = 0;
     Unity.CurrentTestFailed = 0;
     Unity.CurrentTestIgnored = 0;
+    Unity.NumberOfAssertions = 0;
 
     UNITY_OUTPUT_START();
 }

--- a/src/unity.c
+++ b/src/unity.c
@@ -9,7 +9,7 @@
 #define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
 #define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
 /// return prematurely if we are already in failure or ignore state
-#define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} }
+#define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} else { Unity.NumberOfAssertions++; } }
 #define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }
 
 struct _Unity Unity;
@@ -40,6 +40,7 @@ const char UnityStrErrDouble[]              = "Unity Double Precision Disabled";
 const char UnityStrErr64[]                  = "Unity 64-bit Support Disabled";
 const char UnityStrBreaker[]                = "-----------------------";
 const char UnityStrResultsTests[]           = " Tests ";
+const char UnityStrResultsAssertions[]      = " Assertions ";
 const char UnityStrResultsFailures[]        = " Failures ";
 const char UnityStrResultsIgnored[]         = " Ignored ";
 
@@ -1156,6 +1157,8 @@ int UnityEnd(void)
     UNITY_PRINT_EOL;
     UnityPrintNumber((_U_SINT)(Unity.NumberOfTests));
     UnityPrint(UnityStrResultsTests);
+    UnityPrintNumber((_U_SINT)(Unity.NumberOfAssertions));
+    UnityPrint(UnityStrResultsAssertions);
     UnityPrintNumber((_U_SINT)(Unity.TestFailures));
     UnityPrint(UnityStrResultsFailures);
     UnityPrintNumber((_U_SINT)(Unity.TestIgnores));

--- a/src/unity.c
+++ b/src/unity.c
@@ -78,24 +78,26 @@ void UnityPrintOk(void);
 void UnityPrint(const char* string)
 {
     const char* pch = string;
+    unsigned char c;
 
     if (pch != NULL)
     {
-        while (*pch)
+        c = *pch;
+        while (c != '\0')
         {
             // printable characters plus CR & LF are printed
-            if ((*pch <= 126) && (*pch >= 32))
+            if ((c <= 126) && (c >= 32))
             {
-                UNITY_OUTPUT_CHAR(*pch);
+                UNITY_OUTPUT_CHAR(c);
             }
             //write escaped carriage returns
-            else if (*pch == 13)
+            else if (c == 13)
             {
                 UNITY_OUTPUT_CHAR('\\');
                 UNITY_OUTPUT_CHAR('r');
             }
             //write escaped line feeds
-            else if (*pch == 10)
+            else if (c == 10)
             {
                 UNITY_OUTPUT_CHAR('\\');
                 UNITY_OUTPUT_CHAR('n');
@@ -104,9 +106,9 @@ void UnityPrint(const char* string)
             else
             {
                 UNITY_OUTPUT_CHAR('\\');
-                UnityPrintNumberHex((_U_UINT)*pch, 2);
+                UnityPrintNumberHex((_U_UINT)c, 2);
             }
-            pch++;
+            c = *(++pch);
         }
     }
 }

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -379,6 +379,7 @@ struct _Unity
     UNITY_COUNTER_TYPE TestIgnores;
     UNITY_COUNTER_TYPE CurrentTestFailed;
     UNITY_COUNTER_TYPE CurrentTestIgnored;
+    UNITY_COUNTER_TYPE NumberOfAssertions;
     jmp_buf AbortFrame;
 };
 

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -567,7 +567,7 @@ extern const char UnityStrErr64[];
 // Test Asserts
 //-------------------------------------------------------
 
-#define UNITY_TEST_ASSERT(condition, line, message)                                              if (condition) {} else {UNITY_TEST_FAIL((UNITY_LINE_TYPE)line, message);}
+#define UNITY_TEST_ASSERT(condition, line, message)                                              { Unity.NumberOfAssertions++; if (condition) {} else {UNITY_TEST_FAIL((UNITY_LINE_TYPE)line, message);} }
 #define UNITY_TEST_ASSERT_NULL(pointer, line, message)                                           UNITY_TEST_ASSERT(((pointer) == NULL),  (UNITY_LINE_TYPE)line, message)
 #define UNITY_TEST_ASSERT_NOT_NULL(pointer, line, message)                                       UNITY_TEST_ASSERT(((pointer) != NULL),  (UNITY_LINE_TYPE)line, message)
 

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -79,6 +79,7 @@ void testUnitySizeInitializationReminder(void)
         UNITY_COUNTER_TYPE TestIgnores;
         UNITY_COUNTER_TYPE CurrentTestFailed;
         UNITY_COUNTER_TYPE CurrentTestIgnored;
+        UNITY_COUNTER_TYPE NumberOfAssertions;
         jmp_buf AbortFrame;
     } _Expected_Unity;
 


### PR DESCRIPTION
We have global test counter and this is OK - we know at the end how many tests have passed and failed. However, tests may contain more than one TEST_ASSERT macro calls. It could be interesting for one to know the total number of assertions passed.