### PR TITLE
Delete function call syntax from Spy detect macros

### DIFF
--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -313,14 +313,14 @@ TEST_TEAR_DOWN(LeakDetection)
     memcpy(Unity.AbortFrame, TestAbortFrame, sizeof(jmp_buf)); \
   }
 
-// This tricky set of defines lets us see if we are using the Spy, returns 1 if true, else 0
-#define USING_SPY_AS(a)                          EXPAND_AND_USE_2ND(ASSIGN_VALUE(a), 0)
-#define ASSIGN_VALUE(a)                          VAL_FUNC_##a
-#define VAL_FUNC_UnityOutputCharSpy_OutputChar() 0, 1
-#define EXPAND_AND_USE_2ND(a, b)                 SECOND_PARAM(a, b, throwaway)
-#define SECOND_PARAM(a, b, ...)                  b
-#if USING_SPY_AS(UNITY_OUTPUT_CHAR())
-  #define USING_OUTPUT_SPY
+// This tricky set of defines lets us see if we are using the Spy, returns 1 if true
+#define USING_SPY_AS(a)                    EXPAND_AND_USE_2ND(ASSIGN_VALUE(a), 0)
+#define ASSIGN_VALUE(a)                    VAL_##a
+#define VAL_UnityOutputCharSpy_OutputChar  0, 1
+#define EXPAND_AND_USE_2ND(a, b)           SECOND_PARAM(a, b, throwaway)
+#define SECOND_PARAM(a, b, ...)            b
+#if USING_SPY_AS(UNITY_OUTPUT_CHAR)
+  #define USING_OUTPUT_SPY // UNITY_OUTPUT_CHAR = UnityOutputCharSpy_OutputChar
 #endif
 TEST(LeakDetection, DetectsLeak)
 {

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -2175,12 +2175,12 @@ void testIgnoredAndThenFailInTearDown(void)
 
 // Tricky series of macros to set USING_OUTPUT_SPY
 #define USING_SPY_AS(a)           EXPAND_AND_USE_2ND(ASSIGN_VALUE(a), 0)
-#define ASSIGN_VALUE(a)           VAL_FUNC_##a
-#define VAL_FUNC_putcharSpy()     0, 1
+#define ASSIGN_VALUE(a)           VAL_##a
+#define VAL_putcharSpy            0, 1
 #define EXPAND_AND_USE_2ND(a, b)  SECOND_PARAM(a, b, throwaway)
 #define SECOND_PARAM(a, b, ...)   b
-#if USING_SPY_AS(UNITY_OUTPUT_CHAR())
-  #define USING_OUTPUT_SPY // true only if UNITY_OUTPUT_CHAR = putchar_Spy
+#if USING_SPY_AS(UNITY_OUTPUT_CHAR)
+  #define USING_OUTPUT_SPY // true only if UNITY_OUTPUT_CHAR = putcharSpy
 #endif
 
 #ifdef USING_OUTPUT_SPY


### PR DESCRIPTION
This fixes #168. See the issue page for more discussion. Allows the tests to build when putchar() is defined as a macro with parenthesis around it, as in the ARM embedded gcc compiler.