### PR TITLE
Add Unity Fixture to the travisCI build and restore header declaration of UNITY_OUTPUT_CHAR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - "2.0.0"
 script:
   - cd test && rake ci
+  - make -s
+  - cd ../extras/fixture/test && rake ci
+  - make -s default noStdLibMalloc

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ script:
   - cd test && rake ci
   - make -s
   - cd ../extras/fixture/test && rake ci
-  - make -s default noStdLibMalloc
+  - make -s default noStdlibMalloc

--- a/src/unity.c
+++ b/src/unity.c
@@ -7,6 +7,9 @@
 #include "unity.h"
 #include <stddef.h>
 
+#ifdef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
+int UNITY_OUTPUT_CHAR(int); //If omitted from header, declare it here so it's ready for use
+#endif
 #define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
 #define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
 /// return prematurely if we are already in failure or ignore state

--- a/src/unity.c
+++ b/src/unity.c
@@ -7,11 +7,6 @@
 #include "unity.h"
 #include <stddef.h>
 
-#ifndef UNITY_OUTPUT_CHAR_USE_PUTC
-//If defined as something else, make sure we declare it here so it's ready for use
-extern int UNITY_OUTPUT_CHAR(int);
-#endif
-
 #define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
 #define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
 /// return prematurely if we are already in failure or ignore state

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -291,12 +291,9 @@ typedef UNITY_DOUBLE_TYPE _UD;
 //Default to using putchar, which is defined in stdio.h
 #include <stdio.h>
 #define UNITY_OUTPUT_CHAR(a) putchar(a)
-// We need to flag the output char function uses putc in
-//  unity.c the extern function is not declared then.
-// Previously the extern was declared in this header but
-//  when redundant function declaration compiler flag is enabled
-//  it wont compile.
-#define UNITY_OUTPUT_CHAR_USE_PUTC
+#else
+//If defined as something else, make sure we declare it here so it's ready for use
+extern int UNITY_OUTPUT_CHAR(int);
 #endif
 
 #ifndef UNITY_PRINT_EOL

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -293,7 +293,9 @@ typedef UNITY_DOUBLE_TYPE _UD;
 #define UNITY_OUTPUT_CHAR(a) putchar(a)
 #else
 //If defined as something else, make sure we declare it here so it's ready for use
+  #ifndef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
 extern int UNITY_OUTPUT_CHAR(int);
+  #endif
 #endif
 
 #ifndef UNITY_PRINT_EOL

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -8,8 +8,6 @@
 #include "unity.h"
 #include <string.h>
 
-int putcharSpy(int c);
-
 // Dividing by these constants produces +/- infinity.
 // The rationale is given in UnityAssertFloatIsInf's body.
 #ifndef UNITY_EXCLUDE_FLOAT


### PR DESCRIPTION
* Prevent changes in core Unity from silently breaking Fixture
* Restore default behavior of outputting a declaration of `UNITY_OUTPUT_CHAR()` in the internal header.
* Adding an option to remove the declaration, as non-default behavior - use `UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION`

Note: The first commit (adding Fixture to travisCI) will fail the build, as the Fixture build is currently broken. The next push will fix this up.

Discussion:
The internals header was declaring UNITY_OUTPUT_CHAR if it was overridden by the user. This was changed in PR #183, where the goal was to remove warnings from `-Wredundant-decls` flag. This is a nice goal, but redundant declarations aren't that harmful. `gcc` will issue an error if declared prototypes don't match, so these redundant function prototypes are *necessarily* the same declaration.

When removing the declaration from the header we would force every file that uses the `UNITY_OUTPUT_CHAR()` function to include a preprocessor guarded section. There are many existing users of Unity, and I didn't feel it was worth it to force code changes from this.

Examples:
***old way***
> #include "myOutput.h"
> #define UNITY_OUTPUT_CHAR myOutput
> #include "unity.h" // <- issues redundant declaration with default behavior

***now*** - the above example works without a warning if `redundant-decls` is requested, but...
> #include "unity.h"
> UNITY_OUTPUT_CHAR('0'); // <- issues an implicit declaration warning, which is worse
// ***unless*** - the user adds this preprocessor guarded declaration above
> #ifndef UNITY_DECL_ISNT_NEEDED // macro has a different name but same meaning
> int UNITY_OUTPUT_CHAR(int);
> #endif

***after this PR*** - back to old default behavior, with added config option to make the first example OK
> #include "myOutput.h"
> #define UNITY_OUTPUT_CHAR myOutput
> #include "unity.h" // <- redundant declaration can be suppressed if required by your code standard

