### PR TITLE
Use UNITY_PTR_ATTRIBUTE() in one place where it was (accidentally?) not used.

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1177,8 +1177,8 @@ void UnityAssertEqualMemory( UNITY_PTR_ATTRIBUTE const void* expected,
                 UnityAddMsgIfSpecified(msg);
                 UNITY_FAIL_AND_BAIL;
             }
-            ptr_exp += 1;
-            ptr_act += 1;
+            ptr_exp = (UNITY_PTR_ATTRIBUTE const void*)((_UP)ptr_exp + 1);
+            ptr_act = (UNITY_PTR_ATTRIBUTE const void*)((_UP)ptr_act + 1);
         }
         /////////////////////////////////////
 


### PR DESCRIPTION
This eliminates a compiler warning for certain compilers.