### PR TITLE
unity_fixture: Make unity_free() NULL-safe

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -227,7 +227,14 @@ static void release_memory(void * mem)
 
 void unity_free(void * mem)
 {
-    int overrun = isOverrun(mem);//strcmp(&memAsChar[guard->size], end) != 0;
+    int overrun;
+
+    if (mem == NULL)
+    {
+        return;
+    }
+
+    overrun = isOverrun(mem);//strcmp(&memAsChar[guard->size], end) != 0;
     release_memory(mem);
     if (overrun)
     {

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -132,6 +132,11 @@ TEST(UnityFixture, PointerSet)
     TEST_ASSERT_POINTERS_EQUAL(&c2, p2);
 }
 
+TEST(UnityFixture, FreeNULLSafety)
+{
+  unity_free(NULL);
+}
+
 //------------------------------------------------------------
 
 TEST_GROUP(UnityCommandOptions);

--- a/extras/fixture/test/unity_fixture_TestRunner.c
+++ b/extras/fixture/test/unity_fixture_TestRunner.c
@@ -18,6 +18,7 @@ TEST_GROUP_RUNNER(UnityFixture)
     RUN_TEST_CASE(UnityFixture, ReallocSizeZeroFreesMemAndReturnsNullPointer);
     RUN_TEST_CASE(UnityFixture, CallocFillsWithZero);
     RUN_TEST_CASE(UnityFixture, PointerSet);
+    RUN_TEST_CASE(UnityFixture, FreeNULLSafety);
 }
 
 TEST_GROUP_RUNNER(UnityCommandOptions)


### PR DESCRIPTION
At the start of `unity_free()`, check `mem` for `NULL`, and return immediately if it is, so we don't crash in this case. This mimics the behaviour of most `free()` implementations.

Closes #135.
