### PR TITLE
Use UNITY_FLOAT_INVALID_TRAIT instead of default.

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -750,7 +750,7 @@ void UnityAssertFloatSpecial(const _UF actual,
                 is_trait = 1;
             break;
 
-        default:
+        case UNITY_FLOAT_INVALID_TRAIT:
             trait_index = 0;
             trait_names[0] = UnityStrInvalidFloatTrait;
             break;

--- a/src/unity.c
+++ b/src/unity.c
@@ -754,6 +754,12 @@ void UnityAssertFloatSpecial(const _UF actual,
             trait_index = 0;
             trait_names[0] = UnityStrInvalidFloatTrait;
             break;
+
+        default:
+           /* A value outside the enum was used for style so
+             just fail because something has gone wrong. */
+            UNITY_FAIL_AND_BAIL;
+
     }
 
     if (is_trait != should_be_trait)
@@ -884,7 +890,7 @@ void UnityAssertDoubleSpecial(const _UD actual,
 
     UNITY_SKIP_EXECUTION;
 
-     switch(style)
+    switch(style)
     {
         /* To determine Inf / Neg Inf, we compare to an Inf / Neg Inf value we create on the fly
          * We are using a variable to hold the zero value because some compilers complain about dividing by zero otherwise */


### PR DESCRIPTION
Using default throws a warning when using `-Wall -Weverything` on clang. `UNITY_FLOAT_INVALID_TRAIT` was also the only enum value not explicitly handled in the switch statement, so handle it explicitly.

I noticed that the first commit failed on gcc because the switch does not have a `default:` case. So I added a `default:` and have it  `UNITY_FAIL_AND_BAIL;` to handle error cases. Do you think this is necessary? I usually use `default:` to handle values not in the enum in my code. But these commits fixes a clang warning for me, `-Wswitch-enum`. However it introduces a covered switch warning on clang, so these two commits probably are not worth it. I'm going to see if both compilers can be satisfied warning wise.