### PR TITLE
Fix some C++ compatibility issues

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1231,9 +1231,9 @@ void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
     UNITY_WEAK_ATTRIBUTE void tearDown(void) { }
 #elif defined(UNITY_WEAK_PRAGMA)
 #   pragma weak setUp
-    void setUp(void);
+    void setUp(void) { }
 #   pragma weak tearDown
-    void tearDown(void);
+    void tearDown(void) { }
 #else
     void setUp(void);
     void tearDown(void);

--- a/src/unity.h
+++ b/src/unity.h
@@ -15,6 +15,9 @@ extern "C"
 
 #include "unity_internals.h"
 
+void setUp(void);
+void tearDown(void);
+
 //-------------------------------------------------------
 // Configuration Options
 //-------------------------------------------------------

--- a/src/unity.h
+++ b/src/unity.h
@@ -8,6 +8,11 @@
 #define UNITY_FRAMEWORK_H
 #define UNITY
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "unity_internals.h"
 
 //-------------------------------------------------------
@@ -271,4 +276,7 @@
 #define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, (message))
 
 //end of UNITY_FRAMEWORK_H
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
I'm using Unity in a project with a mix of C and C++ tests, and these two issues tripped me up.
 - without a `extern "C"` prototype, `setUp()` ends up being mangled in my test_foo.cpp build and thus unity.c invokes its local weak symbol instead.
 - without wrapping unity.h in `extern "C"`, functions like `UnityAssertEqualNumber` get mangled and the link fails with `undefined reference to `UnityBegin(char const*)'`.
