### PR TITLE
removed duplicated declaration of putcharSpy

### DIFF
--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -53,7 +53,6 @@ static const _UD d_zero = 0.0;
 void startPutcharSpy(void);
 void endPutcharSpy(void);
 char* getBufferPutcharSpy(void);
-void putcharSpy(int c);
 
 static int SetToOneToFailInTearDown;
 static int SetToOneMeanWeAlreadyCheckedThisGuy;


### PR DESCRIPTION
The error I was getting: 

```
tests/testunity.c:56:6: error: redundant redeclaration of ‘putcharSpy’ [-Werror=redundant-decls]
 void putcharSpy(int c);
      ^~~~~~~~~~
<command-line>:0:19: note: previous declaration of ‘putcharSpy’ was here
../src/unity_internals.h:269:13: note: in expansion of macro ‘UNITY_OUTPUT_CHAR’
 extern void UNITY_OUTPUT_CHAR(int);
             ^~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:39: test] Error 1

```