### PR TITLE
New asserter: TEST_ASSERT_EQUAL_STRING_LEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,17 @@ String Assertions
 
 Compare two null-terminate strings.  Fail if any character is different or if the lengths are different.
 
+    TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len)
+
+Compare two strings.  Fail if any character is different, stop comparing after len characters.
+
     TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)
 
 Compare two null-terminate strings.  Fail if any character is different or if the lengths are different. Output a custom message on failure.
+
+    TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)
+
+Compare two strings.  Fail if any character is different, stop comparing after len characters. Output a custom message on failure.
 
 Pointer Assertions
 ------------------

--- a/auto/parseOutput.rb
+++ b/auto/parseOutput.rb
@@ -105,6 +105,8 @@ class ParseOutput
             else
                 @className = 0
             end
+	else
+                @className = 0
         end
         
     end

--- a/docs/Unity Summary.txt
+++ b/docs/Unity Summary.txt
@@ -178,9 +178,17 @@ TEST_ASSERT_EQUAL_STRING(expected, actual)
 
 Compare two null-terminate strings.  Fail if any character is different or if the lengths are different.
 
+TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len)
+
+Compare two strings.  Fail if any character is different, stop comparing after len characters.
+
 TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)
 
 Compare two null-terminate strings.  Fail if any character is different or if the lengths are different. Output a custom message on failure.
+
+TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)
+
+Compare two strings.  Fail if any character is different, stop comparing after len characters. Output a custom message on failure.
 
 ------------------
 Pointer Assertions

--- a/src/unity.c
+++ b/src/unity.c
@@ -110,6 +110,42 @@ void UnityPrint(const char* string)
     }
 }
 
+void UnityPrintLen(const char* string, const _UU32 length)
+{
+    const char* pch = string;
+
+    if (pch != NULL)
+    {
+        while (*pch && (pch - string) < length)
+        {
+            // printable characters plus CR & LF are printed
+            if ((*pch <= 126) && (*pch >= 32))
+            {
+                UNITY_OUTPUT_CHAR(*pch);
+            }
+            //write escaped carriage returns
+            else if (*pch == 13)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('r');
+            }
+            //write escaped line feeds
+            else if (*pch == 10)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('n');
+            }
+            // unprintable characters are shown as codes
+            else
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UnityPrintNumberHex((_U_UINT)*pch, 2);
+            }
+            pch++;
+        }
+    }
+}
+
 //-----------------------------------------------
 void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T style)
 {
@@ -347,6 +383,35 @@ static void UnityPrintExpectedAndActualStrings(const char* expected, const char*
       UnityPrint(UnityStrNull);
     }
 }
+
+//-----------------------------------------------
+static void UnityPrintExpectedAndActualStringsLen(const char* expected, const char* actual, const _UU32 length)
+{
+    UnityPrint(UnityStrExpected);
+    if (expected != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrintLen(expected, length);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+      UnityPrint(UnityStrNull);
+    }
+    UnityPrint(UnityStrWas);
+    if (actual != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrintLen(actual, length);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+      UnityPrint(UnityStrNull);
+    }
+}
+
+
 
 //-----------------------------------------------
 // Assertion & Control Helpers
@@ -943,6 +1008,47 @@ void UnityAssertEqualString(const char* expected,
       UNITY_FAIL_AND_BAIL;
     }
 }
