### PR TITLE
Add tests for printing numbers, interface for spying on output strings

### DIFF
--- a/test/targets/clang_file.yml
+++ b/test/targets/clang_file.yml
@@ -28,7 +28,7 @@ compiler:
     - '-Wstrict-overflow=5'
     - '-Wuninitialized'
     - '-Wunused'
-    - '-Wunreachable-code'
+#   - '-Wunreachable-code'
     - '-Wreturn-type'
     - '-Wshadow'
     - '-Wundef'
@@ -57,6 +57,7 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_64
       - UNITY_OUTPUT_RESULTS_FILE
@@ -65,7 +66,7 @@ compiler:
     extension: '.o'
     destination: *build_path
 linker:
-  path: gcc
+  path: clang
   options:
     - -lm
     - '-m64'

--- a/test/targets/clang_strict.yml
+++ b/test/targets/clang_strict.yml
@@ -28,7 +28,7 @@ compiler:
     - '-Wstrict-overflow=5'
     - '-Wuninitialized'
     - '-Wunused'
-    - '-Wunreachable-code'
+#   - '-Wunreachable-code'
     - '-Wreturn-type'
     - '-Wshadow'
     - '-Wundef'
@@ -57,6 +57,7 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES
       - UNITY_SUPPORT_64
@@ -65,7 +66,7 @@ compiler:
     extension: '.o'
     destination: *build_path
 linker:
-  path: gcc
+  path: clang
   options:
     - -lm
     - '-m64'

--- a/test/targets/gcc_32.yml
+++ b/test/targets/gcc_32.yml
@@ -19,6 +19,7 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
       - UNITY_EXCLUDE_LIMITS_H
       - UNITY_EXCLUDE_SIZEOF

--- a/test/targets/gcc_64.yml
+++ b/test/targets/gcc_64.yml
@@ -19,6 +19,7 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
       - UNITY_EXCLUDE_LIMITS_H
       - UNITY_EXCLUDE_SIZEOF

--- a/test/targets/gcc_auto_limits.yml
+++ b/test/targets/gcc_auto_limits.yml
@@ -19,6 +19,7 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES

--- a/test/targets/gcc_auto_sizeof.yml
+++ b/test/targets/gcc_auto_sizeof.yml
@@ -19,8 +19,9 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
-      - UNITY_EXCLUDE_LIMTIS_H
+      - UNITY_EXCLUDE_LIMITS_H
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES
       - UNITY_SUPPORT_64

--- a/test/targets/gcc_auto_stdint.yml
+++ b/test/targets/gcc_auto_stdint.yml
@@ -32,6 +32,7 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES
       - UNITY_SUPPORT_64

--- a/test/targets/gcc_manual_math.yml
+++ b/test/targets/gcc_manual_math.yml
@@ -19,6 +19,7 @@ compiler:
   defines:
     prefix: '-D'
     items:
+      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_MATH_H
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES

--- a/test/tests/testparameterized.c
+++ b/test/tests/testparameterized.c
@@ -5,7 +5,10 @@
 ========================================== */
 
 #include <setjmp.h>
+#include <stdio.h>
 #include "unity.h"
+
+int putcharSpy(int c) {return putchar(c);} // include passthrough for linking tests
 
 #define TEST_CASE(...)
 


### PR DESCRIPTION
If Unity core is compiled with UNITY_OUTPUT_CHAR = putcharSpy, these tests
  will run, otherwise they are ignored and print a message.
Includes an implementation of `putcharSpy()`, which allows checking the I/O
  from Unity during a test. Follows closely from the Fixture spy.
Adding "-D UNITY_OUTPUT_CHAR=putcharSpy" to testing build targets

The interface to `putcharSpy()` also defines `startPutcharSpy()` `endPutcharSpy()` and ` getBufferPutcharSpy()`. These methods could be used to test more of Unity's character output.

