### PR TITLE
Clean up int conversion warnings in Fixture

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -23,9 +23,9 @@ void tearDown(void) { /*does nothing*/ }
 static void announceTestRun(unsigned int runNumber)
 {
     UnityPrint("Unity test run ");
-    UnityPrintNumber(runNumber+1);
+    UnityPrintNumberUnsigned(runNumber+1);
     UnityPrint(" of ");
-    UnityPrintNumber(UnityFixture.RepeatCount);
+    UnityPrintNumberUnsigned(UnityFixture.RepeatCount);
     UNITY_PRINT_EOL();
 }
 
@@ -45,7 +45,7 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void))
         UnityEnd();
     }
 
-    return Unity.TestFailures;
+    return (int)Unity.TestFailures;
 }
 
 static int selected(const char* filter, const char* name)
@@ -71,7 +71,7 @@ void UnityTestRunner(unityfunction* setup,
                      const char* printableName,
                      const char* group,
                      const char* name,
-                     const char* file, int line)
+                     const char* file, unsigned int line)
 {
     if (testSelected(name) && groupSelected(group))
     {

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -23,7 +23,7 @@ void UnityTestRunner(unityfunction* setup,
                      const char* printableName,
                      const char* group,
                      const char* name,
-                     const char* file, int line);
+                     const char* file, unsigned int line);
 
 void UnityIgnoreTest(const char* printableName, const char* group, const char* name);
 void UnityMalloc_StartTest(void);

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -1,8 +1,11 @@
 CC = gcc
-CFLAGS += -Werror
+#DEBUG = -O0 -g
 CFLAGS += -std=c99
 CFLAGS += -pedantic
-CFLAGS += -Wundef
+CFLAGS += -Wall
+CFLAGS += -Wextra
+CFLAGS += -Werror
+CFLAGS += $(DEBUG)
 DEFINES = -D UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar
 SRC = ../src/unity_fixture.c \
       ../../../src/unity.c   \
@@ -32,7 +35,26 @@ noStdlibMalloc: ../build/
 	./$(TARGET)
 
 clangEverything:
-	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m64 -Weverything # || true #prevents make from failing
+	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m64 -Weverything
 
 ../build :
 	mkdir -p ../build
+
+clean:
+	rm -f $(TARGET)
+
+# These extended flags DO get included before any target build runs
+CFLAGS += -Wbad-function-cast
+CFLAGS += -Wcast-qual
+#CFLAGS += -Wconversion
+CFLAGS += -Wformat=2
+CFLAGS += -Wmissing-prototypes
+CFLAGS += -Wold-style-definition
+CFLAGS += -Wpointer-arith
+CFLAGS += -Wshadow
+CFLAGS += -Wstrict-overflow=5
+CFLAGS += -Wstrict-prototypes
+CFLAGS += -Wswitch-default
+CFLAGS += -Wundef
+CFLAGS += -Wunused
+CFLAGS += -fstrict-aliasing

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -46,7 +46,7 @@ clean:
 # These extended flags DO get included before any target build runs
 CFLAGS += -Wbad-function-cast
 CFLAGS += -Wcast-qual
-#CFLAGS += -Wconversion
+CFLAGS += -Wconversion
 CFLAGS += -Wformat=2
 CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wold-style-definition

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -22,14 +22,13 @@ TEST_TEAR_DOWN(UnityFixture)
 {
 }
 
-int my_int;
-int* pointer1 = 0;
-int* pointer2 = (int*)2;
-int* pointer3 = (int*)3;
-int int1;
-int int2;
-int int3;
-int int4;
+static int* pointer1 = 0;
+static int* pointer2 = (int*)2;
+static int* pointer3 = (int*)3;
+static int int1;
+static int int2;
+static int int3;
+static int int4;
 
 TEST(UnityFixture, PointerSetting)
 {
@@ -112,8 +111,8 @@ TEST(UnityFixture, CallocFillsWithZero)
     free(m);
 }
 
-char *p1;
-char *p2;
+static char *p1;
+static char *p2;
 
 TEST(UnityFixture, PointerSet)
 {
@@ -143,10 +142,10 @@ TEST(UnityFixture, FreeNULLSafety)
 
 TEST_GROUP(UnityCommandOptions);
 
-int savedVerbose;
-unsigned int savedRepeat;
-const char* savedName;
-const char* savedGroup;
+static int savedVerbose;
+static unsigned int savedRepeat;
+static const char* savedName;
+static const char* savedGroup;
 
 TEST_SETUP(UnityCommandOptions)
 {

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -144,7 +144,7 @@ TEST(UnityFixture, FreeNULLSafety)
 TEST_GROUP(UnityCommandOptions);
 
 int savedVerbose;
-int savedRepeat;
+unsigned int savedRepeat;
 const char* savedName;
 const char* savedGroup;
 

--- a/extras/fixture/test/unity_output_Spy.c
+++ b/extras/fixture/test/unity_output_Spy.c
@@ -22,7 +22,7 @@ void UnityOutputCharSpy_Create(int s)
     size = s;
     count = 0;
     spy_enable = 0;
-    buffer = malloc(size);
+    buffer = malloc((size_t)size);
     TEST_ASSERT_NOT_NULL_MESSAGE(buffer, "Internal malloc failed in Spy Create():" __FILE__);
     memset(buffer, 0, size);
 }
@@ -38,7 +38,7 @@ int UnityOutputCharSpy_OutputChar(int c)
     if (spy_enable)
     {
         if (count < (size-1))
-            buffer[count++] = c;
+            buffer[count++] = (char)c;
     }
     else
     {


### PR DESCRIPTION
Turn on `-Wconversion` in Makefile - fix all warnings.
Fix most of the rest of `clang`'s `-Weverything` warnings. Delete unused variables and mark as `static` where appropriate.