### PR TITLE
UnityPrintFloat overflow fixes

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -283,7 +283,7 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
 void UnityPrintFloat(_UF number)
 {
     char TempBuffer[32];
-    sprintf(TempBuffer, "%.6f", number);
+    snprintf(TempBuffer, sizeof(TempBuffer), "%.6f", number);
     UnityPrint(TempBuffer);
 }
 #endif

--- a/src/unity.c
+++ b/src/unity.c
@@ -280,9 +280,18 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
 //-----------------------------------------------
 #ifdef UNITY_FLOAT_VERBOSE
 #include <stdio.h>
+
+#ifndef UNITY_VERBOSE_NUMBER_MAX_LENGTH
+# ifdef UNITY_DOUBLE_VERBOSE
+#  define UNITY_VERBOSE_NUMBER_MAX_LENGTH 317
+# else
+#  define UNITY_VERBOSE_NUMBER_MAX_LENGTH 47
+# endif
+#endif
+
 void UnityPrintFloat(_UF number)
 {
-    char TempBuffer[32];
+    char TempBuffer[UNITY_VERBOSE_NUMBER_MAX_LENGTH + 1];
     snprintf(TempBuffer, sizeof(TempBuffer), "%.6f", number);
     UnityPrint(TempBuffer);
 }

--- a/src/unity.h
+++ b/src/unity.h
@@ -44,6 +44,7 @@ void tearDown(void);
 //     - define UNITY_DOUBLE_PRECISION to specify the precision to use when doing TEST_ASSERT_EQUAL_DOUBLE
 //     - define UNITY_DOUBLE_TYPE to specify something other than double
 //     - define UNITY_DOUBLE_VERBOSE to print floating point values in errors (uses sprintf)
+//     - define UNITY_VERBOSE_NUMBER_MAX_LENGTH to change maximum length of printed numbers (used by sprintf)
 
 // Output
 //     - by default, Unity prints to standard out with putchar.  define UNITY_OUTPUT_CHAR(a) with a different function if desired


### PR DESCRIPTION
`UnityPrintFloat()` overflows on some inputs, eg. `FLT_MAX`. Fix this by using `strncpy` instead of `strcpy`.

Additionally, `UnityPrintFloat()`'s temporal buffer is large enough to allow formatting single and double precision floats without truncation (see http://stackoverflow.com/a/7235717). Users can choose other temporal buffer length by defining `UNITY_VERBOSE_NUMBER_MAX_LENGTH`.