### PR TITLE
100% code coverage for Unity project

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -491,6 +491,13 @@ void UnityAssertEqualNumber(const _U_SINT expected,
     }
 }
 
+#define UnityPrintPointlessAndBail()       \
+{                                          \
+    UnityTestResultsFailBegin(lineNumber); \
+    UnityPrint(UnityStrPointless);         \
+    UnityAddMsgIfSpecified(msg);           \
+    UNITY_FAIL_AND_BAIL; }
+
 //-----------------------------------------------
 void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                               UNITY_INTERNAL_PTR actual,
@@ -507,10 +514,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
 
     if (elements == 0)
     {
-        UnityTestResultsFailBegin(lineNumber);
-        UnityPrint(UnityStrPointless);
-        UnityAddMsgIfSpecified(msg);
-        UNITY_FAIL_AND_BAIL;
+        UnityPrintPointlessAndBail();
     }
 
     if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
@@ -625,10 +629,7 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const _UF* expected,
 
     if (elements == 0)
     {
-        UnityTestResultsFailBegin(lineNumber);
-        UnityPrint(UnityStrPointless);
-        UnityAddMsgIfSpecified(msg);
-        UNITY_FAIL_AND_BAIL;
+        UnityPrintPointlessAndBail();
     }
 
     if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
@@ -789,10 +790,7 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const _UD* expected,
 
     if (elements == 0)
     {
-        UnityTestResultsFailBegin(lineNumber);
-        UnityPrint(UnityStrPointless);
-        UnityAddMsgIfSpecified(msg);
-        UNITY_FAIL_AND_BAIL;
+        UnityPrintPointlessAndBail();
     }
 
     if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
@@ -1071,10 +1069,7 @@ void UnityAssertEqualStringArray( const char** expected,
     // if no elements, it's an error
     if (num_elements == 0)
     {
-        UnityTestResultsFailBegin(lineNumber);
-        UnityPrint(UnityStrPointless);
-        UnityAddMsgIfSpecified(msg);
-        UNITY_FAIL_AND_BAIL;
+        UnityPrintPointlessAndBail();
     }
 
     if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
@@ -1134,10 +1129,7 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
 
     if ((elements == 0) || (length == 0))
     {
-        UnityTestResultsFailBegin(lineNumber);
-        UnityPrint(UnityStrPointless);
-        UnityAddMsgIfSpecified(msg);
-        UNITY_FAIL_AND_BAIL;
+        UnityPrintPointlessAndBail();
     }
 
     if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)

--- a/src/unity.c
+++ b/src/unity.c
@@ -164,12 +164,9 @@ void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T s
 }
 
 //-----------------------------------------------
-/// basically do an itoa using as little ram as possible
 void UnityPrintNumber(const _U_SINT number_to_print)
 {
-    _U_UINT divisor = 1;
-    _U_UINT next_divisor;
-    _U_UINT number;
+    _U_UINT number = (_U_UINT)number_to_print;
 
     if (number_to_print < 0)
     {
@@ -177,29 +174,7 @@ void UnityPrintNumber(const _U_SINT number_to_print)
         UNITY_OUTPUT_CHAR('-');
         number = (_U_UINT)(-number_to_print);
     }
-    else
-    {
-        //Non-negative number
-        number = (_U_UINT)number_to_print;
-    }
-
-    // figure out initial divisor
-    while (number / divisor > 9)
-    {
-        next_divisor = divisor * 10;
-        if (next_divisor > divisor)
-            divisor = next_divisor;
-        else
-            break;
-    }
-
-    // now mod and print, then divide divisor
-    do
-    {
-        UNITY_OUTPUT_CHAR((char)('0' + (number / divisor % 10)));
-        divisor /= 10;
-    }
-    while (divisor > 0);
+    UnityPrintNumberUnsigned(number);
 }
 
 //-----------------------------------------------
