### PR TITLE
Check for writes to guard space on malloc'd buffers in Fixture

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -166,7 +166,7 @@ static unsigned int  heap_index;
 typedef struct GuardBytes
 {
     size_t size;
-    char guard_space[4];
+    size_t guard_space;
 } Guard;
 
 
@@ -202,6 +202,7 @@ void* unity_malloc(size_t size)
     if (guard == NULL) return NULL;
     malloc_count++;
     guard->size = size;
+    guard->guard_space = 0;
     mem = (char*)&(guard[1]);
     memcpy(&mem[size], end, sizeof(end));
 
@@ -214,7 +215,7 @@ static int isOverrun(void* mem)
     char* memAsChar = (char*)mem;
     guard--;
 
-    return strcmp(&memAsChar[guard->size], end) != 0;
+    return guard->guard_space != 0 || strcmp(&memAsChar[guard->size], end) != 0;
 }
 
 static void release_memory(void* mem)

--- a/extras/fixture/test/unity_fixture_TestRunner.c
+++ b/extras/fixture/test/unity_fixture_TestRunner.c
@@ -40,6 +40,8 @@ TEST_GROUP_RUNNER(LeakDetection)
     RUN_TEST_CASE(LeakDetection, DetectsLeak);
     RUN_TEST_CASE(LeakDetection, BufferOverrunFoundDuringFree);
     RUN_TEST_CASE(LeakDetection, BufferOverrunFoundDuringRealloc);
+    RUN_TEST_CASE(LeakDetection, BufferGuardWriteFoundDuringFree);
+    RUN_TEST_CASE(LeakDetection, BufferGuardWriteFoundDuringRealloc);
 }
 
 TEST_GROUP_RUNNER(InternalMalloc)


### PR DESCRIPTION
There was already some space reserved as a guard, added check for writes before the beginning of the buffer. Use a `size_t` variable to prevent padding from mismatched sizes in the struct on some platforms.
Did not change the 'Buffer overrun detected' message. This message applies whether the write is before the beginning or after the end of a buffer.
Underrun buffer writes are likely to be a more rare case.