### PR TITLE
Fix to prevent warning using armcc: Warning:  #61-D

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -135,7 +135,7 @@ void UnityPrintNumber(const _U_SINT number_to_print)
     _U_SINT next_divisor;
     _U_UINT number;
 
-    if (number_to_print == (1l << (UNITY_LONG_WIDTH-1)))
+    if (number_to_print == (1ul << (UNITY_LONG_WIDTH-1)))
     {
         //The largest representable negative number
         UNITY_OUTPUT_CHAR('-');


### PR DESCRIPTION
The armcc compiler gives a warning on the changed line:
Warning:  #61-D: integer operation result is out of range.
Really easy to fix.