### PR TITLE
Include <stdio.h> (for sprintf) when using UNITY_FLOAT_VERBOSE

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -285,7 +285,7 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
 
 //-----------------------------------------------
 #ifdef UNITY_FLOAT_VERBOSE
-#include <string.h>
+#include <stdio.h>
 void UnityPrintFloat(_UF number)
 {
     char TempBuffer[32];


### PR DESCRIPTION
When building with `UNITY_FLOAT_VERBOSE`, I get:
```
error: implicit declaration of function 'sprintf' [-Werror=implicit-function-declaration]
sprintf(TempBuffer, "%.6f", number);
^
```
Apparently `<string.h>` was being included to declare `sprintf`, but `<stdio.h>` is the right header to include.