### PR TITLE
Print escapes for C strings

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -106,6 +106,7 @@ void UnityPrint(const char* string)
             else
             {
                 UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('x');
                 UnityPrintNumberHex((_U_UINT)*pch, 2);
             }
             pch++;
@@ -143,6 +144,7 @@ void UnityPrintLen(const char* string, const _UU32 length)
             else
             {
                 UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('x');
                 UnityPrintNumberHex((_U_UINT)*pch, 2);
             }
             pch++;
@@ -163,6 +165,8 @@ void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T s
     }
     else
     {
+        UNITY_OUTPUT_CHAR('0');
+        UNITY_OUTPUT_CHAR('x');
         UnityPrintNumberHex((_U_UINT)number, (char)((style & 0x000F) << 1));
     }
 }
@@ -207,8 +211,6 @@ void UnityPrintNumberHex(const _U_UINT number, const char nibbles_to_print)
 {
     _U_UINT nibble;
     char nibbles = nibbles_to_print;
-    UNITY_OUTPUT_CHAR('0');
-    UNITY_OUTPUT_CHAR('x');
 
     while (nibbles > 0)
     {

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -2275,6 +2275,14 @@ void testFailureCountIncrementsAndIsReturnedAtEnd(void)
     TEST_ASSERT_EQUAL(1, failures);
 }
 
+void testCstringsEscapeSequence(void)
+{
+    startPutcharSpy();
+    UnityPrint("\x16\x10");
+    endPutcharSpy();
+    TEST_ASSERT_EQUAL_STRING("\\x16\\x10", getBufferPutcharSpy());
+}
+
 #define TEST_ASSERT_EQUAL_PRINT_NUMBERS(expected, actual) {             \
         startPutcharSpy(); UnityPrintNumber((actual)); endPutcharSpy(); \
         TEST_ASSERT_EQUAL_STRING((expected), getBufferPutcharSpy());    \

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1373,7 +1373,7 @@ void testNotEqualString4(void)
 void testNotEqualStringLen4(void)
 {
     EXPECT_ABORT_BEGIN
-    TEST_ASSERT_EQUAL_STRING_LEN("\r\x16", "bar\n", 4);
+    TEST_ASSERT_EQUAL_STRING_LEN("ba\r\x16", "ba\r\n", 4);
     VERIFY_FAILS_END
 }
 


### PR DESCRIPTION
* Unity to print C-style escaped strings as "\x16", changes from "\0x16" before, makes it easier to copy strings from output
* Add test for C string escape sequences