### PR TITLE
Add option to set NaN not equal NaN for floating point assertions

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -619,12 +619,17 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
 /* Wrap this define in a function with variable types as float or double */
 #define UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff)                       \
     if (isinf(expected) && isinf(actual) && (isneg(expected) == isneg(actual))) return 1; \
-    if (isnan(expected) && isnan(actual)) return 1;                                       \
+    if (UNITY_NAN_CHECK) return 1;                                                        \
     diff = actual - expected;                                                             \
     if (diff < 0.0f) diff = 0.0f - diff;                                                  \
     if (delta < 0.0f) delta = 0.0f - delta;                                               \
-    return !(isnan(diff) || isinf(diff) || (delta < diff));
+    return !(isnan(diff) || isinf(diff) || (diff > delta))
     /* This first part of this condition will catch any NaN or Infinite values */
+#ifndef UNITY_NAN_NOT_EQUAL_NAN
+  #define UNITY_NAN_CHECK isnan(expected) && isnan(actual)
+#else
+  #define UNITY_NAN_CHECK 0
+#endif
 
 #ifndef UNITY_EXCLUDE_FLOAT
 static int UnityFloatsWithin(_UF delta, _UF expected, _UF actual)

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -3713,7 +3713,7 @@ void testNotEqualDoubleArraysNegative3(void)
 #endif
 }
 
-void testNotEqualDoubleArraysNaN(void)
+void testEqualDoubleArraysNaN(void)
 {
 #ifdef UNITY_EXCLUDE_DOUBLE
     TEST_IGNORE();


### PR DESCRIPTION
This PR adds an option to change the default NaN comparison. NaN != NaN in C code (NaN is not equal to any value, not even itself). As such, one might want a failure during `TEST_ASSERT_EQUAL_FLOAT(NaN, NaN)`.
Compile with `UNITY_NAN_NOT_EQUAL_NAN` defined to enable this option.