### PR TITLE
Fixture rakefile has a conflict defining UNITY_OUTPUT_CHAR

### DIFF
--- a/test/rakefile_helper.rb
+++ b/test/rakefile_helper.rb
@@ -97,7 +97,7 @@ module RakefileHelpers
     if $cfg['compiler']['defines']['items'].nil?
       defines  = ''
     else
-      defines  = squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'])
+      defines  = squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'] + ['UNITY_OUTPUT_CHAR=putcharSpy'])
     end
     options  = squash('', $cfg['compiler']['options'])
     includes = squash($cfg['compiler']['includes']['prefix'], $cfg['compiler']['includes']['items'])

--- a/test/targets/clang_file.yml
+++ b/test/targets/clang_file.yml
@@ -57,7 +57,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_64
       - UNITY_OUTPUT_RESULTS_FILE

--- a/test/targets/clang_strict.yml
+++ b/test/targets/clang_strict.yml
@@ -57,7 +57,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES
       - UNITY_SUPPORT_64

--- a/test/targets/gcc_32.yml
+++ b/test/targets/gcc_32.yml
@@ -19,7 +19,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
       - UNITY_EXCLUDE_LIMITS_H
       - UNITY_EXCLUDE_SIZEOF

--- a/test/targets/gcc_64.yml
+++ b/test/targets/gcc_64.yml
@@ -19,7 +19,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
       - UNITY_EXCLUDE_LIMITS_H
       - UNITY_EXCLUDE_SIZEOF

--- a/test/targets/gcc_auto_limits.yml
+++ b/test/targets/gcc_auto_limits.yml
@@ -19,7 +19,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES

--- a/test/targets/gcc_auto_sizeof.yml
+++ b/test/targets/gcc_auto_sizeof.yml
@@ -19,7 +19,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_STDINT_H
       - UNITY_EXCLUDE_LIMITS_H
       - UNITY_INCLUDE_DOUBLE

--- a/test/targets/gcc_auto_stdint.yml
+++ b/test/targets/gcc_auto_stdint.yml
@@ -32,7 +32,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES
       - UNITY_SUPPORT_64

--- a/test/targets/gcc_manual_math.yml
+++ b/test/targets/gcc_manual_math.yml
@@ -19,7 +19,6 @@ compiler:
   defines:
     prefix: '-D'
     items:
-      - UNITY_OUTPUT_CHAR=putcharSpy
       - UNITY_EXCLUDE_MATH_H
       - UNITY_INCLUDE_DOUBLE
       - UNITY_SUPPORT_TEST_CASES


### PR DESCRIPTION
 Make core Unity `rakefile_helper` follow Fixture `rakefile_helper` define procedure.
 This commit reverts parts of 36e2ca1.