### PR TITLE
Followup of PR #185 without breaking the UNITY_OUTPUT_CHAR behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rvm:
   - "2.0.0"
 script:
   - cd test && rake ci
+  - make -s
+  - cd ../extras/fixture/test && rake ci
+  - make -s default noStdlibMalloc

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -15,6 +15,8 @@ struct _UnityFixture UnityFixture;
 //Build with -D UNITY_OUTPUT_CHAR=outputChar and include <stdio.h>
 //int (*outputChar)(int) = putchar;
 
+extern int  UnityOutputCharSpy_OutputChar(int c);
+
 #if !defined(UNITY_WEAK_ATTRIBUTE) && !defined(UNITY_WEAK_PRAGMA)
 void setUp(void)    { /*does nothing*/ }
 void tearDown(void) { /*does nothing*/ }


### PR DESCRIPTION
Fixture building was broken due to PR #182 and was not catched by travis. Now this is added and the output spy is declared extern for now because I have no clue how this is organized. This is probably a much better fix for now compared to PR #185 