### PR TITLE
Feature - remove dependencies from Fixture, add internal heap option

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -6,21 +6,19 @@
 ========================================== */
 
 #include <string.h>
-#include <stdio.h>
 #include "unity_fixture.h"
 #include "unity_internals.h"
 
 UNITY_FIXTURE_T UnityFixture;
 
 //If you decide to use the function pointer approach.
-int (*outputChar)(int) = putchar;
+//Build with -D UNITY_OUTPUT_CHAR=outputChar and include <stdio.h>
+//int (*outputChar)(int) = putchar;
 
-int verbose = 0;
-
-void setUp(void);
-void tearDown(void);
+#if !defined(UNITY_WEAK_ATTRIBUTE) && !defined(UNITY_WEAK_PRAGMA)
 void setUp(void)    { /*does nothing*/ }
 void tearDown(void) { /*does nothing*/ }
+#endif
 
 static void announceTestRun(unsigned int runNumber)
 {
@@ -67,11 +65,6 @@ static int groupSelected(const char* group)
     return selected(UnityFixture.GroupFilter, group);
 }
 
-static void runTestCase(void)
-{
-
-}
-
 void UnityTestRunner(unityfunction* setup,
         unityfunction* testBody,
         unityfunction* teardown,
@@ -95,7 +88,6 @@ void UnityTestRunner(unityfunction* setup,
         UnityMalloc_StartTest();
         UnityPointer_Init();
 
-        runTestCase();
         if (TEST_PROTECT())
         {
             setup();
@@ -174,7 +166,6 @@ void UnityMalloc_MakeMallocFailAfterCount(int countdown)
 #endif
 
 #include <stdlib.h>
-#include <string.h>
 
 typedef struct GuardBytes
 {

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -48,7 +48,7 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
     return UnityFailureCount();
 }
 
-static int selected(const char * filter, const char * name)
+static int selected(const char* filter, const char* name)
 {
     if (filter == 0)
         return 1;
@@ -66,12 +66,12 @@ static int groupSelected(const char* group)
 }
 
 void UnityTestRunner(unityfunction* setup,
-        unityfunction* testBody,
-        unityfunction* teardown,
-        const char * printableName,
-        const char * group,
-        const char * name,
-        const char * file, int line)
+                     unityfunction* testBody,
+                     unityfunction* teardown,
+                     const char* printableName,
+                     const char* group,
+                     const char* name,
+                     const char* file, int line)
 {
     if (testSelected(name) && groupSelected(group))
     {
@@ -107,7 +107,7 @@ void UnityTestRunner(unityfunction* setup,
     }
 }
 
-void UnityIgnoreTest(const char * printableName, const char * group, const char * name)
+void UnityIgnoreTest(const char* printableName, const char* group, const char* name)
 {
     if (testSelected(name) && groupSelected(group))
     {
@@ -176,7 +176,7 @@ typedef struct GuardBytes
 
 static const char end[] = "END";
 
-void * unity_malloc(size_t size)
+void* unity_malloc(size_t size)
 {
     char* mem;
     Guard* guard;
@@ -198,7 +198,7 @@ void * unity_malloc(size_t size)
     return (void*)mem;
 }
 
-static int isOverrun(void * mem)
+static int isOverrun(void* mem)
 {
     Guard* guard = (Guard*)mem;
     char* memAsChar = (char*)mem;
@@ -207,7 +207,7 @@ static int isOverrun(void * mem)
     return strcmp(&memAsChar[guard->size], end) != 0;
 }
 
-static void release_memory(void * mem)
+static void release_memory(void* mem)
 {
     Guard* guard = (Guard*)mem;
     guard--;
@@ -216,7 +216,7 @@ static void release_memory(void * mem)
     UNITY_FIXTURE_FREE(guard);
 }
 
-void unity_free(void * mem)
+void unity_free(void* mem)
 {
     int overrun;
 
@@ -240,7 +240,7 @@ void* unity_calloc(size_t num, size_t size)
     return mem;
 }
 
-void* unity_realloc(void * oldMem, size_t size)
+void* unity_realloc(void* oldMem, size_t size)
 {
     Guard* guard = (Guard*)oldMem;
 //    char* memAsChar = (char*)oldMem;
@@ -276,9 +276,9 @@ void* unity_realloc(void * oldMem, size_t size)
 //Automatic pointer restoration functions
 typedef struct _PointerPair
 {
-    struct _PointerPair * next;
-    void ** pointer;
-    void * old_value;
+    struct _PointerPair* next;
+    void** pointer;
+    void* old_value;
 } PointerPair;
 
 enum {MAX_POINTERS=50};

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -149,21 +149,12 @@ void UnityMalloc_MakeMallocFailAfterCount(int countdown)
     malloc_fail_countdown = countdown;
 }
 
-#ifdef malloc
+// These definitions are always included from unity_fixture_malloc_overrides.h
+// We undef to use them or avoid conflict with <stdlib.h> per the C standard
 #undef malloc
-#endif
-
-#ifdef free
 #undef free
-#endif
-
-#ifdef calloc
 #undef calloc
-#endif
-
-#ifdef realloc
 #undef realloc
-#endif
 
 #include <stdlib.h>
 
@@ -290,7 +281,7 @@ void UnityPointer_Init(void)
     pointer_index = 0;
 }
 
-void UnityPointer_Set(void ** pointer, void * newValue)
+void UnityPointer_Set(void** pointer, void* newValue)
 {
     if (pointer_index >= MAX_POINTERS)
     {
@@ -311,8 +302,7 @@ void UnityPointer_UndoAllSets(void)
     {
         pointer_index--;
         *(pointer_store[pointer_index].pointer) =
-        pointer_store[pointer_index].old_value;
-
+            pointer_store[pointer_index].old_value;
     }
 }
 
@@ -373,7 +363,13 @@ int UnityGetCommandLineOptions(int argc, const char* argv[])
             {
                 if (*(argv[i]) >= '0' && *(argv[i]) <= '9')
                 {
-                    UnityFixture.RepeatCount = atoi(argv[i]);
+                    unsigned int digit = 0;
+                    UnityFixture.RepeatCount = 0;
+                    while (argv[i][digit] >= '0' && argv[i][digit] <= '9')
+                    {
+                        UnityFixture.RepeatCount *= 10;
+                        UnityFixture.RepeatCount += (unsigned int)argv[i][digit++] - '0';
+                    }
                     i++;
                 }
             }

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -179,9 +179,11 @@ void* unity_malloc(size_t size)
         malloc_fail_countdown--;
     }
 
+    if (size == 0) return NULL;
     malloc_count++;
 
     guard = (Guard*)UNITY_FIXTURE_MALLOC(size + sizeof(Guard) + sizeof(end));
+    if (guard == NULL) return NULL;
     guard->size = size;
     mem = (char*)&(guard[1]);
     memcpy(&mem[size], end, sizeof(end));
@@ -227,6 +229,7 @@ void unity_free(void* mem)
 void* unity_calloc(size_t num, size_t size)
 {
     void* mem = unity_malloc(num * size);
+    if (mem == NULL) return NULL;
     memset(mem, 0, num*size);
     return mem;
 }
@@ -237,8 +240,7 @@ void* unity_realloc(void* oldMem, size_t size)
 //    char* memAsChar = (char*)oldMem;
     void* newMem;
 
-    if (oldMem == 0)
-        return unity_malloc(size);
+    if (oldMem == NULL) return unity_malloc(size);
 
     guard--;
     if (isOverrun(oldMem))
@@ -250,13 +252,13 @@ void* unity_realloc(void* oldMem, size_t size)
     if (size == 0)
     {
         release_memory(oldMem);
-        return 0;
+        return NULL;
     }
 
-    if (guard->size >= size)
-        return oldMem;
+    if (guard->size >= size) return oldMem;
 
     newMem = unity_malloc(size);
+    if (newMem == NULL) return NULL; // Do not release old memory
     memcpy(newMem, oldMem, guard->size);
     unity_free(oldMem);
     return newMem;

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -38,9 +38,4 @@ void UnityPointer_Set(void** ptr, void* newValue);
 void UnityPointer_UndoAllSets(void);
 void UnityPointer_Init(void);
 
-void UnityAssertEqualPointer(const void * expected,
-                            const void * actual,
-                            const char* msg,
-                            const UNITY_LINE_TYPE lineNumber);
-
 #endif /* UNITY_FIXTURE_INTERNALS_H_ */

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -17,15 +17,15 @@ typedef struct _UNITY_FIXTURE_T
 } UNITY_FIXTURE_T;
 
 typedef void unityfunction(void);
-void UnityTestRunner(unityfunction * setup,
-        unityfunction * body,
-        unityfunction * teardown,
-        const char * printableName,
-        const char * group,
-        const char * name,
-        const char * file, int line);
+void UnityTestRunner(unityfunction* setup,
+                     unityfunction* body,
+                     unityfunction* teardown,
+                     const char* printableName,
+                     const char* group,
+                     const char* name,
+                     const char* file, int line);
 
-void UnityIgnoreTest(const char * printableName, const char * group, const char * name);
+void UnityIgnoreTest(const char* printableName, const char* group, const char* name);
 void UnityMalloc_StartTest(void);
 void UnityMalloc_EndTest(void);
 UNITY_COUNTER_TYPE UnityFailureCount(void);
@@ -34,7 +34,7 @@ UNITY_COUNTER_TYPE UnityTestsCount(void);
 int UnityGetCommandLineOptions(int argc, const char* argv[]);
 void UnityConcludeFixtureTest(void);
 
-void UnityPointer_Set(void ** ptr, void * newValue);
+void UnityPointer_Set(void** ptr, void* newValue);
 void UnityPointer_UndoAllSets(void);
 void UnityPointer_Init(void);
 

--- a/extras/fixture/src/unity_fixture_malloc_overrides.h
+++ b/extras/fixture/src/unity_fixture_malloc_overrides.h
@@ -10,11 +10,21 @@
 
 #include <stddef.h>
 
+#ifdef UNITY_EXCLUDE_STDLIB_MALLOC
+// Define this macro to remove the use of stdlib.h, malloc, and free.
+// Many embedded systems do not have a heap or malloc/free by default.
+// This internal unity_malloc() provides allocated memory deterministically from
+// the end of an array only, unity_free() only releases from end-of-array,
+// blocks are not coalesced, and memory not freed in LIFO order is stranded.
+    #ifndef UNITY_INTERNAL_HEAP_SIZE_BYTES
+    #define UNITY_INTERNAL_HEAP_SIZE_BYTES 256
+    #endif
+#endif
+
 // These functions are used by the Unity Fixture to allocate and release memory
 // on the heap and can be overridden with platform-specific implementations.
 // For example, when using FreeRTOS UNITY_FIXTURE_MALLOC becomes pvPortMalloc()
 // and UNITY_FIXTURE_FREE becomes vPortFree().
-
 #if !defined(UNITY_FIXTURE_MALLOC) || !defined(UNITY_FIXTURE_FREE)
     #define UNITY_FIXTURE_MALLOC(size) malloc(size)
     #define UNITY_FIXTURE_FREE(ptr)    free(ptr)

--- a/extras/fixture/src/unity_fixture_malloc_overrides.h
+++ b/extras/fixture/src/unity_fixture_malloc_overrides.h
@@ -10,26 +10,17 @@
 
 #include <stddef.h>
 
-// This function is used by the Unity Fixture to allocate memory on
-// the heap and can be overridden with platform-specific heap
-// implementations. For example, when using FreeRTOS
-// UNITY_FIXTURE_MALLOC becomes pvPortMalloc().
+// These functions are used by the Unity Fixture to allocate and release memory
+// on the heap and can be overridden with platform-specific implementations.
+// For example, when using FreeRTOS UNITY_FIXTURE_MALLOC becomes pvPortMalloc()
+// and UNITY_FIXTURE_FREE becomes vPortFree().
 
-#ifndef UNITY_FIXTURE_MALLOC
-   #define UNITY_FIXTURE_MALLOC( SIZE ) malloc( ( SIZE ) )
+#if !defined(UNITY_FIXTURE_MALLOC) || !defined(UNITY_FIXTURE_FREE)
+    #define UNITY_FIXTURE_MALLOC(size) malloc(size)
+    #define UNITY_FIXTURE_FREE(ptr)    free(ptr)
 #else
-   extern void * UNITY_FIXTURE_MALLOC(size_t size);
-#endif
-
-// This function is used by the Unity Fixture to release memory in the
-// heap and can be overridden with platform-specific heap
-// implementations. For example, when using FreeRTOS
-// UNITY_FIXTURE_FREE becomes vPortFree().
-
-#ifndef UNITY_FIXTURE_FREE
-   #define UNITY_FIXTURE_FREE( PTR ) free( ( PTR ) )
-#else
-   extern void UNITY_FIXTURE_FREE(void *ptr);
+    extern void* UNITY_FIXTURE_MALLOC(size_t size);
+    extern void UNITY_FIXTURE_FREE(void* ptr);
 #endif
 
 #define malloc  unity_malloc

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -14,6 +14,22 @@ SRC = ../src/unity_fixture.c \
 INC_DIR = -I../src -I../../../src/
 TARGET = fixture_tests.exe
 
-all:
+all: default noStdlibMalloc 32bits
+
+default:
 	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET)
+	@ echo "default build"
 	./$(TARGET)
+
+32bits:
+	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m32
+	@ echo "32bits build"
+	./$(TARGET)
+
+noStdlibMalloc:
+	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -D UNITY_EXCLUDE_STDLIB_MALLOC
+	@ echo "build with noStdlibMalloc"
+	./$(TARGET)
+
+clangEverything:
+	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m64 -Weverything # || true #prevents make from failing

--- a/extras/fixture/test/main/AllTests.c
+++ b/extras/fixture/test/main/AllTests.c
@@ -11,7 +11,8 @@ static void runAllTests(void)
 {
     RUN_TEST_GROUP(UnityFixture);
     RUN_TEST_GROUP(UnityCommandOptions);
-    RUN_TEST_GROUP(LeakDetection)
+    RUN_TEST_GROUP(LeakDetection);
+    RUN_TEST_GROUP(InternalMalloc);
 }
 
 int main(int argc, const char* argv[])

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -79,6 +79,7 @@ TEST(UnityFixture, ReallocLargerNeeded)
 {
     void* m1 = malloc(10);
     void* m2;
+    CHECK(m1);
     strcpy((char*)m1, "123456789");
     m2 = realloc(m1, 15);
     CHECK(m1 != m2);
@@ -104,6 +105,7 @@ TEST(UnityFixture, CallocFillsWithZero)
 {
     void* m = calloc(3, sizeof(char));
     char* s = (char*)m;
+    CHECK(m);
     TEST_ASSERT_BYTES_EQUAL(0, s[0]);
     TEST_ASSERT_BYTES_EQUAL(0, s[1]);
     TEST_ASSERT_BYTES_EQUAL(0, s[2]);
@@ -323,6 +325,7 @@ TEST(LeakDetection, DetectsLeak)
     TEST_IGNORE_MESSAGE("Build with '-D UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar' to enable tests");
 #else
     void* m = malloc(10);
+    TEST_ASSERT_NOT_NULL(m);
     UnityOutputCharSpy_Enable(1);
     EXPECT_ABORT_BEGIN
     UnityMalloc_EndTest();
@@ -341,6 +344,7 @@ TEST(LeakDetection, BufferOverrunFoundDuringFree)
     TEST_IGNORE();
 #else
     void* m = malloc(10);
+    TEST_ASSERT_NOT_NULL(m);
     char* s = (char*)m;
     s[10] = (char)0xFF;
     UnityOutputCharSpy_Enable(1);
@@ -360,6 +364,7 @@ TEST(LeakDetection, BufferOverrunFoundDuringRealloc)
     TEST_IGNORE();
 #else
     void* m = malloc(10);
+    TEST_ASSERT_NOT_NULL(m);
     char* s = (char*)m;
     s[10] = (char)0xFF;
     UnityOutputCharSpy_Enable(1);

--- a/extras/fixture/test/unity_fixture_TestRunner.c
+++ b/extras/fixture/test/unity_fixture_TestRunner.c
@@ -41,3 +41,11 @@ TEST_GROUP_RUNNER(LeakDetection)
     RUN_TEST_CASE(LeakDetection, BufferOverrunFoundDuringFree);
     RUN_TEST_CASE(LeakDetection, BufferOverrunFoundDuringRealloc);
 }
+
+TEST_GROUP_RUNNER(InternalMalloc)
+{
+    RUN_TEST_CASE(InternalMalloc, MallocPastBufferFails);
+    RUN_TEST_CASE(InternalMalloc, CallocPastBufferFails);
+    RUN_TEST_CASE(InternalMalloc, MallocThenReallocGrowsMemoryInPlace);
+    RUN_TEST_CASE(InternalMalloc, ReallocFailDoesNotFreeMem);
+}

--- a/extras/fixture/test/unity_output_Spy.c
+++ b/extras/fixture/test/unity_output_Spy.c
@@ -23,6 +23,7 @@ void UnityOutputCharSpy_Create(int s)
     count = 0;
     spy_enable = 0;
     buffer = UNITY_FIXTURE_MALLOC(size);
+    TEST_ASSERT_NOT_NULL_MESSAGE(buffer, "Internal malloc failed in Spy Create():" __FILE__);
     memset(buffer, 0, size);
 }
 

--- a/extras/fixture/test/unity_output_Spy.c
+++ b/extras/fixture/test/unity_output_Spy.c
@@ -22,7 +22,7 @@ void UnityOutputCharSpy_Create(int s)
     size = s;
     count = 0;
     spy_enable = 0;
-    buffer = UNITY_FIXTURE_MALLOC(size);
+    buffer = malloc(size);
     TEST_ASSERT_NOT_NULL_MESSAGE(buffer, "Internal malloc failed in Spy Create():" __FILE__);
     memset(buffer, 0, size);
 }
@@ -30,7 +30,7 @@ void UnityOutputCharSpy_Create(int s)
 void UnityOutputCharSpy_Destroy(void)
 {
     size = 0;
-    UNITY_FIXTURE_FREE(buffer);
+    free(buffer);
 }
 
 int UnityOutputCharSpy_OutputChar(int c)


### PR DESCRIPTION
1. The crux of this pull request is the addition of the configuration option `UNITY_EXCLUDE_STDLIB_MALLOC`. This feature removes the dependency on malloc/free for constrained embedded systems without a heap. It uses a static heap inside Unity Fixture. Setting `UNITY_INTERNAL_HEAP_SIZE_BYTES` sizes the heap.
Adding this option is useful for testing on embedded systems. It leaves the `malloc()` functionality available, but allows Unity Fixture to actually build without a system library heap implementation. Setting this option 1) Excludes dependence on `stdlib.h` 2) Implements a simple replacement for `malloc` inside `unity_malloc`.
The tests for Fixture will all run using the default heap size (256 bytes) when compiled with `-D UNITY_EXCLUDE_STDLIB_MALLOC`.
2. Breaks dependencies on `putchar()` (wasn't even being used), `atoi()`, and `stdlib.h` when not required.
3. Some cleanup of whitespace and old code.
4. Added NULL safety checks! It is amazing how many crashes were lurking, uncovered when the heap size is only 256 bytes.
5. Slight change to `unity_malloc()` within C standards: Return value is now `NULL` for size=0. Previously, it returned a 0 size block of memory you were not allowed to dereference, but had to free.