### PR TITLE
Fixes #118: unity_output_Spy should use the platform-agnostic macros for memory and printing

### DIFF
--- a/extras/fixture/test/unity_output_Spy.c
+++ b/extras/fixture/test/unity_output_Spy.c
@@ -7,8 +7,8 @@
 
 
 #include "unity_output_Spy.h"
-#include <stdio.h>
-#include <stdlib.h>
+#include "unity_fixture.h"
+
 #include <string.h>
 
 static int size;
@@ -21,14 +21,14 @@ void UnityOutputCharSpy_Create(int s)
     size = s;
     count = 0;
     spy_enable = 0;
-    buffer = malloc(size);
+    buffer = UNITY_FIXTURE_MALLOC(size);
     memset(buffer, 0, size);
 }
 
 void UnityOutputCharSpy_Destroy(void)
 {
     size = 0;
-    free(buffer);
+    UNITY_FIXTURE_FREE(buffer);
 }
 
 int UnityOutputCharSpy_OutputChar(int c)
@@ -40,7 +40,7 @@ int UnityOutputCharSpy_OutputChar(int c)
     }
     else
     {
-        putchar(c);
+        UNITY_OUTPUT_CHAR(c);
     }
     return c;
 }


### PR DESCRIPTION
Refactored includes to use "unity_fixture.h" to get the appropriate macros.