### PR TITLE
Suppress output of FAIL messages that are expected during testing Unity itself

### DIFF
--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -19,11 +19,13 @@ static const _UD d_zero = 0.0;
 #endif
 
 #define EXPECT_ABORT_BEGIN \
+    startPutcharSpy();     \
     if (TEST_PROTECT())    \
     {
 
 #define VERIFY_FAILS_END                                                       \
     }                                                                          \
+    endPutcharSpy(); /* start/end Spy to suppress output of failure message */ \
     Unity.CurrentTestFailed = (Unity.CurrentTestFailed == 1) ? 0 : 1;          \
     if (Unity.CurrentTestFailed == 1) {                                        \
       SetToOneMeanWeAlreadyCheckedThisGuy = 1;                                 \
@@ -36,6 +38,7 @@ static const _UD d_zero = 0.0;
 
 #define VERIFY_IGNORES_END                                                     \
     }                                                                          \
+    endPutcharSpy(); /* start/end Spy to suppress output of ignore message */  \
     Unity.CurrentTestFailed = (Unity.CurrentTestIgnored == 1) ? 0 : 1;         \
     Unity.CurrentTestIgnored = 0;                                              \
     if (Unity.CurrentTestFailed == 1) {                                        \
@@ -46,6 +49,11 @@ static const _UD d_zero = 0.0;
       UnityPrint(":FAIL: [[[[ Test Should Have Ignored But Did Not ]]]]");     \
       UNITY_OUTPUT_CHAR('\n');                                                 \
     }
+
+void startPutcharSpy(void);
+void endPutcharSpy(void);
+char* getBufferPutcharSpy(void);
+void putcharSpy(int c);
 
 static int SetToOneToFailInTearDown;
 static int SetToOneMeanWeAlreadyCheckedThisGuy;


### PR DESCRIPTION
* Works when using the putcharSpy, transparent without it

If a test includes a block like this:
```C
    EXPECT_ABORT_BEGIN
    TEST_ASSERT_TRUE(0);
    VERIFY_FAILS_END
```

The output was:
`testunity.c:3749:testNotEqualDoubleArraysLengthZero:FAIL: You Asked Me To Compare Nothing, Which Was Pointless.testunity.c:3740:testNotEqualDoubleArraysLengthZero:PASS`

_**NEW output would be:**_
`testunity.c:3740:testNotEqualDoubleArraysLengthZero:PASS`

This eliminates the FAIL message and makes it easier to read the output.


