### PR TITLE
Fixture C89 comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script:
   - make -s
   - cd ../extras/fixture/test && rake ci
   - make -s default noStdlibMalloc
+  - make -s C89

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #include <string.h>
 #include "unity_fixture.h"
@@ -11,9 +11,9 @@
 
 struct _UnityFixture UnityFixture;
 
-//If you decide to use the function pointer approach.
-//Build with -D UNITY_OUTPUT_CHAR=outputChar and include <stdio.h>
-//int (*outputChar)(int) = putchar;
+/* If you decide to use the function pointer approach.
+ * Build with -D UNITY_OUTPUT_CHAR=outputChar and include <stdio.h>
+ * int (*outputChar)(int) = putchar; */
 
 #if !defined(UNITY_WEAK_ATTRIBUTE) && !defined(UNITY_WEAK_PRAGMA)
 void setUp(void)    { /*does nothing*/ }
@@ -123,9 +123,8 @@ void UnityIgnoreTest(const char* printableName, const char* group, const char* n
 }
 
 
-//-------------------------------------------------
-//Malloc and free stuff
-//
+/*------------------------------------------------- */
+/* Malloc and free stuff */
 #define MALLOC_DONT_FAIL -1
 static int malloc_count;
 static int malloc_fail_countdown = MALLOC_DONT_FAIL;
@@ -150,8 +149,8 @@ void UnityMalloc_MakeMallocFailAfterCount(int countdown)
     malloc_fail_countdown = countdown;
 }
 
-// These definitions are always included from unity_fixture_malloc_overrides.h
-// We undef to use them or avoid conflict with <stdlib.h> per the C standard
+/* These definitions are always included from unity_fixture_malloc_overrides.h */
+/* We undef to use them or avoid conflict with <stdlib.h> per the C standard */
 #undef malloc
 #undef free
 #undef calloc
@@ -282,24 +281,24 @@ void* unity_realloc(void* oldMem, size_t size)
 
     if (guard->size >= size) return oldMem;
 
-#ifdef UNITY_EXCLUDE_STDLIB_MALLOC // Optimization if memory is expandable
+#ifdef UNITY_EXCLUDE_STDLIB_MALLOC /* Optimization if memory is expandable */
     if (oldMem == unity_heap + heap_index - guard->size - sizeof(end) &&
         heap_index + size - guard->size <= UNITY_INTERNAL_HEAP_SIZE_BYTES)
     {
-        release_memory(oldMem); // Not thread-safe, like unity_heap generally
-        return unity_malloc(size); // No memcpy since data is in place
+        release_memory(oldMem); /* Not thread-safe, like unity_heap generally */
+        return unity_malloc(size); /* No memcpy since data is in place */
     }
 #endif
     newMem = unity_malloc(size);
-    if (newMem == NULL) return NULL; // Do not release old memory
+    if (newMem == NULL) return NULL; /* Do not release old memory */
     memcpy(newMem, oldMem, guard->size);
     release_memory(oldMem);
     return newMem;
 }
 
 
-//--------------------------------------------------------
-//Automatic pointer restoration functions
+/*-------------------------------------------------------- */
+/*Automatic pointer restoration functions */
 struct PointerPair
 {
     void** pointer;
@@ -393,7 +392,7 @@ int UnityGetCommandLineOptions(int argc, const char* argv[])
                 }
             }
         } else {
-            // ignore unknown parameter
+            /* ignore unknown parameter */
             i++;
         }
     }
@@ -415,7 +414,7 @@ void UnityConcludeFixtureTest(void)
             UNITY_PRINT_EOL();
         }
     }