@@ -207,16 +182,11 @@ void UnityPrintNumber(const _U_SINT number_to_print)
 void UnityPrintNumberUnsigned(const _U_UINT number)
 {
     _U_UINT divisor = 1;
-    _U_UINT next_divisor;
 
     // figure out initial divisor
     while (number / divisor > 9)
     {
-        next_divisor = divisor * 10;
-        if (next_divisor > divisor)
-            divisor = next_divisor;
-        else
-            break;
+        divisor *= 10;
     }
 
     // now mod and print, then divide divisor

--- a/src/unity.h
+++ b/src/unity.h
@@ -235,8 +235,8 @@ void tearDown(void);
 //Structs and Strings
 #define TEST_ASSERT_EQUAL_PTR_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, (message))
 #define TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_STRING((expected), (actual), __LINE__, (message))
-#define TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                 UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, (message))
-#define TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                     UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                       UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                           UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, (message))
 
 //Arrays
 #define TEST_ASSERT_EQUAL_INT_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_INT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,8 @@ endif
 #DEBUG = -O0 -g
 CFLAGS += -std=c99 -pedantic -Wall -Wextra -Werror -Wredundant-decls
 CFLAGS += $(DEBUG)
-DEFINES = -D UNITY_OUTPUT_CHAR=putcharSpy -D UNITY_INCLUDE_DOUBLE
+DEFINES =  -D UNITY_OUTPUT_CHAR=putcharSpy
+DEFINES += -D UNITY_SUPPORT_64 -D UNITY_INCLUDE_DOUBLE -D UNITY_NO_WEAK
 SRC = ../src/unity.c tests/testunity.c build/testunityRunner.c
 INC_DIR = -I ../src
 COV_FLAGS = -fprofile-arcs -ftest-coverage -I ../../src
@@ -24,8 +25,6 @@ coverage: $(BUILD_DIR)/testunityRunner.c
 	./$(TARGET) | grep Tests -A1
 	cd $(BUILD_DIR) && \
 	gcov unity.c | head -3
-
-uncovered:
 	grep '###' $(BUILD_DIR)/unity.c.gcov -C2 || true
 
 test: CFLAGS += -Wbad-function-cast -Wcast-qual -Wconversion -Wformat=2 -Wold-style-definition \

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -3722,6 +3722,8 @@ void testNotEqualDoubleArraysLengthZero(void)
 #endif
 }
 
+// ===================== THESE TEST WILL RUN IF YOUR CONFIG INCLUDES DETAIL SUPPORT ==================
+
 void testThatDetailsCanBeHandleOneDetail(void)
 {
 #ifdef UNITY_EXCLUDE_DETAILS
@@ -3731,6 +3733,19 @@ void testThatDetailsCanBeHandleOneDetail(void)
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_INT_MESSAGE(5, 6, "Should Fail And Say Detail1");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testThatDetailsCanHandleTestFail(void)
+{
+#ifdef UNITY_EXCLUDE_DETAILS
+    TEST_IGNORE();
+#else
+    UNITY_SET_DETAILS("Detail1","Detail2");
+
+    EXPECT_ABORT_BEGIN
+    TEST_FAIL_MESSAGE("Should Fail And Say Detail1 and Detail2");
     VERIFY_FAILS_END
 #endif
 }

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1545,6 +1545,7 @@ void testEqualIntArrays(void)
     TEST_ASSERT_EQUAL_INT_ARRAY(p0, p1, 4);
     TEST_ASSERT_EQUAL_INT_ARRAY(p0, p2, 3);
     TEST_ASSERT_EQUAL_INT_ARRAY(p0, p3, 1);
+    TEST_ASSERT_EQUAL_INT_ARRAY(NULL, NULL, 1);
 }
 
 void testNotEqualIntArraysNullExpected(void)
@@ -3032,6 +3033,7 @@ void testEqualFloatArrays(void)
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 4);
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p2, 3);
     TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p3, 1);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(NULL, NULL, 1);
 #endif
 }
 
@@ -3562,6 +3564,7 @@ void testEqualDoubleArrays(void)
     TEST_ASSERT_EQUAL_DOUBLE_ARRAY(p0, p1, 4);
     TEST_ASSERT_EQUAL_DOUBLE_ARRAY(p0, p2, 3);
     TEST_ASSERT_EQUAL_DOUBLE_ARRAY(p0, p3, 1);
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY(NULL, NULL, 1);
 #endif
 }
 

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1370,7 +1370,7 @@ void testNotEqualString4(void)
 void testNotEqualStringLen4(void)
 {
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_STRING_LEN("bar\r", "bar\n", 4);
+    TEST_ASSERT_EQUAL_STRING_LEN("\r\x16", "bar\n", 4);
     VERIFY_FAILS_END
 }
 