+
+//-----------------------------------------------
+void UnityAssertEqualStringLen(const char* expected,
+                            const char* actual,
+                            const _UU32 length,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber)
+{
+    _UU32 i;
+
+    UNITY_SKIP_EXECUTION;
+
+    // if both pointers not null compare the strings
+    if (expected && actual)
+    {
+        for (i = 0; (expected[i] || actual[i]) && i < length; i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                Unity.CurrentTestFailed = 1;
+                break;
+            }
+        }
+    }
+    else
+    { // handle case of one pointers being null (if both null, test should pass)
+        if (expected != actual)
+        {
+            Unity.CurrentTestFailed = 1;
+        }
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+      UnityTestResultsFailBegin(lineNumber);
+      UnityPrintExpectedAndActualStringsLen(expected, actual, length);
+      UnityAddMsgIfSpecified(msg);
+      UNITY_FAIL_AND_BAIL;
+    }
+}
+
 
 //-----------------------------------------------
 void UnityAssertEqualStringArray( const char** expected,

--- a/src/unity.h
+++ b/src/unity.h
@@ -116,6 +116,7 @@
 //Structs and Strings
 #define TEST_ASSERT_EQUAL_PTR(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_STRING(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len)                                        UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)                                            UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, __LINE__, NULL)
 
 //Arrays
@@ -219,7 +220,7 @@
 
 //Structs and Strings
 #define TEST_ASSERT_EQUAL_PTR_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, __LINE__, message)
-#define TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, __LINE__, message)
+#define TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                       UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, __LINE__, message)
 #define TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                           UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, __LINE__, message)
 
 //Arrays

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -440,6 +440,12 @@ void UnityAssertEqualString(const char* expected,
                             const char* msg,
                             const UNITY_LINE_TYPE lineNumber);
 
+void UnityAssertEqualStringLen(const char* expected,
+                            const char* actual,
+                            const _UU32 length,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber);
+
 void UnityAssertEqualStringArray( const char** expected,
                                   const char** actual,
                                   const _UU32 num_elements,
@@ -597,6 +603,7 @@ extern const char UnityStrErr64[];
 
 #define UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, line, message)                             UnityAssertEqualNumber((_U_SINT)(_UP)(expected), (_U_SINT)(_UP)(actual), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_POINTER)
 #define UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, line, message)                          UnityAssertEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)line)
+#define UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, line, message)                 UnityAssertEqualStringLen((const char*)(expected), (const char*)(actual), (_UU32)(len), (message), (UNITY_LINE_TYPE)line)
 #define UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, line, message)                     UnityAssertEqualMemory((UNITY_PTR_ATTRIBUTE void*)(expected), (UNITY_PTR_ATTRIBUTE void*)(actual), (_UU32)(len), 1, (message), (UNITY_LINE_TYPE)line)
 
 #define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_PTR_ATTRIBUTE const void*)(expected), (UNITY_PTR_ATTRIBUTE const void*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line, UNITY_DISPLAY_STYLE_INT)

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1265,6 +1265,16 @@ void testEqualStrings(void)
     TEST_ASSERT_EQUAL_STRING("", "");
 }
 
+void testEqualStringsLen(void)
+{
+    const char *testString = "foobar";
+    TEST_ASSERT_EQUAL_STRING_LEN(testString, testString, strlen(testString));
+    TEST_ASSERT_EQUAL_STRING_LEN("foobar", "foobaz", 5);
+    TEST_ASSERT_EQUAL_STRING_LEN("foo", testString, 3);
+    TEST_ASSERT_EQUAL_STRING_LEN(testString, foo, 3);
+    TEST_ASSERT_EQUAL_STRING_LEN("", "", 3);
+}
+
 void testEqualStringsWithCarriageReturnsAndLineFeeds(void)
 {
     const char *testString = "foo\r\nbar";
@@ -1283,10 +1293,24 @@ void testNotEqualString1(void)
     VERIFY_FAILS_END
 }
 
+void testNotEqualStringLen1(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING_LEN("foobar", "foobaz", 6);
+    VERIFY_FAILS_END
+}
+
 void testNotEqualString2(void)
 {
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_STRING("foo", "");
+    VERIFY_FAILS_END
+}
+
+void testNotEqualStringLen2(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING_LEN("foo", "", 3);
     VERIFY_FAILS_END
 }
 
@@ -1297,10 +1321,24 @@ void testNotEqualString3(void)
     VERIFY_FAILS_END
 }
 
+void testNotEqualStringLen3(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING_LEN("", "bar", 3);
+    VERIFY_FAILS_END
+}
+
 void testNotEqualString4(void)
 {
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_STRING("bar\r", "bar\n");
+    VERIFY_FAILS_END
+}
+
+void testNotEqualStringLen4(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING_LEN("bar\r", "bar\n", 4);
     VERIFY_FAILS_END
 }
 

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -6,6 +6,7 @@
 
 #include <setjmp.h>
 #include "unity.h"
+#include <string.h>
 
 // Dividing by these constants produces +/- infinity.
 // The rationale is given in UnityAssertFloatIsInf's body.
@@ -1271,7 +1272,7 @@ void testEqualStringsLen(void)
     TEST_ASSERT_EQUAL_STRING_LEN(testString, testString, strlen(testString));
     TEST_ASSERT_EQUAL_STRING_LEN("foobar", "foobaz", 5);
     TEST_ASSERT_EQUAL_STRING_LEN("foo", testString, 3);
-    TEST_ASSERT_EQUAL_STRING_LEN(testString, foo, 3);
+    TEST_ASSERT_EQUAL_STRING_LEN(testString, "foo", 3);
     TEST_ASSERT_EQUAL_STRING_LEN("", "", 3);
 }
 


### PR DESCRIPTION
Adds support for asserting that strings are equal up-to n characters.

Adds the same functionality that strncmp() offers, asserting that the n first characters of the expected/actual strings are the same, ignoring the rest of the characters.

TEST_ASSERT_EQUAL_STRING_LEN and TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE has been added.

Unit tests for TEST_ASSERT_EQUAL_STRING_LEN has been added following the same pattern as for TEST_ASSERT_EQUAL_STRING.
