### PR TITLE
Fix #182, remove redundant function declarations

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -67,9 +67,6 @@ const _U_UINT UnitySizeMask[] =
 #endif
 };
 
-void UnityPrintFail(void);
-void UnityPrintOk(void);
-
 //-----------------------------------------------
 // Pretty Printers & Test Result Output Handlers
 //-----------------------------------------------
@@ -1261,8 +1258,6 @@ void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
 
 //-----------------------------------------------
 #if defined(UNITY_WEAK_ATTRIBUTE)
-    void setUp(void);
-    void tearDown(void);
     UNITY_WEAK_ATTRIBUTE void setUp(void) { }
     UNITY_WEAK_ATTRIBUTE void tearDown(void) { }
 #elif defined(UNITY_WEAK_PRAGMA)
@@ -1270,9 +1265,6 @@ void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
     void setUp(void) { }
 #   pragma weak tearDown
     void tearDown(void) { }
-#else
-    void setUp(void);
-    void tearDown(void);
 #endif
 //-----------------------------------------------
 void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum)

--- a/src/unity.c
+++ b/src/unity.c
@@ -7,6 +7,11 @@
 #include "unity.h"
 #include <stddef.h>
 
+#ifndef UNITY_OUTPUT_CHAR_USE_PUTC
+//If defined as something else, make sure we declare it here so it's ready for use
+extern int UNITY_OUTPUT_CHAR(int);
+#endif
+
 #define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
 #define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
 /// return prematurely if we are already in failure or ignore state

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -291,9 +291,12 @@ typedef UNITY_DOUBLE_TYPE _UD;
 //Default to using putchar, which is defined in stdio.h
 #include <stdio.h>
 #define UNITY_OUTPUT_CHAR(a) putchar(a)
-#else
-//If defined as something else, make sure we declare it here so it's ready for use
-extern int UNITY_OUTPUT_CHAR(int);
+// We need to flag the output char function uses putc in
+//  unity.c the extern function is not declared then.
+// Previously the extern was declared in this header but
+//  when redundant function declaration compiler flag is enabled
+//  it wont compile.
+#define UNITY_OUTPUT_CHAR_USE_PUTC
 #endif
 
 #ifndef UNITY_PRINT_EOL

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ ifeq ($(shell uname -s), Darwin)
 CC = clang
 endif
 #DEBUG = -O0 -g
-CFLAGS += -std=c99 -pedantic -Wall -Wextra -Werror
+CFLAGS += -std=c99 -pedantic -Wall -Wextra -Werror -Wredundant-decls
 CFLAGS += $(DEBUG)
 DEFINES = -D UNITY_OUTPUT_CHAR=putcharSpy -D UNITY_INCLUDE_DOUBLE
 SRC = ../src/unity.c tests/testunity.c build/testunityRunner.c

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -8,6 +8,8 @@
 #include "unity.h"
 #include <string.h>
 
+int putcharSpy(int c);
+
 // Dividing by these constants produces +/- infinity.
 // The rationale is given in UnityAssertFloatIsInf's body.
 #ifndef UNITY_EXCLUDE_FLOAT


### PR DESCRIPTION
Fixes #182 

The declaration of the extern UNITY_OUTPUT_CHAR has been moved to unity.c