### PR TITLE
Add option to print FAILED instead of FAIL during the summary

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1323,6 +1323,9 @@ int UnityEnd(void)
     else
     {
         UnityPrintFail();
+#ifdef UNITY_DIFFERENTIATE_FINAL_FAIL
+        UNITY_OUTPUT_CHAR('E'); UNITY_OUTPUT_CHAR('D');
+#endif
     }
     UNITY_PRINT_EOL();
     UNITY_OUTPUT_COMPLETE();

--- a/src/unity.h
+++ b/src/unity.h
@@ -48,6 +48,7 @@ void tearDown(void);
 
 // Output
 //     - by default, Unity prints to standard out with putchar.  define UNITY_OUTPUT_CHAR(a) with a different function if desired
+//     - define UNITY_DIFFERENTIATE_FINAL_FAIL to print FAILED (vs. FAIL) at test end summary - for automated search for failure
 
 // Optimization
 //     - by default, line numbers are stored in unsigned shorts.  Define UNITY_LINE_TYPE with a different type if your files are huge


### PR DESCRIPTION
For easier automation and searching for a test suite failure
Off by default
Closes issue #106

Example after changing one test to fail:
> $ make -s
331 Tests 1 Failures 1 Ignored 
__FAIL__
File '../../src/unity.c'
Lines executed:92.27% of 621
../../src/unity.c:creating 'unity.c.gcov'
$ make -s DEBUG=-DUNITY_DIFFERENTIATE_FINAL_FAIL
331 Tests 1 Failures 1 Ignored 
__FAILED__
File '../../src/unity.c'
Lines executed:92.28% of 622
../../src/unity.c:creating 'unity.c.gcov'