### PR TITLE
Refactor Fixture, no EOL with ignored tests, add a Makefile for Fixture tests 

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -398,10 +398,10 @@ void UnityConcludeFixtureTest(void)
 {
     if (Unity.CurrentTestIgnored)
     {
-        //if (UnityFixture.Verbose)
-        //{
+        if (UnityFixture.Verbose)
+        {
             UNITY_PRINT_EOL();
-        //}
+        }
         Unity.TestIgnores++;
     }
     else if (!Unity.CurrentTestFailed)

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -179,11 +179,11 @@ void UnityMalloc_MakeMallocFailAfterCount(int countdown)
 typedef struct GuardBytes
 {
     size_t size;
-    char guard[sizeof(size_t)];
+    char guard_space[4];
 } Guard;
 
 
-static const char * end = "END";
+static const char end[] = "END";
 
 void * unity_malloc(size_t size)
 {
@@ -199,10 +199,10 @@ void * unity_malloc(size_t size)
 
     malloc_count++;
 
-    guard = (Guard*)UNITY_FIXTURE_MALLOC(size + sizeof(Guard) + 4);
+    guard = (Guard*)UNITY_FIXTURE_MALLOC(size + sizeof(Guard) + sizeof(end));
     guard->size = size;
     mem = (char*)&(guard[1]);
-    memcpy(&mem[size], end, strlen(end) + 1);
+    memcpy(&mem[size], end, sizeof(end));
 
     return (void*)mem;
 }

--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -55,13 +55,8 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
 
 //This goes at the bottom of each test file or in a separate c file
 #define TEST_GROUP_RUNNER(group)\
-    void TEST_##group##_GROUP_RUNNER_runAll(void);\
     void TEST_##group##_GROUP_RUNNER(void);\
-    void TEST_##group##_GROUP_RUNNER(void)\
-    {\
-        TEST_##group##_GROUP_RUNNER_runAll();\
-    }\
-    void TEST_##group##_GROUP_RUNNER_runAll(void)
+    void TEST_##group##_GROUP_RUNNER(void)
 
 //Call this from main
 #define RUN_TEST_GROUP(group)\

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -1,0 +1,15 @@
+CC = gcc
+DEFINES = -D UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar
+SRC = ../src/unity_fixture.c \
+      ../../../src/unity.c   \
+      unity_fixture_Test.c   \
+      unity_fixture_TestRunner.c \
+      unity_output_Spy.c     \
+      main/AllTests.c
+
+INC_DIR = -I../src -I../../../src/
+TARGET = fixture_tests.exe
+
+all:
+	@ $(CC) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET)
+	@ ./$(TARGET)

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -277,6 +277,10 @@ TEST(UnityCommandOptions, UnknownCommandIsIgnored)
     TEST_ASSERT_EQUAL(98, UnityFixture.RepeatCount);
 }
 
+IGNORE_TEST(UnityCommandOptions, TestShouldBeIgnored)
+{
+    TEST_FAIL_MESSAGE("This test should not run!");
+}
 
 //------------------------------------------------------------
 

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -316,9 +316,9 @@ TEST(LeakDetection, DetectsLeak)
     UnityMalloc_EndTest();
     EXPECT_ABORT_END
     UnityOutputCharSpy_Enable(0);
+    Unity.CurrentTestFailed = 0;
     CHECK(strstr(UnityOutputCharSpy_Get(), "This test leaks!"));
     free(m);
-    Unity.CurrentTestFailed = 0;
 }
 
 TEST(LeakDetection, BufferOverrunFoundDuringFree)
@@ -331,8 +331,8 @@ TEST(LeakDetection, BufferOverrunFoundDuringFree)
     free(m);
     EXPECT_ABORT_END
     UnityOutputCharSpy_Enable(0);
-    CHECK(strstr(UnityOutputCharSpy_Get(), "Buffer overrun detected during free()"));
     Unity.CurrentTestFailed = 0;
+    CHECK(strstr(UnityOutputCharSpy_Get(), "Buffer overrun detected during free()"));
 }
 
 TEST(LeakDetection, BufferOverrunFoundDuringRealloc)
@@ -345,6 +345,6 @@ TEST(LeakDetection, BufferOverrunFoundDuringRealloc)
     m = realloc(m, 100);
     EXPECT_ABORT_END
     UnityOutputCharSpy_Enable(0);
-    CHECK(strstr(UnityOutputCharSpy_Get(), "Buffer overrun detected during realloc()"));
     Unity.CurrentTestFailed = 0;
+    CHECK(strstr(UnityOutputCharSpy_Get(), "Buffer overrun detected during realloc()"));
 }

--- a/extras/fixture/test/unity_fixture_TestRunner.c
+++ b/extras/fixture/test/unity_fixture_TestRunner.c
@@ -32,6 +32,7 @@ TEST_GROUP_RUNNER(UnityCommandOptions)
     RUN_TEST_CASE(UnityCommandOptions, MultipleOptions);
     RUN_TEST_CASE(UnityCommandOptions, MultipleOptionsDashRNotLastAndNoValueSpecified);
     RUN_TEST_CASE(UnityCommandOptions, UnknownCommandIsIgnored);
+    RUN_TEST_CASE(UnityCommandOptions, TestShouldBeIgnored);
 }
 
 TEST_GROUP_RUNNER(LeakDetection)


### PR DESCRIPTION
* Cleaned up 'end' variable for `unity_malloc()` usage. Use `sizeof` instead of magic numbers.
* Simplified the group runner macro, reduces call stack.
* Not adding EOL after every ignored test anymore. Mostly for visual prettiness in quiet mode.
* Made some tests fail, that weren't checking the Leak Detection strings properly. They still pass if built with the Spy as the output function. `UnityOutputCharSpy_OutputChar()`
* Added a Makefile in fixture/test/