### PR TITLE
catch-all else

### DIFF
--- a/auto/parseOutput.rb
+++ b/auto/parseOutput.rb
@@ -105,6 +105,8 @@ class ParseOutput
             else
                 @className = 0
             end
+	else
+                @className = 0
         end
         
     end


### PR DESCRIPTION
The current code fails if RUBY_PLATFORM has more (or less) than 2 components, e.g. x86_64-linux-gnu.

The fix will treat these cases as "not windows", therefore "unix".