-    else // Unity.CurrentTestFailed
+    else /* Unity.CurrentTestFailed */
     {
         Unity.TestFailures++;
         UNITY_PRINT_EOL();

--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #ifndef UNITY_FIXTURE_H_
 #define UNITY_FIXTURE_H_
@@ -53,17 +53,17 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
     { void TEST_##group##_##name##_run(void);\
       TEST_##group##_##name##_run(); }
 
-//This goes at the bottom of each test file or in a separate c file
+/* This goes at the bottom of each test file or in a separate c file */
 #define TEST_GROUP_RUNNER(group)\
     void TEST_##group##_GROUP_RUNNER(void);\
     void TEST_##group##_GROUP_RUNNER(void)
 
-//Call this from main
+/* Call this from main */
 #define RUN_TEST_GROUP(group)\
     { void TEST_##group##_GROUP_RUNNER(void);\
       TEST_##group##_GROUP_RUNNER(); }
 
-//CppUTest Compatibility Macros
+/* CppUTest Compatibility Macros */
 #define UT_PTR_SET(ptr, newPointerValue)               UnityPointer_Set((void**)&(ptr), (void*)(newPointerValue), __LINE__)
 #define TEST_ASSERT_POINTERS_EQUAL(expected, actual)   TEST_ASSERT_EQUAL_PTR((expected), (actual))
 #define TEST_ASSERT_BYTES_EQUAL(expected, actual)      TEST_ASSERT_EQUAL_HEX8(0xff & (expected), 0xff & (actual))

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #ifndef UNITY_FIXTURE_INTERNALS_H_
 #define UNITY_FIXTURE_INTERNALS_H_

--- a/extras/fixture/src/unity_fixture_malloc_overrides.h
+++ b/extras/fixture/src/unity_fixture_malloc_overrides.h
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #ifndef UNITY_FIXTURE_MALLOC_OVERRIDES_H_
 #define UNITY_FIXTURE_MALLOC_OVERRIDES_H_
@@ -11,20 +11,20 @@
 #include <stddef.h>
 
 #ifdef UNITY_EXCLUDE_STDLIB_MALLOC
-// Define this macro to remove the use of stdlib.h, malloc, and free.
-// Many embedded systems do not have a heap or malloc/free by default.
-// This internal unity_malloc() provides allocated memory deterministically from
-// the end of an array only, unity_free() only releases from end-of-array,
-// blocks are not coalesced, and memory not freed in LIFO order is stranded.
+/* Define this macro to remove the use of stdlib.h, malloc, and free.
+ * Many embedded systems do not have a heap or malloc/free by default.
+ * This internal unity_malloc() provides allocated memory deterministically from
+ * the end of an array only, unity_free() only releases from end-of-array,
+ * blocks are not coalesced, and memory not freed in LIFO order is stranded. */
     #ifndef UNITY_INTERNAL_HEAP_SIZE_BYTES
     #define UNITY_INTERNAL_HEAP_SIZE_BYTES 256
     #endif
 #endif
 
-// These functions are used by the Unity Fixture to allocate and release memory
-// on the heap and can be overridden with platform-specific implementations.
-// For example, when using FreeRTOS UNITY_FIXTURE_MALLOC becomes pvPortMalloc()
-// and UNITY_FIXTURE_FREE becomes vPortFree().
+/* These functions are used by the Unity Fixture to allocate and release memory
+ * on the heap and can be overridden with platform-specific implementations.
+ * For example, when using FreeRTOS UNITY_FIXTURE_MALLOC becomes pvPortMalloc()
+ * and UNITY_FIXTURE_FREE becomes vPortFree(). */
 #if !defined(UNITY_FIXTURE_MALLOC) || !defined(UNITY_FIXTURE_FREE)
     #define UNITY_FIXTURE_MALLOC(size) malloc(size)
     #define UNITY_FIXTURE_FREE(ptr)    free(ptr)

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -38,10 +38,10 @@ noStdlibMalloc: $(BUILD_DIR)
 	@ echo "build with noStdlibMalloc"
 	./$(TARGET)
 
-clang89: ../build/
-	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m32 -std=c89 -Wno-comment
+C89: ../build/
+	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m32 -std=c89
 	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m32 \
-		-D UNITY_EXCLUDE_STDLIB_MALLOC -std=c89 -Wno-comment ; ./$(TARGET)
+		-D UNITY_EXCLUDE_STDLIB_MALLOC -std=c89 ; ./$(TARGET)
 
 clangEverything:
 	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -Weverything

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -38,10 +38,11 @@ noStdlibMalloc: $(BUILD_DIR)
 	@ echo "build with noStdlibMalloc"
 	./$(TARGET)
 
-C89: ../build/
-	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m32 -std=c89
-	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -m32 \
-		-D UNITY_EXCLUDE_STDLIB_MALLOC -std=c89 ; ./$(TARGET)
+C89: CFLAGS += -D UNITY_EXCLUDE_STDINT_H # C89 did not have type 'long long', <stdint.h>
+C89: $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -std=c89 && ./$(TARGET)
+	$(CC) $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -D UNITY_EXCLUDE_STDLIB_MALLOC -std=c89
+	./$(TARGET)
 
 clangEverything:
 	clang $(CFLAGS) $(DEFINES) $(SRC) $(INC_DIR) -o $(TARGET) -Weverything

--- a/extras/fixture/test/main/AllTests.c
+++ b/extras/fixture/test/main/AllTests.c
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #include "unity_fixture.h"
 

--- a/extras/fixture/test/template_fixture_tests.c
+++ b/extras/fixture/test/template_fixture_tests.c
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #include "unity_fixture.h"
 

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #include "unity_fixture.h"
 #include "unity_output_Spy.h"
@@ -79,7 +79,7 @@ TEST(UnityFixture, ReallocLargerNeeded)
     CHECK(m1);
     strcpy((char*)m1, "123456789");
     m2 = realloc(m1, 15);
-    // CHECK(m1 != m2); //Depends on implementation
+    /* CHECK(m1 != m2); //Depends on implementation */
     STRCMP_EQUAL("123456789", m2);
     free(m2);
 }
@@ -142,9 +142,9 @@ TEST(UnityFixture, ConcludeTestIncrementsFailCount)
     _U_UINT savedIgnores = Unity.TestIgnores;
     UnityOutputCharSpy_Enable(1);
     Unity.CurrentTestFailed = 1;
-    UnityConcludeFixtureTest(); // Resets TestFailed for this test to pass
+    UnityConcludeFixtureTest(); /* Resets TestFailed for this test to pass */
     Unity.CurrentTestIgnored = 1;
-    UnityConcludeFixtureTest(); // Resets TestIgnored
+    UnityConcludeFixtureTest(); /* Resets TestIgnored */
     UnityOutputCharSpy_Enable(0);
     TEST_ASSERT_EQUAL(savedFails + 1, Unity.TestFailures);
     TEST_ASSERT_EQUAL(savedIgnores + 1, Unity.TestIgnores);
@@ -152,7 +152,7 @@ TEST(UnityFixture, ConcludeTestIncrementsFailCount)
     Unity.TestIgnores = savedIgnores;
 }
 
-//------------------------------------------------------------
+/*------------------------------------------------------------ */
 
 TEST_GROUP(UnityCommandOptions);
 
@@ -312,7 +312,7 @@ IGNORE_TEST(UnityCommandOptions, TestShouldBeIgnored)
     TEST_FAIL_MESSAGE("This test should not run!");
 }
 
