### PR TITLE
Delete unused Fixture internals functions for failure, ignore, & test counts

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -45,7 +45,7 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
         UnityEnd();
     }
 
-    return UnityFailureCount();
+    return Unity.TestFailures;
 }
 
 static int selected(const char* filter, const char* name)
@@ -337,21 +337,6 @@ void UnityPointer_UndoAllSets(void)
         *(pointer_store[pointer_index].pointer) =
             pointer_store[pointer_index].old_value;
     }
-}
-
-UNITY_COUNTER_TYPE UnityFailureCount(void)
-{
-    return Unity.TestFailures;
-}
-
-UNITY_COUNTER_TYPE UnityIgnoreCount(void)
-{
-    return Unity.TestIgnores;
-}
-
-UNITY_COUNTER_TYPE UnityTestsCount(void)
-{
-    return Unity.NumberOfTests;
 }
 
 int UnityGetCommandLineOptions(int argc, const char* argv[])

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -28,9 +28,6 @@ void UnityTestRunner(unityfunction* setup,
 void UnityIgnoreTest(const char* printableName, const char* group, const char* name);
 void UnityMalloc_StartTest(void);
 void UnityMalloc_EndTest(void);
-UNITY_COUNTER_TYPE UnityFailureCount(void);
-UNITY_COUNTER_TYPE UnityIgnoreCount(void);
-UNITY_COUNTER_TYPE UnityTestsCount(void);
 int UnityGetCommandLineOptions(int argc, const char* argv[]);
 void UnityConcludeFixtureTest(void);
 


### PR DESCRIPTION
These wrapper functions should be in core `Unity`, if warranted.
Use the Unity struct directly for access, or consider `MACRO()` functions. No test coverage exists.