@@ -2258,6 +2258,19 @@ int putcharSpy(int c)
         c = putchar(c);
 #endif
     return c;
+}
+
+void testFailureCountIncrementsAndIsReturnedAtEnd(void)
+{
+    Unity.CurrentTestFailed = 1;
+    startPutcharSpy(); // Suppress output
+    UnityConcludeTest();
+    TEST_ASSERT_EQUAL(1, Unity.TestFailures);
+
+    int failures = UnityEnd();
+    Unity.TestFailures--;
+    endPutcharSpy();
+    TEST_ASSERT_EQUAL(1, failures);
 }
 
 #define TEST_ASSERT_EQUAL_PRINT_NUMBERS(expected, actual) {             \

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1476,6 +1476,16 @@ void testEqualStringArrayIfBothNulls(void)
     TEST_ASSERT_EQUAL_STRING_ARRAY(expStrings, testStrings, 4);
 }
 
+void testNotEqualStringArrayLengthZero(void)
+{
+    const char *testStrings[] = {NULL};
+    const char **expStrings = NULL;
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING_ARRAY(expStrings, testStrings, 0);
+    VERIFY_FAILS_END
+}
+
 void testEqualMemory(void)
 {
     const char *testString = "whatever";
@@ -1513,6 +1523,13 @@ void testNotEqualMemory4(void)
 {
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_MEMORY("fool", NULL, 4);
+    VERIFY_FAILS_END
+}
+
+void testNotEqualMemoryLengthZero(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_MEMORY(NULL, NULL, 0);
     VERIFY_FAILS_END
 }
 

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1580,6 +1580,16 @@ void testNotEqualIntArrays3(void)
     VERIFY_FAILS_END
 }
 
+void testNotEqualIntArraysLengthZero(void)
+{
+    _UU32 p0[1] = {1};
+    _UU32 p1[1] = {1};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_INT_ARRAY(p0, p1, 0);
+    VERIFY_FAILS_END
+}
+
 void testEqualPtrArrays(void)
 {
     char A = 1;
@@ -3148,6 +3158,20 @@ void testNotEqualFloatArraysInf(void)
 #endif
 }
 
+void testNotEqualFloatArraysLengthZero(void)
+{
+#ifdef UNITY_EXCLUDE_FLOAT
+    TEST_IGNORE();
+#else
+    float p0[1] = {0.0f};
+    float p1[1] = {0.0f};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(p0, p1, 0);
+    VERIFY_FAILS_END
+#endif
+}
+
 // ===================== THESE TEST WILL RUN IF YOUR CONFIG INCLUDES DOUBLE SUPPORT ==================
 
 void testDoublesWithinDelta(void)
@@ -3660,6 +3684,20 @@ void testNotEqualDoubleArraysInf(void)
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_DOUBLE_ARRAY(p0, p1, 4);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testNotEqualDoubleArraysLengthZero(void)
+{
+#ifdef UNITY_EXCLUDE_DOUBLE
+    TEST_IGNORE();
+#else
+    double p0[1] = {0.0};
+    double p1[1] = {0.0};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_DOUBLE_ARRAY(p0, p1, 0);
     VERIFY_FAILS_END
 #endif
 }

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1390,10 +1390,24 @@ void testNotEqualString_ExpectedStringIsNull(void)
     VERIFY_FAILS_END
 }
 
+void testNotEqualStringLen_ExpectedStringIsNull(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING_LEN(NULL, "bar", 1);
+    VERIFY_FAILS_END
+}
+
 void testNotEqualString_ActualStringIsNull(void)
 {
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_STRING("foo", NULL);
+    VERIFY_FAILS_END
+}
+
+void testNotEqualStringLen_ActualStringIsNull(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING_LEN("foo", NULL, 1);
     VERIFY_FAILS_END
 }
 


### PR DESCRIPTION
This series of commits is mostly in service of getting code coverage for Unity. The new tests specifically cover lines that were untested before. Refactoring code simplifies things a little bit.

* Add test for failure count and UnityEnd return value
* Test number arrays comparison, with length equal to 0
* Remove weak linked setup/teardown from coverage build, unreachable & empty, no need to cover
* Simplify printing StrPointless into a single macro, remove repeated code
* Refactor UnityPrintNumber(), remove unreachable code. Remove what looks like an overflow check. The variable `divisor` cannot overflow.



