### PR TITLE
Fix additional primitive type conversion warnings on Linux

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -158,7 +158,7 @@ void UnityMalloc_MakeMallocFailAfterCount(int countdown)
 
 #ifdef UNITY_EXCLUDE_STDLIB_MALLOC
 static unsigned char unity_heap[UNITY_INTERNAL_HEAP_SIZE_BYTES];
-static unsigned int  heap_index;
+static size_t heap_index;
 #else
 #include <stdlib.h>
 #endif

--- a/extras/fixture/test/unity_output_Spy.c
+++ b/extras/fixture/test/unity_output_Spy.c
@@ -24,7 +24,7 @@ void UnityOutputCharSpy_Create(int s)
     spy_enable = 0;
     buffer = malloc((size_t)size);
     TEST_ASSERT_NOT_NULL_MESSAGE(buffer, "Internal malloc failed in Spy Create():" __FILE__);
-    memset(buffer, 0, size);
+    memset(buffer, 0, (size_t)size);
 }
 
 void UnityOutputCharSpy_Destroy(void)

--- a/src/unity.c
+++ b/src/unity.c
@@ -733,7 +733,7 @@ void UnityAssertFloatSpecial(const _UF actual,
     const char* trait_names[] = { UnityStrInf, UnityStrNegInf, UnityStrNaN, UnityStrDet };
     _U_SINT should_be_trait   = ((_U_SINT)style & 1);
     _U_SINT is_trait          = !should_be_trait;
-    _U_SINT trait_index       = style >> 1;
+    _U_SINT trait_index       = (_U_SINT)(style >> 1);
 
     UNITY_SKIP_EXECUTION;
 


### PR DESCRIPTION
Using gcc 4.8 on Ubuntu 14
Linux `gcc` didn't like the `size_t` to `unsigned int` conversions, or the `UNITY_FLOAT_TRAIT_T` (enum) to `_U_SINT`.