### PR TITLE
check 'i' limit before using it as an array index.

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1004,7 +1004,7 @@ void UnityAssertEqualStringLen(const char* expected,
     /* if both pointers not null compare the strings */
     if (expected && actual)
     {
-        for (i = 0; (expected[i] || actual[i]) && i < length; i++)
+        for (i = 0; (i < length) && (expected[i] || actual[i]); i++)
         {
             if (expected[i] != actual[i])
             {


### PR DESCRIPTION
fix cppcheck "Array index 'i' is used before limits check."