### PR TITLE
Fixture - require spy or else ignore tests

### DIFF
--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -1,4 +1,8 @@
 CC = gcc
+CFLAGS += -Werror
+CFLAGS += -std=c99
+CFLAGS += -pedantic
+CFLAGS += -Wundef
 DEFINES = -D UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar
 SRC = ../src/unity_fixture.c \
       ../../../src/unity.c   \
@@ -11,5 +15,5 @@ INC_DIR = -I../src -I../../../src/
 TARGET = fixture_tests.exe
 
 all:
-	@ $(CC) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET)
-	@ ./$(TARGET)
+	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET)
+	./$(TARGET)

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -309,14 +309,17 @@ TEST_TEAR_DOWN(LeakDetection)
   }
 
 // This tricky set of defines lets us see if we are using the Spy, returns 1 if true, else 0
-#define USING_OUTPUT_SPY(a)                      EXPAND_AND_USE_2ND(ASSIGN_VALUE(a), 0)
+#define USING_SPY_AS(a)                          EXPAND_AND_USE_2ND(ASSIGN_VALUE(a), 0)
 #define ASSIGN_VALUE(a)                          VAL_FUNC_##a
 #define VAL_FUNC_UnityOutputCharSpy_OutputChar() 0, 1
-#define EXPAND_AND_USE_2ND(a, b)                 SECOND_PARAM(a, b)
+#define EXPAND_AND_USE_2ND(a, b)                 SECOND_PARAM(a, b, throwaway)
 #define SECOND_PARAM(a, b, ...)                  b
+#if USING_SPY_AS(UNITY_OUTPUT_CHAR())
+  #define USING_OUTPUT_SPY
+#endif
 TEST(LeakDetection, DetectsLeak)
 {
-#if USING_OUTPUT_SPY(UNITY_OUTPUT_CHAR()) == 0
+#ifndef USING_OUTPUT_SPY
     TEST_IGNORE_MESSAGE("Build with '-D UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar' to enable tests");
 #else
     void* m = malloc(10);
@@ -333,7 +336,7 @@ TEST(LeakDetection, DetectsLeak)
 
 TEST(LeakDetection, BufferOverrunFoundDuringFree)
 {
-#if USING_OUTPUT_SPY(UNITY_OUTPUT_CHAR()) == 0
+#ifndef USING_OUTPUT_SPY
     UNITY_PRINT_EOL();
     TEST_IGNORE();
 #else
@@ -352,7 +355,7 @@ TEST(LeakDetection, BufferOverrunFoundDuringFree)
 
 TEST(LeakDetection, BufferOverrunFoundDuringRealloc)
 {
-#if USING_OUTPUT_SPY(UNITY_OUTPUT_CHAR()) == 0
+#ifndef USING_OUTPUT_SPY
     UNITY_PRINT_EOL();
     TEST_IGNORE();
 #else


### PR DESCRIPTION
Add MACROs to check if tests are built using the Output Spy
 Ignore tests that need the Spy if we are not building with it

Fixture C99 compliance on tricky macros for Spy & match core Unity version
 Add CFLAGS in Fixture Makefile to catch C99 rules with '-pedantic'