### PR TITLE
UnityPrintFloat buffer overflow fix

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -283,7 +283,7 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
 void UnityPrintFloat(_UF number)
 {
     char TempBuffer[32];
-    sprintf(TempBuffer, "%.6f", number);
+    snprintf(TempBuffer, sizeof(TempBuffer), "%.6f", number);
     UnityPrint(TempBuffer);
 }
 #endif

--- a/src/unity.c
+++ b/src/unity.c
@@ -280,9 +280,10 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
 //-----------------------------------------------
 #ifdef UNITY_FLOAT_VERBOSE
 #include <stdio.h>
+#include <float.h>
 void UnityPrintFloat(_UF number)
 {
-    char TempBuffer[32];
+    char TempBuffer[1/*'-'*/ + (FLT_MAX_10_EXP+1)/*38+1 digits*/ + 1/*'.'*/ + 6/*Default? precision*/ + 1/*\0*/];
     snprintf(TempBuffer, sizeof(TempBuffer), "%.6f", number);
     UnityPrint(TempBuffer);
 }


### PR DESCRIPTION
`UnityPrintFloat()` overflows on some inputs, eg. `FLT_MAX`. Fix this by using `strncpy` instead of `strcpy`.

Additionally, `UnityPrintFloat()`'s temporal buffer is now large enough to allow formatting any single precision float without truncation (truncation still performed for certain double precision floats).