### PR TITLE
Update unity_fixture_Test.c

### DIFF
--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -524,7 +524,11 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     void* out_of_mem = realloc(n1, UNITY_INTERNAL_HEAP_SIZE_BYTES/2 + 1);
     void* n2 = malloc(10);
     TEST_ASSERT_NOT_NULL(m);
-    TEST_ASSERT_NULL(out_of_mem);
+    if (out_of_mem == NULL)
+    {
+        free(n1);
+        TEST_ASSERT_NULL(out_of_mem);
+    }
     TEST_ASSERT_NOT_EQUAL(n2, n1);
     free(n2);
     free(m);

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -527,7 +527,6 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     TEST_ASSERT_NULL(out_of_mem);
     TEST_ASSERT_NOT_EQUAL(n2, n1);
     free(n2);
-    free(n1);
     free(m);
 #endif
 }


### PR DESCRIPTION
[[../Unity-master/extras/fixture/test/unity_fixture_Test.c:530](https://github.com/ThrowTheSwitch/Unity/blob/master/extras/fixture/test/unity_fixture_Test.c#L530)]: (error) Deallocating a deallocated pointer: n1

**[This answer](http://stackoverflow.com/a/16676964) from [Daniel Fischer](http://stackoverflow.com/users/1011995/daniel-fischer) was helpful in fixing the error because if realloc returns a pointer to a different location, the old location is freed.**

Found by https://github.com/bryongloden/cppcheck