### PR TITLE
Bug fix - ignored tests were incorrectly counted when not selected for running.

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -115,15 +115,18 @@ void UnityTestRunner(unityfunction* setup,
     }
 }
 
-void UnityIgnoreTest(const char * printableName)
+void UnityIgnoreTest(const char * printableName, const char * group, const char * name)
 {
-    Unity.NumberOfTests++;
-    Unity.CurrentTestIgnored = 1;
-    if (!UnityFixture.Verbose)
-        UNITY_OUTPUT_CHAR('!');
-    else
-        UnityPrint(printableName);
-    UnityConcludeFixtureTest();
+    if (testSelected(name) && groupSelected(group)) 
+    {
+        Unity.NumberOfTests++;
+        Unity.CurrentTestIgnored = 1;
+        if (!UnityFixture.Verbose)
+            UNITY_OUTPUT_CHAR('!');
+        else
+            UnityPrint(printableName);
+        UnityConcludeFixtureTest();
+    }
 }
 
 

--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -45,7 +45,7 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
     void TEST_##group##_##name##_run(void);\
     void TEST_##group##_##name##_run(void)\
     {\
-        UnityIgnoreTest("IGNORE_TEST(" #group ", " #name ")");\
+        UnityIgnoreTest("IGNORE_TEST(" #group ", " #name ")", TEST_GROUP_##group, #name);\
     }\
     void TEST_##group##_##name##_(void)
 

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -25,7 +25,7 @@ void UnityTestRunner(unityfunction * setup,
         const char * name,
         const char * file, int line);
 
-void UnityIgnoreTest(const char * printableName);
+void UnityIgnoreTest(const char * printableName, const char * group, const char * name);
 void UnityMalloc_StartTest(void);
 void UnityMalloc_EndTest(void);
 int UnityFailureCount(void);


### PR DESCRIPTION
Ignored tests are now correctly skipped if not selected by test name or
by group name.