### PR TITLE
Move UNITY_PRINT_EOL to internals, change to function macro

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -28,7 +28,7 @@ static void announceTestRun(unsigned int runNumber)
     UnityPrintNumber(runNumber+1);
     UnityPrint(" of ");
     UnityPrintNumber(UnityFixture.RepeatCount);
-    UNITY_OUTPUT_CHAR('\n');
+    UNITY_PRINT_EOL;
 }
 
 int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
@@ -43,7 +43,7 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
         UnityBegin(argv[0]);
         announceTestRun(r);
         runAllTests();
-        UNITY_OUTPUT_CHAR('\n');
+        UNITY_PRINT_EOL;
         UnityEnd();
     }
 
@@ -396,7 +396,7 @@ void UnityConcludeFixtureTest(void)
     {
         //if (UnityFixture.Verbose)
         //{
-            UNITY_OUTPUT_CHAR('\n');
+            UNITY_PRINT_EOL;
         //}
         Unity.TestIgnores++;
     }
@@ -405,13 +405,13 @@ void UnityConcludeFixtureTest(void)
         if (UnityFixture.Verbose)
         {
             UnityPrint(" PASS");
-            UNITY_OUTPUT_CHAR('\n');
+            UNITY_PRINT_EOL;
         }
     }
     else if (Unity.CurrentTestFailed)
     {
         Unity.TestFailures++;
-        UNITY_OUTPUT_CHAR('\n');
+        UNITY_PRINT_EOL;
     }
 
     Unity.CurrentTestFailed = 0;

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -28,7 +28,7 @@ static void announceTestRun(unsigned int runNumber)
     UnityPrintNumber(runNumber+1);
     UnityPrint(" of ");
     UnityPrintNumber(UnityFixture.RepeatCount);
-    UNITY_PRINT_EOL;
+    UNITY_PRINT_EOL();
 }
 
 int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
@@ -43,7 +43,7 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
         UnityBegin(argv[0]);
         announceTestRun(r);
         runAllTests();
-        UNITY_PRINT_EOL;
+        UNITY_PRINT_EOL();
         UnityEnd();
     }
 
@@ -396,7 +396,7 @@ void UnityConcludeFixtureTest(void)
     {
         //if (UnityFixture.Verbose)
         //{
-            UNITY_PRINT_EOL;
+            UNITY_PRINT_EOL();
         //}
         Unity.TestIgnores++;
     }
@@ -405,13 +405,13 @@ void UnityConcludeFixtureTest(void)
         if (UnityFixture.Verbose)
         {
             UnityPrint(" PASS");
-            UNITY_PRINT_EOL;
+            UNITY_PRINT_EOL();
         }
     }
     else if (Unity.CurrentTestFailed)
     {
         Unity.TestFailures++;
-        UNITY_PRINT_EOL;
+        UNITY_PRINT_EOL();
     }
 
     Unity.CurrentTestFailed = 0;

--- a/src/unity.c
+++ b/src/unity.c
@@ -11,7 +11,6 @@
 #define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
 /// return prematurely if we are already in failure or ignore state
 #define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} }
-#define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }
 
 struct _Unity Unity;
 

--- a/src/unity.c
+++ b/src/unity.c
@@ -355,7 +355,7 @@ void UnityConcludeTest(void)
 
     Unity.CurrentTestFailed = 0;
     Unity.CurrentTestIgnored = 0;
-    UNITY_PRINT_EOL;
+    UNITY_PRINT_EOL();
 }
 
 //-----------------------------------------------
@@ -1272,16 +1272,16 @@ void UnityBegin(const char* filename)
 //-----------------------------------------------
 int UnityEnd(void)
 {
-    UNITY_PRINT_EOL;
+    UNITY_PRINT_EOL();
     UnityPrint(UnityStrBreaker);
-    UNITY_PRINT_EOL;
+    UNITY_PRINT_EOL();
     UnityPrintNumber((_U_SINT)(Unity.NumberOfTests));
     UnityPrint(UnityStrResultsTests);
     UnityPrintNumber((_U_SINT)(Unity.TestFailures));
     UnityPrint(UnityStrResultsFailures);
     UnityPrintNumber((_U_SINT)(Unity.TestIgnores));
     UnityPrint(UnityStrResultsIgnored);
-    UNITY_PRINT_EOL;
+    UNITY_PRINT_EOL();
     if (Unity.TestFailures == 0U)
     {
         UnityPrintOk();
@@ -1290,7 +1290,7 @@ int UnityEnd(void)
     {
         UnityPrintFail();
     }
-    UNITY_PRINT_EOL;
+    UNITY_PRINT_EOL();
     UNITY_OUTPUT_COMPLETE();
     return (int)(Unity.TestFailures);
 }

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -291,6 +291,10 @@ typedef UNITY_DOUBLE_TYPE _UD;
 extern int UNITY_OUTPUT_CHAR(int);
 #endif
 
+#ifndef UNITY_PRINT_EOL
+#define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }
+#endif
+
 #ifndef UNITY_OUTPUT_START
 #define UNITY_OUTPUT_START()
 #endif

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -292,7 +292,7 @@ extern int UNITY_OUTPUT_CHAR(int);
 #endif
 
 #ifndef UNITY_PRINT_EOL
-#define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }
+#define UNITY_PRINT_EOL       UNITY_OUTPUT_CHAR('\n')
 #endif
 
 #ifndef UNITY_OUTPUT_START

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -292,7 +292,7 @@ extern int UNITY_OUTPUT_CHAR(int);
 #endif
 
 #ifndef UNITY_PRINT_EOL
-#define UNITY_PRINT_EOL       UNITY_OUTPUT_CHAR('\n')
+#define UNITY_PRINT_EOL()    UNITY_OUTPUT_CHAR('\n')
 #endif
 
 #ifndef UNITY_OUTPUT_START


### PR DESCRIPTION
No functional changes. This set of commits mainly moves the EOL macro to internals so that the Fixture  can have access to it. This is more consistent and makes it easier to override the macro. Turning it into a function seems clearer.