### PR TITLE
Added back TEST_ASSERT_EQUAL_STRING_MESSAGE() which was (accidentally?) removed some time ago.

### DIFF
--- a/src/unity.h
+++ b/src/unity.h
@@ -220,6 +220,7 @@
 
 //Structs and Strings
 #define TEST_ASSERT_EQUAL_PTR_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, __LINE__, message)
+#define TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, __LINE__, message)
 #define TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                       UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, __LINE__, message)
 #define TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                           UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, __LINE__, message)
 

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1260,7 +1260,7 @@ void testEqualStrings(void)
     const char *testString = "foo";
 
     TEST_ASSERT_EQUAL_STRING(testString, testString);
-    TEST_ASSERT_EQUAL_STRING("foo", "foo");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE("foo", "foo", "foo isn't foo");
     TEST_ASSERT_EQUAL_STRING("foo", testString);
     TEST_ASSERT_EQUAL_STRING(testString, "foo");
     TEST_ASSERT_EQUAL_STRING("", "");
@@ -1270,7 +1270,7 @@ void testEqualStringsLen(void)
 {
     const char *testString = "foobar";
     TEST_ASSERT_EQUAL_STRING_LEN(testString, testString, strlen(testString));
-    TEST_ASSERT_EQUAL_STRING_LEN("foobar", "foobaz", 5);
+    TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE("foobar", "foobaz", 5, "fooba isn't fooba");
     TEST_ASSERT_EQUAL_STRING_LEN("foo", testString, 3);
     TEST_ASSERT_EQUAL_STRING_LEN(testString, "foo", 3);
     TEST_ASSERT_EQUAL_STRING_LEN("", "", 3);


### PR DESCRIPTION
The symmetric TEST_ASSERT_EQUAL_STRING() still exists.