### PR TITLE
Clean up IgnoreTest function in Fixture

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -75,7 +75,6 @@ void UnityTestRunner(unityfunction* setup,
 {
     if (testSelected(name) && groupSelected(group))
     {
-        Unity.CurrentTestFailed = 0;
         Unity.TestFile = file;
         Unity.CurrentTestName = printableName;
         Unity.CurrentTestLineNumber = line;
@@ -112,12 +111,14 @@ void UnityIgnoreTest(const char* printableName, const char* group, const char* n
     if (testSelected(name) && groupSelected(group))
     {
         Unity.NumberOfTests++;
-        Unity.CurrentTestIgnored = 1;
+        Unity.TestIgnores++;
         if (!UnityFixture.Verbose)
             UNITY_OUTPUT_CHAR('!');
         else
+        {
             UnityPrint(printableName);
-        UnityConcludeFixtureTest();
+            UNITY_PRINT_EOL();
+        }
     }
 }
 
@@ -403,11 +404,8 @@ void UnityConcludeFixtureTest(void)
 {
     if (Unity.CurrentTestIgnored)
     {
-        if (UnityFixture.Verbose)
-        {
-            UNITY_PRINT_EOL();
-        }
         Unity.TestIgnores++;
+        UNITY_PRINT_EOL();
     }
     else if (!Unity.CurrentTestFailed)
     {
@@ -417,7 +415,7 @@ void UnityConcludeFixtureTest(void)
             UNITY_PRINT_EOL();
         }
     }
-    else if (Unity.CurrentTestFailed)
+    else // Unity.CurrentTestFailed
     {
         Unity.TestFailures++;
         UNITY_PRINT_EOL();

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -343,7 +343,6 @@ TEST(LeakDetection, DetectsLeak)
 TEST(LeakDetection, BufferOverrunFoundDuringFree)
 {
 #ifndef USING_OUTPUT_SPY
-    UNITY_PRINT_EOL();
     TEST_IGNORE();
 #else
     void* m = malloc(10);
@@ -363,7 +362,6 @@ TEST(LeakDetection, BufferOverrunFoundDuringFree)
 TEST(LeakDetection, BufferOverrunFoundDuringRealloc)
 {
 #ifndef USING_OUTPUT_SPY
-    UNITY_PRINT_EOL();
     TEST_IGNORE();
 #else
     void* m = malloc(10);
@@ -383,7 +381,6 @@ TEST(LeakDetection, BufferOverrunFoundDuringRealloc)
 TEST(LeakDetection, BufferGuardWriteFoundDuringFree)
 {
 #ifndef USING_OUTPUT_SPY
-    UNITY_PRINT_EOL();
     TEST_IGNORE();
 #else
     void* m = malloc(10);
@@ -404,7 +401,6 @@ TEST(LeakDetection, BufferGuardWriteFoundDuringFree)
 TEST(LeakDetection, BufferGuardWriteFoundDuringRealloc)
 {
 #ifndef USING_OUTPUT_SPY
-    UNITY_PRINT_EOL();
     TEST_IGNORE();
 #else
     void* m = malloc(10);
@@ -424,7 +420,6 @@ TEST(LeakDetection, BufferGuardWriteFoundDuringRealloc)
 TEST(LeakDetection, PointerSettingMax)
 {
 #ifndef USING_OUTPUT_SPY
-    UNITY_PRINT_EOL();
     TEST_IGNORE();
 #else
     int i;


### PR DESCRIPTION
By removing the call to the `UnityConcludeFixtureTest()` function the code is simplified and doesn't depend on passing global state updates. Tests that are ignored in the `testBody` with `TEST_IGNORE()` still output the right EOL.