### PR TITLE
Cleanup fixture memory testing

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -207,9 +207,6 @@ void* unity_malloc(size_t size)
     mem = (char*)&(guard[1]);
     memcpy(&mem[size], end, sizeof(end));
 
-#ifndef UNITY_FIXTURE_MALLOC_OVERRIDES_H_
-    free(guard);
-#endif
     return (void*)mem;
 }
 

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -479,6 +479,10 @@ TEST(LeakDetection, PointerSettingMax)
 //------------------------------------------------------------
 
 TEST_GROUP(InternalMalloc);
+#define TEST_ASSERT_MEMORY_ALL_FREE_LIFO_ORDER(first_mem_ptr, ptr) \
+    ptr = malloc(10); free(ptr);                                   \
+    TEST_ASSERT_EQUAL_PTR_MESSAGE(first_mem_ptr, ptr, "Memory was stranded, free in LIFO order");
+
 
 TEST_SETUP(InternalMalloc) { }
 TEST_TEAR_DOWN(InternalMalloc) { }
@@ -491,6 +495,7 @@ TEST(InternalMalloc, MallocPastBufferFails)
     free(m);
     TEST_ASSERT_NOT_NULL(m);
     TEST_ASSERT_NULL(n);
+    TEST_ASSERT_MEMORY_ALL_FREE_LIFO_ORDER(m, n);
 #endif
 }
 
@@ -502,6 +507,7 @@ TEST(InternalMalloc, CallocPastBufferFails)
     free(m);
     TEST_ASSERT_NOT_NULL(m);
     TEST_ASSERT_NULL(n);
+    TEST_ASSERT_MEMORY_ALL_FREE_LIFO_ORDER(m, n);
 #endif
 }
 
@@ -513,6 +519,7 @@ TEST(InternalMalloc, MallocThenReallocGrowsMemoryInPlace)
     free(n);
     TEST_ASSERT_NOT_NULL(m);
     TEST_ASSERT_EQUAL(m, n);
+    TEST_ASSERT_MEMORY_ALL_FREE_LIFO_ORDER(m, n);
 #endif
 }
 
@@ -523,6 +530,7 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     void* n1 = malloc(10);
     void* out_of_mem = realloc(n1, UNITY_INTERNAL_HEAP_SIZE_BYTES/2 + 1);
     void* n2 = malloc(10);
+
     free(n2);
     if (out_of_mem == NULL) free(n1);
     free(m);
@@ -530,5 +538,6 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     TEST_ASSERT_NOT_NULL(m);       // Got a real memory location
     TEST_ASSERT_NULL(out_of_mem);  // The realloc should have failed
     TEST_ASSERT_NOT_EQUAL(n2, n1); // If n1 != n2 then realloc did not free n1
+    TEST_ASSERT_MEMORY_ALL_FREE_LIFO_ORDER(m, n2);
 #endif
 }

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -523,14 +523,11 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     void* n1 = malloc(10);
     void* out_of_mem = realloc(n1, UNITY_INTERNAL_HEAP_SIZE_BYTES/2 + 1);
     void* n2 = malloc(10);
-    TEST_ASSERT_NOT_NULL(m);
-    if (out_of_mem == NULL)
-    {
-        free(n1);
-        TEST_ASSERT_NULL(out_of_mem);
-    }
-    TEST_ASSERT_NOT_EQUAL(n2, n1);
     free(n2);
+    if (out_of_mem == NULL) free(n1);
     free(m);
+    TEST_ASSERT_NOT_NULL(m);
+    TEST_ASSERT_NULL(out_of_mem);
+    TEST_ASSERT_NOT_EQUAL(n2, n1);
 #endif
 }

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -488,9 +488,9 @@ TEST(InternalMalloc, MallocPastBufferFails)
 #ifdef UNITY_EXCLUDE_STDLIB_MALLOC
     void* m = malloc(UNITY_INTERNAL_HEAP_SIZE_BYTES/2 + 1);
     void* n = malloc(UNITY_INTERNAL_HEAP_SIZE_BYTES/2);
+    free(m);
     TEST_ASSERT_NOT_NULL(m);
     TEST_ASSERT_NULL(n);
-    free(m);
 #endif
 }
 
@@ -499,9 +499,9 @@ TEST(InternalMalloc, CallocPastBufferFails)
 #ifdef UNITY_EXCLUDE_STDLIB_MALLOC
     void* m = calloc(1, UNITY_INTERNAL_HEAP_SIZE_BYTES/2 + 1);
     void* n = calloc(1, UNITY_INTERNAL_HEAP_SIZE_BYTES/2);
+    free(m);
     TEST_ASSERT_NOT_NULL(m);
     TEST_ASSERT_NULL(n);
-    free(m);
 #endif
 }
 
@@ -510,9 +510,9 @@ TEST(InternalMalloc, MallocThenReallocGrowsMemoryInPlace)
 #ifdef UNITY_EXCLUDE_STDLIB_MALLOC
     void* m = malloc(UNITY_INTERNAL_HEAP_SIZE_BYTES/2 + 1);
     void* n = realloc(m, UNITY_INTERNAL_HEAP_SIZE_BYTES/2 + 9);
+    free(n);
     TEST_ASSERT_NOT_NULL(m);
     TEST_ASSERT_EQUAL(m, n);
-    free(n);
 #endif
 }
 
@@ -526,8 +526,9 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     free(n2);
     if (out_of_mem == NULL) free(n1);
     free(m);
-    TEST_ASSERT_NOT_NULL(m);
-    TEST_ASSERT_NULL(out_of_mem);
-    TEST_ASSERT_NOT_EQUAL(n2, n1);
+
+    TEST_ASSERT_NOT_NULL(m);       // Got a real memory location
+    TEST_ASSERT_NULL(out_of_mem);  // The realloc should have failed
+    TEST_ASSERT_NOT_EQUAL(n2, n1); // If n1 != n2 then realloc did not free n1
 #endif
 }


### PR DESCRIPTION
Reverts commit 783fcae, see comment in #205
Clean up fixture tests to be clearer, follows #206
Verify the tests for Internal Malloc implementation free all the heap in LIFO order

Before, freeing in order was not required just nice to have. For the fixture tests, let's stick to freeing all memory in the order specified by the implementation of `UNITY_EXCLUDE_STDLIB_MALLOC`.