-//------------------------------------------------------------
+/*------------------------------------------------------------ */
 
 TEST_GROUP(LeakDetection);
 
@@ -342,7 +342,7 @@ TEST_TEAR_DOWN(LeakDetection)
     memcpy(Unity.AbortFrame, TestAbortFrame, sizeof(jmp_buf)); \
   }
 
-// This tricky set of defines lets us see if we are using the Spy, returns 1 if true
+/* This tricky set of defines lets us see if we are using the Spy, returns 1 if true */
 #ifdef __STDC_VERSION__
 
 #if __STDC_VERSION__ >= 199901L
@@ -352,17 +352,17 @@ TEST_TEAR_DOWN(LeakDetection)
 #define EXPAND_AND_USE_2ND(a, b)           SECOND_PARAM(a, b, throwaway)
 #define SECOND_PARAM(a, b, ...)            b
 #if USING_SPY_AS(UNITY_OUTPUT_CHAR)
-  #define USING_OUTPUT_SPY // UNITY_OUTPUT_CHAR = UnityOutputCharSpy_OutputChar
+  #define USING_OUTPUT_SPY /* UNITY_OUTPUT_CHAR = UnityOutputCharSpy_OutputChar */
 #endif
-#endif // >= 199901
+#endif /* >= 199901 */
 
