### PR TITLE
Test generator: scrub strings after comments

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -95,9 +95,9 @@ class UnityTestRunnerGenerator
     tests_and_line_numbers = []
 
     source_scrubbed = source.clone
-    source_scrubbed = source_scrubbed.gsub(/"[^"]*"/, '')      # remove things in strings
     source_scrubbed = source_scrubbed.gsub(/\/\/.*$/, '')      # remove line comments
     source_scrubbed = source_scrubbed.gsub(/\/\*.*?\*\//m, '') # remove block comments
+    source_scrubbed = source_scrubbed.gsub(/"[^"]*"/, '')      # remove things in strings
     lines = source_scrubbed.split(/(^\s*\#.*$)                 # Treat preprocessor directives as a logical line
                               | (;|\{|\}) /x)                  # Match ;, {, and } as end of lines
 

--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -95,9 +95,9 @@ class UnityTestRunnerGenerator
     tests_and_line_numbers = []
 
     source_scrubbed = source.clone
+    source_scrubbed = source_scrubbed.gsub(/"[^"\n]*"/, '')      # remove things in strings
     source_scrubbed = source_scrubbed.gsub(/\/\/.*$/, '')      # remove line comments
     source_scrubbed = source_scrubbed.gsub(/\/\*.*?\*\//m, '') # remove block comments
-    source_scrubbed = source_scrubbed.gsub(/"[^"]*"/, '')      # remove things in strings
     lines = source_scrubbed.split(/(^\s*\#.*$)                 # Treat preprocessor directives as a logical line
                               | (;|\{|\}) /x)                  # Match ;, {, and } as end of lines
 


### PR DESCRIPTION
This fixes #220.

Removing strings from test files is still dangerous, but much
less likely to cause problems after this change to do the
removal after removing comments.

The bug could still manifest if a test file contains defines two
macros, one that contains a single quotation mark and then another
defined somewhere after it that contains a single quotation mark.
Everything in between the aforementioned quotation marks would
still be ignored after this commit, but that is an unlikely
scenario.