### PR TITLE
100% code coverage for Unity Fixture

### DIFF
--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -75,5 +75,6 @@ CFLAGS += -Wstrict-prototypes
 CFLAGS += -Wswitch-default
 CFLAGS += -Wundef
 CFLAGS += -Wno-error=undef  # Warning only, this should not stop the build
+CFLAGS += -Wunreachable-code
 CFLAGS += -Wunused
 CFLAGS += -fstrict-aliasing

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -1,4 +1,7 @@
 CC = gcc
+ifeq ($(shell uname -s), Darwin)
+CC = clang
+endif
 #DEBUG = -O0 -g
 CFLAGS += -std=c99
 CFLAGS += -pedantic
@@ -15,21 +18,22 @@ SRC = ../src/unity_fixture.c \
       main/AllTests.c
 
 INC_DIR = -I../src -I../../../src/
+BUILD_DIR = ../build
 TARGET = ../build/fixture_tests.exe
 
 all: default noStdlibMalloc 32bits
 
-default: ../build/
-	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET)
+default: $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -D UNITY_SUPPORT_64
 	@ echo "default build"
 	./$(TARGET)
 
-32bits: ../build/
+32bits: $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m32
 	@ echo "32bits build"
 	./$(TARGET)
 
-noStdlibMalloc: ../build/
+noStdlibMalloc: $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -D UNITY_EXCLUDE_STDLIB_MALLOC
 	@ echo "build with noStdlibMalloc"
 	./$(TARGET)
@@ -40,13 +44,22 @@ clang89: ../build/
 		-D UNITY_EXCLUDE_STDLIB_MALLOC -std=c89 -Wno-comment ; ./$(TARGET)
 
 clangEverything:
-	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m64 -Weverything
+	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -Weverything
 
-../build :
-	mkdir -p ../build
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
 
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(BUILD_DIR)/*.gc*
+
+coverage: $(BUILD_DIR)
+	cd $(BUILD_DIR) && \
+	$(CC) $(DEFINES) $(foreach i, $(SRC), ../test/$(i)) $(INC_DIR) -o $(TARGET) -fprofile-arcs -ftest-coverage
+	rm -f $(BUILD_DIR)/*.gcda
+	./$(TARGET) > /dev/null ; ./$(TARGET) -v > /dev/null
+	cd $(BUILD_DIR) && \
+	gcov unity_fixture.c | head -3
+	grep '###' $(BUILD_DIR)/unity_fixture.c.gcov -C2 || true # Show uncovered lines
 
 # These extended flags DO get included before any target build runs
 CFLAGS += -Wbad-function-cast

--- a/extras/fixture/test/unity_fixture_TestRunner.c
+++ b/extras/fixture/test/unity_fixture_TestRunner.c
@@ -19,6 +19,7 @@ TEST_GROUP_RUNNER(UnityFixture)
     RUN_TEST_CASE(UnityFixture, CallocFillsWithZero);
     RUN_TEST_CASE(UnityFixture, PointerSet);
     RUN_TEST_CASE(UnityFixture, FreeNULLSafety);
+    RUN_TEST_CASE(UnityFixture, ConcludeTestIncrementsFailCount);
 }
 
 TEST_GROUP_RUNNER(UnityCommandOptions)
@@ -32,6 +33,8 @@ TEST_GROUP_RUNNER(UnityCommandOptions)
     RUN_TEST_CASE(UnityCommandOptions, MultipleOptions);
     RUN_TEST_CASE(UnityCommandOptions, MultipleOptionsDashRNotLastAndNoValueSpecified);
     RUN_TEST_CASE(UnityCommandOptions, UnknownCommandIsIgnored);
+    RUN_TEST_CASE(UnityCommandOptions, GroupOrNameFilterWithoutStringFails);
+    RUN_TEST_CASE(UnityCommandOptions, GroupFilterReallyFilters);
     RUN_TEST_CASE(UnityCommandOptions, TestShouldBeIgnored);
 }
 

--- a/extras/fixture/test/unity_output_Spy.c
+++ b/extras/fixture/test/unity_output_Spy.c
@@ -19,7 +19,7 @@ static int spy_enable;
 
 void UnityOutputCharSpy_Create(int s)
 {
-    size = s;
+    size = (s > 0) ? s : 0;
     count = 0;
     spy_enable = 0;
     buffer = malloc((size_t)size);


### PR DESCRIPTION
Create coverage target in Makefile to output statement coverage with `gcov`
Add tests for uncovered lines
Run `make coverage -s` to see coverage for the fixture, specifically the file `unity_fixture.c`