### PR TITLE
Update unity_fixture_Test.c

### DIFF
--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -527,7 +527,7 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     TEST_ASSERT_NULL(out_of_mem);
     TEST_ASSERT_NOT_EQUAL(n2, n1);
     free(n2);
-    free(n1);
+    // free(n1);
     free(m);
 #endif
 }


### PR DESCRIPTION
On line 530 deallocating a deallocated pointer: n1 is an error.

Found by https://github.com/danmar/cppcheck