### PR TITLE
Bugfix - line numbers output by Fixture memory checks

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -140,7 +140,7 @@ void UnityMalloc_EndTest(void)
     malloc_fail_countdown = MALLOC_DONT_FAIL;
     if (malloc_count != 0)
     {
-        TEST_FAIL_MESSAGE("This test leaks!");
+        UNITY_TEST_FAIL(Unity.CurrentTestLineNumber, "This test leaks!");
     }
 }
 
@@ -247,7 +247,7 @@ void unity_free(void* mem)
     release_memory(mem);
     if (overrun)
     {
-        TEST_FAIL_MESSAGE("Buffer overrun detected during free()");
+        UNITY_TEST_FAIL(Unity.CurrentTestLineNumber, "Buffer overrun detected during free()");
     }
 }
 
@@ -270,7 +270,7 @@ void* unity_realloc(void* oldMem, size_t size)
     if (isOverrun(oldMem))
     {
         release_memory(oldMem);
-        TEST_FAIL_MESSAGE("Buffer overrun detected during realloc()");
+        UNITY_TEST_FAIL(Unity.CurrentTestLineNumber, "Buffer overrun detected during realloc()");
     }
 
     if (size == 0)

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -299,15 +299,14 @@ void* unity_realloc(void* oldMem, size_t size)
 
 //--------------------------------------------------------
 //Automatic pointer restoration functions
-typedef struct _PointerPair
+struct PointerPair
 {
-    struct _PointerPair* next;
     void** pointer;
     void* old_value;
-} PointerPair;
+};
 
-enum {MAX_POINTERS=50};
-static PointerPair pointer_store[MAX_POINTERS+1];
+enum { MAX_POINTERS = 50 };
+static struct PointerPair pointer_store[MAX_POINTERS];
 static int pointer_index = 0;
 
 void UnityPointer_Init(void)
@@ -315,11 +314,11 @@ void UnityPointer_Init(void)
     pointer_index = 0;
 }
 
-void UnityPointer_Set(void** pointer, void* newValue)
+void UnityPointer_Set(void** pointer, void* newValue, UNITY_LINE_TYPE line)
 {
     if (pointer_index >= MAX_POINTERS)
     {
-        TEST_FAIL_MESSAGE("Too many pointers set");
+        UNITY_TEST_FAIL(line, "Too many pointers set");
     }
     else
     {

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -9,7 +9,7 @@
 #include "unity_fixture.h"
 #include "unity_internals.h"
 
-UNITY_FIXTURE_T UnityFixture;
+struct _UnityFixture UnityFixture;
 
 //If you decide to use the function pointer approach.
 //Build with -D UNITY_OUTPUT_CHAR=outputChar and include <stdio.h>

--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -64,7 +64,7 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
       TEST_##group##_GROUP_RUNNER(); }
 
 //CppUTest Compatibility Macros
-#define UT_PTR_SET(ptr, newPointerValue)               UnityPointer_Set((void**)&(ptr), (void*)(newPointerValue))
+#define UT_PTR_SET(ptr, newPointerValue)               UnityPointer_Set((void**)&(ptr), (void*)(newPointerValue), __LINE__)
 #define TEST_ASSERT_POINTERS_EQUAL(expected, actual)   TEST_ASSERT_EQUAL_PTR((expected), (actual))
 #define TEST_ASSERT_BYTES_EQUAL(expected, actual)      TEST_ASSERT_EQUAL_HEX8(0xff & (expected), 0xff & (actual))
 #define FAIL(message)                                  TEST_FAIL_MESSAGE((message))

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -34,7 +34,7 @@ UNITY_COUNTER_TYPE UnityTestsCount(void);
 int UnityGetCommandLineOptions(int argc, const char* argv[]);
 void UnityConcludeFixtureTest(void);
 
-void UnityPointer_Set(void** ptr, void* newValue);
+void UnityPointer_Set(void** ptr, void* newValue, UNITY_LINE_TYPE line);
 void UnityPointer_UndoAllSets(void);
 void UnityPointer_Init(void);
 

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -8,13 +8,13 @@
 #ifndef UNITY_FIXTURE_INTERNALS_H_
 #define UNITY_FIXTURE_INTERNALS_H_
 
-typedef struct _UNITY_FIXTURE_T
+struct _UnityFixture
 {
     int Verbose;
     unsigned int RepeatCount;
     const char* NameFilter;
     const char* GroupFilter;
-} UNITY_FIXTURE_T;
+};
 
 typedef void unityfunction(void);
 void UnityTestRunner(unityfunction* setup,

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -422,6 +422,26 @@ TEST(LeakDetection, BufferGuardWriteFoundDuringRealloc)
 #endif
 }
 
+TEST(LeakDetection, PointerSettingMax)
+{
+#ifndef USING_OUTPUT_SPY
+    UNITY_PRINT_EOL();
+    TEST_IGNORE();
+#else
+    int i;
+    for (i = 0; i < 50; i++) UT_PTR_SET(pointer1, &int1);
+    UnityOutputCharSpy_Enable(1);
+    EXPECT_ABORT_BEGIN
+    UT_PTR_SET(pointer1, &int1);
+    EXPECT_ABORT_END
+    UnityOutputCharSpy_Enable(0);
+    Unity.CurrentTestFailed = 0;
+    CHECK(strstr(UnityOutputCharSpy_Get(), "Too many pointers set"));
+#endif
+}
+
+//------------------------------------------------------------
+
 TEST_GROUP(InternalMalloc);
 
 TEST_SETUP(InternalMalloc) { }

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-extern UNITY_FIXTURE_T UnityFixture;
+extern struct _UnityFixture UnityFixture;
 
 TEST_GROUP(UnityFixture);
 

--- a/extras/fixture/test/unity_fixture_TestRunner.c
+++ b/extras/fixture/test/unity_fixture_TestRunner.c
@@ -42,6 +42,7 @@ TEST_GROUP_RUNNER(LeakDetection)
     RUN_TEST_CASE(LeakDetection, BufferOverrunFoundDuringRealloc);
     RUN_TEST_CASE(LeakDetection, BufferGuardWriteFoundDuringFree);
     RUN_TEST_CASE(LeakDetection, BufferGuardWriteFoundDuringRealloc);
+    RUN_TEST_CASE(LeakDetection, PointerSettingMax);
 }
 
 TEST_GROUP_RUNNER(InternalMalloc)


### PR DESCRIPTION
Fix printing the test line number for leak detection failures in Fixture
The old failure would print the line in unity_fixture.c, not very useful.
Now using CurrentTestLineNumber, which is better.
Pointer setting macro passes line number from test directly.