-#else  // __STDC_VERSION__ else
+#else  /* __STDC_VERSION__ else */
 #define UnityOutputCharSpy_OutputChar 42
-#if UNITY_OUTPUT_CHAR == UnityOutputCharSpy_OutputChar // Works if no -Wundef -Werror
+#if UNITY_OUTPUT_CHAR == UnityOutputCharSpy_OutputChar /* Works if no -Wundef -Werror */
   #define USING_OUTPUT_SPY
 #endif
 #undef UnityOutputCharSpy_OutputChar
-#endif // __STDC_VERSION__
+#endif /* __STDC_VERSION__ */
 
 TEST(LeakDetection, DetectsLeak)
 {
@@ -428,7 +428,7 @@ TEST(LeakDetection, BufferGuardWriteFoundDuringFree)
     void* m = malloc(10);
     char* s = (char*)m;
     TEST_ASSERT_NOT_NULL(m);
-    s[-1] = (char)0x00; // Will not detect 0
+    s[-1] = (char)0x00; /* Will not detect 0 */
     s[-2] = (char)0x01;
     UnityOutputCharSpy_Enable(1);
     EXPECT_ABORT_BEGIN
@@ -476,7 +476,7 @@ TEST(LeakDetection, PointerSettingMax)
 #endif
 }
 
-//------------------------------------------------------------
+/*------------------------------------------------------------ */
 
 TEST_GROUP(InternalMalloc);
 #define TEST_ASSERT_MEMORY_ALL_FREE_LIFO_ORDER(first_mem_ptr, ptr) \
@@ -535,9 +535,9 @@ TEST(InternalMalloc, ReallocFailDoesNotFreeMem)
     if (out_of_mem == NULL) free(n1);
     free(m);
 
-    TEST_ASSERT_NOT_NULL(m);       // Got a real memory location
-    TEST_ASSERT_NULL(out_of_mem);  // The realloc should have failed
-    TEST_ASSERT_NOT_EQUAL(n2, n1); // If n1 != n2 then realloc did not free n1
+    TEST_ASSERT_NOT_NULL(m);       /* Got a real memory location */
+    TEST_ASSERT_NULL(out_of_mem);  /* The realloc should have failed */
+    TEST_ASSERT_NOT_EQUAL(n2, n1); /* If n1 != n2 then realloc did not free n1 */
     TEST_ASSERT_MEMORY_ALL_FREE_LIFO_ORDER(m, n2);
 #endif
 }

--- a/extras/fixture/test/unity_fixture_TestRunner.c
+++ b/extras/fixture/test/unity_fixture_TestRunner.c
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #include "unity_fixture.h"
 

--- a/extras/fixture/test/unity_output_Spy.c
+++ b/extras/fixture/test/unity_output_Spy.c
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 
 #include "unity_output_Spy.h"

--- a/extras/fixture/test/unity_output_Spy.h
+++ b/extras/fixture/test/unity_output_Spy.h
@@ -1,9 +1,9 @@
-//- Copyright (c) 2010 James Grenning and Contributed to Unity Project
-/* ==========================================
-    Unity Project - A Test Framework for C
-    Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
-    [Released under MIT License. Please refer to license.txt for details]
-========================================== */
+/* Copyright (c) 2010 James Grenning and Contributed to Unity Project
+ * ==========================================
+ *  Unity Project - A Test Framework for C
+ *  Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+ *  [Released under MIT License. Please refer to license.txt for details]
+ * ========================================== */
 
 #ifndef D_unity_output_Spy_H
 #define D_unity_output_Spy_H


### PR DESCRIPTION
Change all comments to `/* */` C89 style.
Add a build step to the TravisCI file to check for C89 compatibility.