### PR TITLE
Unity prints float (and double) by default

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -9,7 +9,7 @@
 #include "unity_fixture.h"
 #include "unity_internals.h"
 
-struct _UnityFixture UnityFixture;
+struct UNITY_FIXTURE_T UnityFixture;
 
 /* If you decide to use the function pointer approach.
  * Build with -D UNITY_OUTPUT_CHAR=outputChar and include <stdio.h>

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -13,14 +13,14 @@ extern "C"
 {
 #endif
 
-struct _UnityFixture
+struct UNITY_FIXTURE_T
 {
     int Verbose;
     unsigned int RepeatCount;
     const char* NameFilter;
     const char* GroupFilter;
 };
-extern struct _UnityFixture UnityFixture;
+extern struct UNITY_FIXTURE_T UnityFixture;
 
 typedef void unityfunction(void);
 void UnityTestRunner(unityfunction* setup,

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -138,8 +138,8 @@ TEST(UnityFixture, FreeNULLSafety)
 
 TEST(UnityFixture, ConcludeTestIncrementsFailCount)
 {
-    _U_UINT savedFails = Unity.TestFailures;
-    _U_UINT savedIgnores = Unity.TestIgnores;
+    UNITY_UINT savedFails = Unity.TestFailures;
+    UNITY_UINT savedIgnores = Unity.TestIgnores;
     UnityOutputCharSpy_Enable(1);
     Unity.CurrentTestFailed = 1;
     UnityConcludeFixtureTest(); /* Resets TestFailed for this test to pass */
@@ -301,7 +301,7 @@ TEST(UnityCommandOptions, GroupOrNameFilterWithoutStringFails)
 
 TEST(UnityCommandOptions, GroupFilterReallyFilters)
 {
-    _U_UINT saved = Unity.NumberOfTests;
+    UNITY_UINT saved = Unity.NumberOfTests;
     TEST_ASSERT_EQUAL(0, UnityGetCommandLineOptions(4, unknownCommand));
     UnityIgnoreTest(NULL, "non-matching", NULL);
     TEST_ASSERT_EQUAL(saved, Unity.NumberOfTests);

--- a/src/unity.c
+++ b/src/unity.c
@@ -19,7 +19,7 @@ void UNITY_OUTPUT_CHAR(int);
 /* return prematurely if we are already in failure or ignore state */
 #define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} }
 
-struct _Unity Unity;
+struct UNITY_STORAGE_T Unity;
 
 static const char UnityStrOk[]                     = "OK";
 static const char UnityStrPass[]                   = "PASS";
@@ -55,7 +55,7 @@ static const char UnityStrDetail1Name[]            = UNITY_DETAIL1_NAME " ";
 static const char UnityStrDetail2Name[]            = " " UNITY_DETAIL2_NAME " ";
 
 /* compiler-generic print formatting masks */
-static const _U_UINT UnitySizeMask[] =
+static const UNITY_UINT UnitySizeMask[] =
 {
     255u,         /* 0xFF */
     65535u,       /* 0xFFFF */
@@ -103,21 +103,21 @@ void UnityPrint(const char* string)
             {
                 UNITY_OUTPUT_CHAR('\\');
                 UNITY_OUTPUT_CHAR('x');
-                UnityPrintNumberHex((_U_UINT)*pch, 2);
+                UnityPrintNumberHex((UNITY_UINT)*pch, 2);
             }
             pch++;
         }
     }
 }
 
-void UnityPrintLen(const char* string, const _UU32 length);
-void UnityPrintLen(const char* string, const _UU32 length)
+void UnityPrintLen(const char* string, const UNITY_UINT32 length);
+void UnityPrintLen(const char* string, const UNITY_UINT32 length)
 {
     const char* pch = string;
 
     if (pch != NULL)
     {
-        while (*pch && (_UU32)(pch - string) < length)
+        while (*pch && (UNITY_UINT32)(pch - string) < length)
         {
             /* printable characters plus CR & LF are printed */
             if ((*pch <= 126) && (*pch >= 32))
@@ -141,7 +141,7 @@ void UnityPrintLen(const char* string, const _UU32 length)
             {
                 UNITY_OUTPUT_CHAR('\\');
                 UNITY_OUTPUT_CHAR('x');
-                UnityPrintNumberHex((_U_UINT)*pch, 2);
+                UnityPrintNumberHex((UNITY_UINT)*pch, 2);
             }
             pch++;
         }
@@ -149,7 +149,7 @@ void UnityPrintLen(const char* string, const _UU32 length)
 }
 
 /*-----------------------------------------------*/
-void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T style)
+void UnityPrintNumberByStyle(const UNITY_INT number, const UNITY_DISPLAY_STYLE_T style)
 {
     if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
     {
@@ -157,35 +157,35 @@ void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T s
     }
     else if ((style & UNITY_DISPLAY_RANGE_UINT) == UNITY_DISPLAY_RANGE_UINT)
     {
-        UnityPrintNumberUnsigned(  (_U_UINT)number  &  UnitySizeMask[((_U_UINT)style & (_U_UINT)0x0F) - 1]  );
+        UnityPrintNumberUnsigned(  (UNITY_UINT)number  &  UnitySizeMask[((UNITY_UINT)style & (UNITY_UINT)0x0F) - 1]  );
     }
     else
     {
         UNITY_OUTPUT_CHAR('0');
         UNITY_OUTPUT_CHAR('x');
-        UnityPrintNumberHex((_U_UINT)number, (char)((style & 0x000F) << 1));
+        UnityPrintNumberHex((UNITY_UINT)number, (char)((style & 0x000F) << 1));
     }
 }
 
 /*-----------------------------------------------*/
-void UnityPrintNumber(const _U_SINT number_to_print)
+void UnityPrintNumber(const UNITY_INT number_to_print)
 {
-    _U_UINT number = (_U_UINT)number_to_print;
+    UNITY_UINT number = (UNITY_UINT)number_to_print;
 
     if (number_to_print < 0)
     {
         /* A negative number, including MIN negative */
         UNITY_OUTPUT_CHAR('-');
-        number = (_U_UINT)(-number_to_print);
+        number = (UNITY_UINT)(-number_to_print);
     }
     UnityPrintNumberUnsigned(number);
 }
 
 /*-----------------------------------------------
  * basically do an itoa using as little ram as possible */
-void UnityPrintNumberUnsigned(const _U_UINT number)
+void UnityPrintNumberUnsigned(const UNITY_UINT number)
 {
-    _U_UINT divisor = 1;
+    UNITY_UINT divisor = 1;
 
     /* figure out initial divisor */
     while (number / divisor > 9)
@@ -203,9 +203,9 @@ void UnityPrintNumberUnsigned(const _U_UINT number)
 }
 
 /*-----------------------------------------------*/
-void UnityPrintNumberHex(const _U_UINT number, const char nibbles_to_print)
+void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print)
 {
-    _U_UINT nibble;
+    UNITY_UINT nibble;
     char nibbles = nibbles_to_print;
 
     while (nibbles > 0)
@@ -223,10 +223,10 @@ void UnityPrintNumberHex(const _U_UINT number, const char nibbles_to_print)
 }
 
 /*-----------------------------------------------*/
-void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
+void UnityPrintMask(const UNITY_UINT mask, const UNITY_UINT number)
 {
-    _U_UINT current_bit = (_U_UINT)1 << (UNITY_INT_WIDTH - 1);
-    _US32 i;
+    UNITY_UINT current_bit = (UNITY_UINT)1 << (UNITY_INT_WIDTH - 1);
+    UNITY_INT32 i;
 
     for (i = 0; i < UNITY_INT_WIDTH; i++)
     {
@@ -261,7 +261,7 @@ void UnityPrintMask(const _U_UINT mask, const _U_UINT number)
 # endif
 #endif
 
-void UnityPrintFloat(_UD number)
+void UnityPrintFloat(UNITY_DOUBLE number)
 {
     char TempBuffer[UNITY_VERBOSE_NUMBER_MAX_LENGTH + 1];
     snprintf(TempBuffer, sizeof(TempBuffer), "%.6f", number);
@@ -290,7 +290,7 @@ static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 #ifndef UNITY_FIXTURES
     UnityPrint(file);
     UNITY_OUTPUT_CHAR(':');
-    UnityPrintNumber((_U_SINT)line);
+    UnityPrintNumber((UNITY_INT)line);
     UNITY_OUTPUT_CHAR(':');
     UnityPrint(Unity.CurrentTestName);
     UNITY_OUTPUT_CHAR(':');
@@ -389,7 +389,7 @@ static void UnityPrintExpectedAndActualStrings(const char* expected, const char*
 }
 
 /*-----------------------------------------------*/
-static void UnityPrintExpectedAndActualStringsLen(const char* expected, const char* actual, const _UU32 length)
+static void UnityPrintExpectedAndActualStringsLen(const char* expected, const char* actual, const UNITY_UINT32 length)
 {
     UnityPrint(UnityStrExpected);
     if (expected != NULL)
@@ -453,9 +453,9 @@ static int UnityCheckArraysForNull(UNITY_INTERNAL_PTR expected, UNITY_INTERNAL_P
  * Assertion Functions
  *-----------------------------------------------*/
 
-void UnityAssertBits(const _U_SINT mask,
-                     const _U_SINT expected,
-                     const _U_SINT actual,
+void UnityAssertBits(const UNITY_INT mask,
+                     const UNITY_INT expected,
+                     const UNITY_INT actual,
                      const char* msg,
                      const UNITY_LINE_TYPE lineNumber)
 {
@@ -465,17 +465,17 @@ void UnityAssertBits(const _U_SINT mask,
     {
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrExpected);
-        UnityPrintMask((_U_UINT)mask, (_U_UINT)expected);
+        UnityPrintMask((UNITY_UINT)mask, (UNITY_UINT)expected);
         UnityPrint(UnityStrWas);
-        UnityPrintMask((_U_UINT)mask, (_U_UINT)actual);
+        UnityPrintMask((UNITY_UINT)mask, (UNITY_UINT)actual);
         UnityAddMsgIfSpecified(msg);
         UNITY_FAIL_AND_BAIL;
     }
 }
 
 /*-----------------------------------------------*/
-void UnityAssertEqualNumber(const _U_SINT expected,
-                            const _U_SINT actual,
+void UnityAssertEqualNumber(const UNITY_INT expected,
+                            const UNITY_INT actual,
                             const char* msg,
                             const UNITY_LINE_TYPE lineNumber,
                             const UNITY_DISPLAY_STYLE_T style)
@@ -504,12 +504,12 @@ void UnityAssertEqualNumber(const _U_SINT expected,
 /*-----------------------------------------------*/
 void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                               UNITY_INTERNAL_PTR actual,
-                              const _UU32 num_elements,
+                              const UNITY_UINT32 num_elements,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber,
                               const UNITY_DISPLAY_STYLE_T style)
 {
-    _UU32 elements = num_elements;
+    UNITY_UINT32 elements = num_elements;
     UNITY_INTERNAL_PTR ptr_exp = (UNITY_INTERNAL_PTR)expected;
     UNITY_INTERNAL_PTR ptr_act = (UNITY_INTERNAL_PTR)actual;
 
@@ -533,20 +533,20 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
         case UNITY_DISPLAY_STYLE_UINT8:
             while (elements--)
             {
-                if (*(UNITY_PTR_ATTRIBUTE const _US8*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const _US8*)ptr_act)
+                if (*(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)ptr_act)
                 {
                     UnityTestResultsFailBegin(lineNumber);
                     UnityPrint(UnityStrElement);
                     UnityPrintNumberUnsigned(num_elements - elements - 1);
                     UnityPrint(UnityStrExpected);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US8*)ptr_exp, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)ptr_exp, style);
                     UnityPrint(UnityStrWas);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US8*)ptr_act, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
                     UNITY_FAIL_AND_BAIL;
                 }
-                ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 1);
-                ptr_act = (UNITY_INTERNAL_PTR)((_UP)ptr_act + 1);
+                ptr_exp = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_exp + 1);
+                ptr_act = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_act + 1);
             }
             break;
         case UNITY_DISPLAY_STYLE_HEX16:
@@ -554,20 +554,20 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
         case UNITY_DISPLAY_STYLE_UINT16:
             while (elements--)
             {
-                if (*(UNITY_PTR_ATTRIBUTE const _US16*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const _US16*)ptr_act)
+                if (*(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)ptr_act)
                 {
                     UnityTestResultsFailBegin(lineNumber);
                     UnityPrint(UnityStrElement);
                     UnityPrintNumberUnsigned(num_elements - elements - 1);
                     UnityPrint(UnityStrExpected);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US16*)ptr_exp, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)ptr_exp, style);
                     UnityPrint(UnityStrWas);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US16*)ptr_act, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
                     UNITY_FAIL_AND_BAIL;
                 }
-                ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 2);
-                ptr_act = (UNITY_INTERNAL_PTR)((_UP)ptr_act + 2);
+                ptr_exp = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_exp + 2);
+                ptr_act = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_act + 2);
             }
             break;
 #ifdef UNITY_SUPPORT_64
@@ -576,40 +576,40 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
         case UNITY_DISPLAY_STYLE_UINT64:
             while (elements--)
             {
-                if (*(UNITY_PTR_ATTRIBUTE const _US64*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const _US64*)ptr_act)
+                if (*(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)ptr_act)
                 {
                     UnityTestResultsFailBegin(lineNumber);
                     UnityPrint(UnityStrElement);
                     UnityPrintNumberUnsigned(num_elements - elements - 1);
                     UnityPrint(UnityStrExpected);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US64*)ptr_exp, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)ptr_exp, style);
                     UnityPrint(UnityStrWas);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US64*)ptr_act, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
                     UNITY_FAIL_AND_BAIL;
                 }
-                ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 8);
-                ptr_act = (UNITY_INTERNAL_PTR)((_UP)ptr_act + 8);
+                ptr_exp = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_exp + 8);
+                ptr_act = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_act + 8);
             }
             break;
 #endif
         default:
             while (elements--)
             {
-                if (*(UNITY_PTR_ATTRIBUTE const _US32*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const _US32*)ptr_act)
+                if (*(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)ptr_exp != *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)ptr_act)
                 {
                     UnityTestResultsFailBegin(lineNumber);
                     UnityPrint(UnityStrElement);
                     UnityPrintNumberUnsigned(num_elements - elements - 1);
                     UnityPrint(UnityStrExpected);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US32*)ptr_exp, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)ptr_exp, style);
                     UnityPrint(UnityStrWas);
-                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const _US32*)ptr_act, style);
+                    UnityPrintNumberByStyle(*(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)ptr_act, style);
                     UnityAddMsgIfSpecified(msg);
                     UNITY_FAIL_AND_BAIL;
                 }
-                ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 4);
-                ptr_act = (UNITY_INTERNAL_PTR)((_UP)ptr_act + 4);
+                ptr_exp = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_exp + 4);
+                ptr_act = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_act + 4);
             }
             break;
     }
@@ -632,21 +632,21 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
 #endif
 
 #ifndef UNITY_EXCLUDE_FLOAT
-static int UnityFloatsWithin(_UF delta, _UF expected, _UF actual)
+static int UnityFloatsWithin(UNITY_FLOAT delta, UNITY_FLOAT expected, UNITY_FLOAT actual)
 {
-    _UF diff;
+    UNITY_FLOAT diff;
     UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff);
 }
 
-void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const _UF* expected,
-                                UNITY_PTR_ATTRIBUTE const _UF* actual,
-                                const _UU32 num_elements,
+void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
+                                UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* actual,
+                                const UNITY_UINT32 num_elements,
                                 const char* msg,
                                 const UNITY_LINE_TYPE lineNumber)
 {
-    _UU32 elements = num_elements;
-    UNITY_PTR_ATTRIBUTE const _UF* ptr_expected = expected;
-    UNITY_PTR_ATTRIBUTE const _UF* ptr_actual = actual;
+    UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_actual = actual;
 
     UNITY_SKIP_EXECUTION;
 
@@ -682,9 +682,9 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const _UF* expected,
 }
 
 /*-----------------------------------------------*/
-void UnityAssertFloatsWithin(const _UF delta,
-                             const _UF expected,
-                             const _UF actual,
+void UnityAssertFloatsWithin(const UNITY_FLOAT delta,
+                             const UNITY_FLOAT expected,
+                             const UNITY_FLOAT actual,
                              const char* msg,
                              const UNITY_LINE_TYPE lineNumber)
 {
@@ -708,15 +708,15 @@ void UnityAssertFloatsWithin(const _UF delta,
 }
 
 /*-----------------------------------------------*/
-void UnityAssertFloatSpecial(const _UF actual,
+void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
                              const char* msg,
                              const UNITY_LINE_TYPE lineNumber,
                              const UNITY_FLOAT_TRAIT_T style)
 {
     const char* trait_names[] = { UnityStrInf, UnityStrNegInf, UnityStrNaN, UnityStrDet };
-    _U_SINT should_be_trait   = ((_U_SINT)style & 1);
-    _U_SINT is_trait          = !should_be_trait;
-    _U_SINT trait_index       = (_U_SINT)(style >> 1);
+    UNITY_INT should_be_trait   = ((UNITY_INT)style & 1);
+    UNITY_INT is_trait          = !should_be_trait;
+    UNITY_INT trait_index       = (UNITY_INT)(style >> 1);
 
     UNITY_SKIP_EXECUTION;
 
@@ -775,21 +775,21 @@ void UnityAssertFloatSpecial(const _UF actual,
 
 /*-----------------------------------------------*/
 #ifndef UNITY_EXCLUDE_DOUBLE
-static int UnityDoublesWithin(_UD delta, _UD expected, _UD actual)
+static int UnityDoublesWithin(UNITY_DOUBLE delta, UNITY_DOUBLE expected, UNITY_DOUBLE actual)
 {
-    _UD diff;
+    UNITY_DOUBLE diff;
     UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff);
 }
 
-void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const _UD* expected,
-                                 UNITY_PTR_ATTRIBUTE const _UD* actual,
-                                 const _UU32 num_elements,
+void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expected,
+                                 UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* actual,
+                                 const UNITY_UINT32 num_elements,
                                  const char* msg,
                                  const UNITY_LINE_TYPE lineNumber)
 {
-    _UU32 elements = num_elements;
-    UNITY_PTR_ATTRIBUTE const _UD* ptr_expected = expected;
-    UNITY_PTR_ATTRIBUTE const _UD* ptr_actual = actual;
+    UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_actual = actual;
 
     UNITY_SKIP_EXECUTION;
 
@@ -825,9 +825,9 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const _UD* expected,
 }
 
 /*-----------------------------------------------*/
-void UnityAssertDoublesWithin(const _UD delta,
-                              const _UD expected,
-                              const _UD actual,
+void UnityAssertDoublesWithin(const UNITY_DOUBLE delta,
+                              const UNITY_DOUBLE expected,
+                              const UNITY_DOUBLE actual,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber)
 {
@@ -851,15 +851,15 @@ void UnityAssertDoublesWithin(const _UD delta,
 
 /*-----------------------------------------------*/
 
-void UnityAssertDoubleSpecial(const _UD actual,
+void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber,
                               const UNITY_FLOAT_TRAIT_T style)
 {
     const char* trait_names[] = { UnityStrInf, UnityStrNegInf, UnityStrNaN, UnityStrDet };
-    _U_SINT should_be_trait   = ((_U_SINT)style & 1);
-    _U_SINT is_trait          = !should_be_trait;
-    _U_SINT trait_index       = (_U_SINT)(style >> 1);
+    UNITY_INT should_be_trait   = ((UNITY_INT)style & 1);
+    UNITY_INT is_trait          = !should_be_trait;
+    UNITY_INT trait_index       = (UNITY_INT)(style >> 1);
 
     UNITY_SKIP_EXECUTION;
 
@@ -918,9 +918,9 @@ void UnityAssertDoubleSpecial(const _UD actual,
 #endif /* not UNITY_EXCLUDE_DOUBLE */
 
 /*-----------------------------------------------*/
-void UnityAssertNumbersWithin( const _U_UINT delta,
-                               const _U_SINT expected,
-                               const _U_SINT actual,
+void UnityAssertNumbersWithin( const UNITY_UINT delta,
+                               const UNITY_INT expected,
+                               const UNITY_INT actual,
                                const char* msg,
                                const UNITY_LINE_TYPE lineNumber,
                                const UNITY_DISPLAY_STYLE_T style)
@@ -930,23 +930,23 @@ void UnityAssertNumbersWithin( const _U_UINT delta,
     if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
     {
         if (actual > expected)
-            Unity.CurrentTestFailed = ((_U_UINT)(actual - expected) > delta);
+            Unity.CurrentTestFailed = ((UNITY_UINT)(actual - expected) > delta);
         else
-            Unity.CurrentTestFailed = ((_U_UINT)(expected - actual) > delta);
+            Unity.CurrentTestFailed = ((UNITY_UINT)(expected - actual) > delta);
     }
     else
     {
-        if ((_U_UINT)actual > (_U_UINT)expected)
-            Unity.CurrentTestFailed = ((_U_UINT)(actual - expected) > delta);
+        if ((UNITY_UINT)actual > (UNITY_UINT)expected)
+            Unity.CurrentTestFailed = ((UNITY_UINT)(actual - expected) > delta);
         else
-            Unity.CurrentTestFailed = ((_U_UINT)(expected - actual) > delta);
+            Unity.CurrentTestFailed = ((UNITY_UINT)(expected - actual) > delta);
     }
 
     if (Unity.CurrentTestFailed)
     {
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrDelta);
-        UnityPrintNumberByStyle((_U_SINT)delta, style);
+        UnityPrintNumberByStyle((UNITY_INT)delta, style);
         UnityPrint(UnityStrExpected);
         UnityPrintNumberByStyle(expected, style);
         UnityPrint(UnityStrWas);
@@ -962,7 +962,7 @@ void UnityAssertEqualString(const char* expected,
                             const char* msg,
                             const UNITY_LINE_TYPE lineNumber)
 {
-    _UU32 i;
+    UNITY_UINT32 i;
 
     UNITY_SKIP_EXECUTION;
 
@@ -998,11 +998,11 @@ void UnityAssertEqualString(const char* expected,
 /*-----------------------------------------------*/
 void UnityAssertEqualStringLen(const char* expected,
                             const char* actual,
-                            const _UU32 length,
+                            const UNITY_UINT32 length,
                             const char* msg,
                             const UNITY_LINE_TYPE lineNumber)
 {
-    _UU32 i;
+    UNITY_UINT32 i;
 
     UNITY_SKIP_EXECUTION;
 
@@ -1039,11 +1039,11 @@ void UnityAssertEqualStringLen(const char* expected,
 /*-----------------------------------------------*/
 void UnityAssertEqualStringArray( const char** expected,
                                   const char** actual,
-                                  const _UU32 num_elements,
+                                  const UNITY_UINT32 num_elements,
                                   const char* msg,
                                   const UNITY_LINE_TYPE lineNumber)
 {
-    _UU32 i, j = 0;
+    UNITY_UINT32 i, j = 0;
 
     UNITY_SKIP_EXECUTION;
 
@@ -1096,15 +1096,15 @@ void UnityAssertEqualStringArray( const char** expected,
 /*-----------------------------------------------*/
 void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
                              UNITY_INTERNAL_PTR actual,
-                             const _UU32 length,
-                             const _UU32 num_elements,
+                             const UNITY_UINT32 length,
+                             const UNITY_UINT32 num_elements,
                              const char* msg,
                              const UNITY_LINE_TYPE lineNumber)
 {
     UNITY_PTR_ATTRIBUTE const unsigned char* ptr_exp = (UNITY_PTR_ATTRIBUTE const unsigned char*)expected;
     UNITY_PTR_ATTRIBUTE const unsigned char* ptr_act = (UNITY_PTR_ATTRIBUTE const unsigned char*)actual;
-    _UU32 elements = num_elements;
-    _UU32 bytes;
+    UNITY_UINT32 elements = num_elements;
+    UNITY_UINT32 bytes;
 
     UNITY_SKIP_EXECUTION;
 
@@ -1139,8 +1139,8 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
                 UnityAddMsgIfSpecified(msg);
                 UNITY_FAIL_AND_BAIL;
             }
-            ptr_exp = (UNITY_INTERNAL_PTR)((_UP)ptr_exp + 1);
-            ptr_act = (UNITY_INTERNAL_PTR)((_UP)ptr_act + 1);
+            ptr_exp = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_exp + 1);
+            ptr_act = (UNITY_INTERNAL_PTR)((UNITY_PTR)ptr_act + 1);
         }
     }
 }
@@ -1249,11 +1249,11 @@ int UnityEnd(void)
     UNITY_PRINT_EOL();
     UnityPrint(UnityStrBreaker);
     UNITY_PRINT_EOL();
-    UnityPrintNumber((_U_SINT)(Unity.NumberOfTests));
+    UnityPrintNumber((UNITY_INT)(Unity.NumberOfTests));
     UnityPrint(UnityStrResultsTests);
-    UnityPrintNumber((_U_SINT)(Unity.TestFailures));
+    UnityPrintNumber((UNITY_INT)(Unity.TestFailures));
     UnityPrint(UnityStrResultsFailures);
-    UnityPrintNumber((_U_SINT)(Unity.TestIgnores));
+    UnityPrintNumber((UNITY_INT)(Unity.TestIgnores));
     UnityPrint(UnityStrResultsIgnored);
     UNITY_PRINT_EOL();
     if (Unity.TestFailures == 0U)

--- a/src/unity.h
+++ b/src/unity.h
@@ -107,10 +107,10 @@ void tearDown(void);
 #define TEST_ASSERT_EQUAL_HEX32(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_HEX64(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX64((expected), (actual), __LINE__, NULL)
 #define TEST_ASSERT_BITS(mask, expected, actual)                                                   UNITY_TEST_ASSERT_BITS((mask), (expected), (actual), __LINE__, NULL)
-#define TEST_ASSERT_BITS_HIGH(mask, actual)                                                        UNITY_TEST_ASSERT_BITS((mask), (_UU32)(-1), (actual), __LINE__, NULL)
-#define TEST_ASSERT_BITS_LOW(mask, actual)                                                         UNITY_TEST_ASSERT_BITS((mask), (_UU32)(0), (actual), __LINE__, NULL)
-#define TEST_ASSERT_BIT_HIGH(bit, actual)                                                          UNITY_TEST_ASSERT_BITS(((_UU32)1 << (bit)), (_UU32)(-1), (actual), __LINE__, NULL)
-#define TEST_ASSERT_BIT_LOW(bit, actual)                                                           UNITY_TEST_ASSERT_BITS(((_UU32)1 << (bit)), (_UU32)(0), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS_HIGH(mask, actual)                                                        UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(-1), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS_LOW(mask, actual)                                                         UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(0), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BIT_HIGH(bit, actual)                                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BIT_LOW(bit, actual)                                                           UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, NULL)
 
 /* Integer Ranges (of all sizes) */
 #define TEST_ASSERT_INT_WITHIN(delta, expected, actual)                                            UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
@@ -212,10 +212,10 @@ void tearDown(void);
 #define TEST_ASSERT_EQUAL_HEX32_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, (message))
 #define TEST_ASSERT_EQUAL_HEX64_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX64((expected), (actual), __LINE__, (message))
 #define TEST_ASSERT_BITS_MESSAGE(mask, expected, actual, message)                                  UNITY_TEST_ASSERT_BITS((mask), (expected), (actual), __LINE__, (message))
-#define TEST_ASSERT_BITS_HIGH_MESSAGE(mask, actual, message)                                       UNITY_TEST_ASSERT_BITS((mask), (_UU32)(-1), (actual), __LINE__, (message))
-#define TEST_ASSERT_BITS_LOW_MESSAGE(mask, actual, message)                                        UNITY_TEST_ASSERT_BITS((mask), (_UU32)(0), (actual), __LINE__, (message))
-#define TEST_ASSERT_BIT_HIGH_MESSAGE(bit, actual, message)                                         UNITY_TEST_ASSERT_BITS(((_UU32)1 << (bit)), (_UU32)(-1), (actual), __LINE__, (message))
-#define TEST_ASSERT_BIT_LOW_MESSAGE(bit, actual, message)                                          UNITY_TEST_ASSERT_BITS(((_UU32)1 << (bit)), (_UU32)(0), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_HIGH_MESSAGE(mask, actual, message)                                       UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(-1), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_LOW_MESSAGE(mask, actual, message)                                        UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(0), (actual), __LINE__, (message))
+#define TEST_ASSERT_BIT_HIGH_MESSAGE(bit, actual, message)                                         UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, (message))
+#define TEST_ASSERT_BIT_LOW_MESSAGE(bit, actual, message)                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, (message))
 
 /* Integer Ranges (of all sizes) */
 #define TEST_ASSERT_INT_WITHIN_MESSAGE(delta, expected, actual, message)                           UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, (message))

--- a/src/unity.h
+++ b/src/unity.h
@@ -37,13 +37,11 @@ void tearDown(void);
  *     - define UNITY_EXCLUDE_FLOAT to disallow floating point comparisons
  *     - define UNITY_FLOAT_PRECISION to specify the precision to use when doing TEST_ASSERT_EQUAL_FLOAT
  *     - define UNITY_FLOAT_TYPE to specify doubles instead of single precision floats
- *     - define UNITY_FLOAT_VERBOSE to print floating point values in errors (uses sprintf)
  *     - define UNITY_INCLUDE_DOUBLE to allow double floating point comparisons
  *     - define UNITY_EXCLUDE_DOUBLE to disallow double floating point comparisons (default)
  *     - define UNITY_DOUBLE_PRECISION to specify the precision to use when doing TEST_ASSERT_EQUAL_DOUBLE
  *     - define UNITY_DOUBLE_TYPE to specify something other than double
- *     - define UNITY_DOUBLE_VERBOSE to print floating point values in errors (uses sprintf)
- *     - define UNITY_VERBOSE_NUMBER_MAX_LENGTH to change maximum length of printed numbers (used by sprintf)
+ *     - define UNITY_EXCLUDE_FLOAT_PRINT to trim binary size, won't print floating point values in errors
 
  * Output
  *     - by default, Unity prints to standard out with putchar.  define UNITY_OUTPUT_CHAR(a) with a different function if desired

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -87,19 +87,19 @@
  *-------------------------------------------------------*/
 
 #if (UNITY_INT_WIDTH == 32)
-    typedef unsigned char   _UU8;
-    typedef unsigned short  _UU16;
-    typedef unsigned int    _UU32;
-    typedef signed char     _US8;
-    typedef signed short    _US16;
-    typedef signed int      _US32;
+    typedef unsigned char   UNITY_UINT8;
+    typedef unsigned short  UNITY_UINT16;
+    typedef unsigned int    UNITY_UINT32;
+    typedef signed char     UNITY_INT8;
+    typedef signed short    UNITY_INT16;
+    typedef signed int      UNITY_INT32;
 #elif (UNITY_INT_WIDTH == 16)
-    typedef unsigned char   _UU8;
-    typedef unsigned int    _UU16;
-    typedef unsigned long   _UU32;
-    typedef signed char     _US8;
-    typedef signed int      _US16;
-    typedef signed long     _US32;
+    typedef unsigned char   UNITY_UINT8;
+    typedef unsigned int    UNITY_UINT16;
+    typedef unsigned long   UNITY_UINT32;
+    typedef signed char     UNITY_INT8;
+    typedef signed int      UNITY_INT16;
+    typedef signed long     UNITY_INT32;
 #else
     #error Invalid UNITY_INT_WIDTH specified! (16 or 32 are supported)
 #endif
@@ -116,22 +116,22 @@
 
 #ifndef UNITY_SUPPORT_64
     /* No 64-bit Support */
-    typedef _UU32 _U_UINT;
-    typedef _US32 _U_SINT;
+    typedef UNITY_UINT32 UNITY_UINT;
+    typedef UNITY_INT32 UNITY_INT;
 #else
 
     /* 64-bit Support */
   #if (UNITY_LONG_WIDTH == 32)
-    typedef unsigned long long _UU64;
-    typedef signed long long   _US64;
+    typedef unsigned long long UNITY_UINT64;
+    typedef signed long long   UNITY_INT64;
   #elif (UNITY_LONG_WIDTH == 64)
-    typedef unsigned long      _UU64;
-    typedef signed long        _US64;
+    typedef unsigned long      UNITY_UINT64;
+    typedef signed long        UNITY_INT64;
   #else
     #error Invalid UNITY_LONG_WIDTH specified! (32 or 64 are supported)
   #endif
-    typedef _UU64 _U_UINT;
-    typedef _US64 _U_SINT;
+    typedef UNITY_UINT64 UNITY_UINT;
+    typedef UNITY_INT64 UNITY_INT;
 
 #endif
 
@@ -140,13 +140,13 @@
  *-------------------------------------------------------*/
 
 #if (UNITY_POINTER_WIDTH == 32)
-    typedef _UU32 _UP;
+    typedef UNITY_UINT32 UNITY_PTR;
 #define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX32
 #elif (UNITY_POINTER_WIDTH == 64)
-    typedef _UU64 _UP;
+    typedef UNITY_UINT64 UNITY_PTR;
 #define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX64
 #elif (UNITY_POINTER_WIDTH == 16)
-    typedef _UU16 _UP;
+    typedef UNITY_UINT16 UNITY_PTR;
 #define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX16
 #else
     #error Invalid UNITY_POINTER_WIDTH specified! (16, 32 or 64 are supported)
@@ -158,7 +158,7 @@
 
 #ifndef UNITY_INTERNAL_PTR
 #define UNITY_INTERNAL_PTR UNITY_PTR_ATTRIBUTE const void*
-/* #define UNITY_INTERNAL_PTR UNITY_PTR_ATTRIBUTE const _UU8* */
+/* #define UNITY_INTERNAL_PTR UNITY_PTR_ATTRIBUTE const UNITY_UINT8* */
 #endif
 
 /*-------------------------------------------------------
@@ -186,7 +186,7 @@
 #ifndef UNITY_FLOAT_TYPE
 #define UNITY_FLOAT_TYPE float
 #endif
-typedef UNITY_FLOAT_TYPE _UF;
+typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
 
 #ifndef isinf
 /* The value of Inf - Inf is NaN */
@@ -232,7 +232,7 @@ typedef UNITY_FLOAT_TYPE _UF;
   #endif
 
   #ifdef UNITY_FLOAT_VERBOSE
-    typedef _UF _UD;
+    typedef UNITY_FLOAT UNITY_DOUBLE;
     /* For parameter in UnityPrintFloat, double promotion required */
   #endif
 
@@ -246,7 +246,7 @@ typedef UNITY_FLOAT_TYPE _UF;
   #ifndef UNITY_DOUBLE_TYPE
   #define UNITY_DOUBLE_TYPE double
   #endif
-  typedef UNITY_DOUBLE_TYPE _UD;
+  typedef UNITY_DOUBLE_TYPE UNITY_DOUBLE;
 
 #endif
 
@@ -304,11 +304,11 @@ extern void UNITY_OUTPUT_FLUSH(void);
  *-------------------------------------------------------*/
 
 #ifndef UNITY_LINE_TYPE
-#define UNITY_LINE_TYPE _U_UINT
+#define UNITY_LINE_TYPE UNITY_UINT
 #endif
 
 #ifndef UNITY_COUNTER_TYPE
-#define UNITY_COUNTER_TYPE _U_UINT
+#define UNITY_COUNTER_TYPE UNITY_UINT
 #endif
 
 /*-------------------------------------------------------
@@ -368,7 +368,7 @@ UNITY_DISPLAY_STYLE_UINT = sizeof(unsigned) + UNITY_DISPLAY_RANGE_UINT + UNITY_D
 } UNITY_DISPLAY_STYLE_T;
 
 #ifndef UNITY_EXCLUDE_FLOAT
-typedef enum _UNITY_FLOAT_TRAIT_T
+typedef enum UNITY_FLOAT_TRAIT
 {
     UNITY_FLOAT_IS_NOT_INF       = 0,
     UNITY_FLOAT_IS_INF,
@@ -382,7 +382,7 @@ typedef enum _UNITY_FLOAT_TRAIT_T
 } UNITY_FLOAT_TRAIT_T;
 #endif
 
-struct _Unity
+struct UNITY_STORAGE_T
 {
     const char* TestFile;
     const char* CurrentTestName;
@@ -399,7 +399,7 @@ struct _Unity
     jmp_buf AbortFrame;
 };
 
-extern struct _Unity Unity;
+extern struct UNITY_STORAGE_T Unity;
 
 /*-------------------------------------------------------
  * Test Suite Management
@@ -437,14 +437,14 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
  *-------------------------------------------------------*/
 
 void UnityPrint(const char* string);
-void UnityPrintMask(const _U_UINT mask, const _U_UINT number);
-void UnityPrintNumberByStyle(const _U_SINT number, const UNITY_DISPLAY_STYLE_T style);
-void UnityPrintNumber(const _U_SINT number);
-void UnityPrintNumberUnsigned(const _U_UINT number);
-void UnityPrintNumberHex(const _U_UINT number, const char nibbles);
+void UnityPrintMask(const UNITY_UINT mask, const UNITY_UINT number);
+void UnityPrintNumberByStyle(const UNITY_INT number, const UNITY_DISPLAY_STYLE_T style);
+void UnityPrintNumber(const UNITY_INT number);
+void UnityPrintNumberUnsigned(const UNITY_UINT number);
+void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles);
 
 #ifdef UNITY_FLOAT_VERBOSE
-void UnityPrintFloat(const _UD number);
+void UnityPrintFloat(const UNITY_DOUBLE number);
 #endif
 
 /*-------------------------------------------------------
@@ -455,22 +455,22 @@ void UnityPrintFloat(const _UD number);
  *  convention and will pull in file and line information
  *  for you. */
 
-void UnityAssertEqualNumber(const _U_SINT expected,
-                            const _U_SINT actual,
+void UnityAssertEqualNumber(const UNITY_INT expected,
+                            const UNITY_INT actual,
                             const char* msg,
                             const UNITY_LINE_TYPE lineNumber,
                             const UNITY_DISPLAY_STYLE_T style);
 
 void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                               UNITY_INTERNAL_PTR actual,
-                              const _UU32 num_elements,
+                              const UNITY_UINT32 num_elements,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber,
                               const UNITY_DISPLAY_STYLE_T style);
 
-void UnityAssertBits(const _U_SINT mask,
-                     const _U_SINT expected,
-                     const _U_SINT actual,
+void UnityAssertBits(const UNITY_INT mask,
+                     const UNITY_INT expected,
+                     const UNITY_INT actual,
                      const char* msg,
                      const UNITY_LINE_TYPE lineNumber);
 
@@ -481,26 +481,26 @@ void UnityAssertEqualString(const char* expected,
 
 void UnityAssertEqualStringLen(const char* expected,
                             const char* actual,
-                            const _UU32 length,
+                            const UNITY_UINT32 length,
                             const char* msg,
                             const UNITY_LINE_TYPE lineNumber);
 
 void UnityAssertEqualStringArray( const char** expected,
                                   const char** actual,
-                                  const _UU32 num_elements,
+                                  const UNITY_UINT32 num_elements,
                                   const char* msg,
                                   const UNITY_LINE_TYPE lineNumber);
 
 void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
                              UNITY_INTERNAL_PTR actual,
-                             const _UU32 length,
-                             const _UU32 num_elements,
+                             const UNITY_UINT32 length,
+                             const UNITY_UINT32 num_elements,
                              const char* msg,
                              const UNITY_LINE_TYPE lineNumber);
 
-void UnityAssertNumbersWithin(const _U_UINT delta,
-                              const _U_SINT expected,
-                              const _U_SINT actual,
+void UnityAssertNumbersWithin(const UNITY_UINT delta,
+                              const UNITY_INT expected,
+                              const UNITY_INT actual,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber,
                               const UNITY_DISPLAY_STYLE_T style);
@@ -510,38 +510,38 @@ void UnityFail(const char* message, const UNITY_LINE_TYPE line);
 void UnityIgnore(const char* message, const UNITY_LINE_TYPE line);
 
 #ifndef UNITY_EXCLUDE_FLOAT
-void UnityAssertFloatsWithin(const _UF delta,
-                             const _UF expected,
-                             const _UF actual,
+void UnityAssertFloatsWithin(const UNITY_FLOAT delta,
+                             const UNITY_FLOAT expected,
+                             const UNITY_FLOAT actual,
                              const char* msg,
                              const UNITY_LINE_TYPE lineNumber);
 
-void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const _UF* expected,
-                                UNITY_PTR_ATTRIBUTE const _UF* actual,
-                                const _UU32 num_elements,
+void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
+                                UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* actual,
+                                const UNITY_UINT32 num_elements,
                                 const char* msg,
                                 const UNITY_LINE_TYPE lineNumber);
 
-void UnityAssertFloatSpecial(const _UF actual,
+void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
                              const char* msg,
                              const UNITY_LINE_TYPE lineNumber,
                              const UNITY_FLOAT_TRAIT_T style);
 #endif
 
 #ifndef UNITY_EXCLUDE_DOUBLE
-void UnityAssertDoublesWithin(const _UD delta,
-                              const _UD expected,
-                              const _UD actual,
+void UnityAssertDoublesWithin(const UNITY_DOUBLE delta,
+                              const UNITY_DOUBLE expected,
+                              const UNITY_DOUBLE actual,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber);
 
-void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const _UD* expected,
-                                 UNITY_PTR_ATTRIBUTE const _UD* actual,
-                                 const _UU32 num_elements,
+void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expected,
+                                 UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* actual,
+                                 const UNITY_UINT32 num_elements,
                                  const char* msg,
                                  const UNITY_LINE_TYPE lineNumber);
 
-void UnityAssertDoubleSpecial(const _UD actual,
+void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
                               const char* msg,
                               const UNITY_LINE_TYPE lineNumber,
                               const UNITY_FLOAT_TRAIT_T style);
@@ -626,61 +626,61 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_NULL(pointer, line, message)                                           UNITY_TEST_ASSERT(((pointer) == NULL),  (UNITY_LINE_TYPE)(line), (message))
 #define UNITY_TEST_ASSERT_NOT_NULL(pointer, line, message)                                       UNITY_TEST_ASSERT(((pointer) != NULL),  (UNITY_LINE_TYPE)(line), (message))
 
-#define UNITY_TEST_ASSERT_EQUAL_INT(expected, actual, line, message)                             UnityAssertEqualNumber((_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
-#define UNITY_TEST_ASSERT_EQUAL_INT8(expected, actual, line, message)                            UnityAssertEqualNumber((_U_SINT)(_US8 )(expected), (_U_SINT)(_US8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
-#define UNITY_TEST_ASSERT_EQUAL_INT16(expected, actual, line, message)                           UnityAssertEqualNumber((_U_SINT)(_US16)(expected), (_U_SINT)(_US16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
-#define UNITY_TEST_ASSERT_EQUAL_INT32(expected, actual, line, message)                           UnityAssertEqualNumber((_U_SINT)(_US32)(expected), (_U_SINT)(_US32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
-#define UNITY_TEST_ASSERT_EQUAL_UINT(expected, actual, line, message)                            UnityAssertEqualNumber((_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
-#define UNITY_TEST_ASSERT_EQUAL_UINT8(expected, actual, line, message)                           UnityAssertEqualNumber((_U_SINT)(_UU8 )(expected), (_U_SINT)(_UU8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
-#define UNITY_TEST_ASSERT_EQUAL_UINT16(expected, actual, line, message)                          UnityAssertEqualNumber((_U_SINT)(_UU16)(expected), (_U_SINT)(_UU16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
-#define UNITY_TEST_ASSERT_EQUAL_UINT32(expected, actual, line, message)                          UnityAssertEqualNumber((_U_SINT)(_UU32)(expected), (_U_SINT)(_UU32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
-#define UNITY_TEST_ASSERT_EQUAL_HEX8(expected, actual, line, message)                            UnityAssertEqualNumber((_U_SINT)(_US8 )(expected), (_U_SINT)(_US8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
-#define UNITY_TEST_ASSERT_EQUAL_HEX16(expected, actual, line, message)                           UnityAssertEqualNumber((_U_SINT)(_US16)(expected), (_U_SINT)(_US16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
-#define UNITY_TEST_ASSERT_EQUAL_HEX32(expected, actual, line, message)                           UnityAssertEqualNumber((_U_SINT)(_US32)(expected), (_U_SINT)(_US32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
-#define UNITY_TEST_ASSERT_BITS(mask, expected, actual, line, message)                            UnityAssertBits((_U_SINT)(mask), (_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_INT(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_EQUAL_INT8(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_EQUAL_INT16(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_EQUAL_INT32(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_EQUAL_UINT(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_EQUAL_UINT8(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_EQUAL_UINT16(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_EQUAL_UINT32(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_EQUAL_HEX8(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_EQUAL_HEX16(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_EQUAL_HEX32(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_BITS(mask, expected, actual, line, message)                            UnityAssertBits((UNITY_INT)(mask), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line))
 
-#define UNITY_TEST_ASSERT_INT_WITHIN(delta, expected, actual, line, message)                     UnityAssertNumbersWithin((delta), (_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
-#define UNITY_TEST_ASSERT_INT8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((_UU8 )(delta), (_U_SINT)(_US8 )(expected), (_U_SINT)(_US8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
-#define UNITY_TEST_ASSERT_INT16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((_UU16)(delta), (_U_SINT)(_US16)(expected), (_U_SINT)(_US16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
-#define UNITY_TEST_ASSERT_INT32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((_UU32)(delta), (_U_SINT)(_US32)(expected), (_U_SINT)(_US32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
-#define UNITY_TEST_ASSERT_UINT_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((delta), (_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
-#define UNITY_TEST_ASSERT_UINT8_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((_UU8 )(delta), (_U_SINT)(_U_UINT)(_UU8 )(expected), (_U_SINT)(_U_UINT)(_UU8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
-#define UNITY_TEST_ASSERT_UINT16_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((_UU16)(delta), (_U_SINT)(_U_UINT)(_UU16)(expected), (_U_SINT)(_U_UINT)(_UU16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
-#define UNITY_TEST_ASSERT_UINT32_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((_UU32)(delta), (_U_SINT)(_U_UINT)(_UU32)(expected), (_U_SINT)(_U_UINT)(_UU32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
-#define UNITY_TEST_ASSERT_HEX8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((_UU8 )(delta), (_U_SINT)(_U_UINT)(_UU8 )(expected), (_U_SINT)(_U_UINT)(_UU8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
-#define UNITY_TEST_ASSERT_HEX16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((_UU16)(delta), (_U_SINT)(_U_UINT)(_UU16)(expected), (_U_SINT)(_U_UINT)(_UU16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
-#define UNITY_TEST_ASSERT_HEX32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((_UU32)(delta), (_U_SINT)(_U_UINT)(_UU32)(expected), (_U_SINT)(_U_UINT)(_UU32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_INT_WITHIN(delta, expected, actual, line, message)                     UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_INT8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_INT16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_INT32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_UINT_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_UINT8_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_UINT16_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_UINT32_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_HEX8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_HEX16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_HEX32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
 
-#define UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, line, message)                             UnityAssertEqualNumber((_U_SINT)(_UP)(expected), (_U_SINT)(_UP)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
+#define UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_INT)(UNITY_PTR)(expected), (UNITY_INT)(UNITY_PTR)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
 #define UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, line, message)                          UnityAssertEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)(line))
-#define UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, line, message)                 UnityAssertEqualStringLen((const char*)(expected), (const char*)(actual), (_UU32)(len), (message), (UNITY_LINE_TYPE)(line))
-#define UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, line, message)                     UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(len), 1, (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, line, message)                 UnityAssertEqualStringLen((const char*)(expected), (const char*)(actual), (UNITY_UINT32)(len), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, line, message)                     UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), 1, (message), (UNITY_LINE_TYPE)(line))
 
-#define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
-#define UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
-#define UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
-#define UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
-#define UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
-#define UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
-#define UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
-#define UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
-#define UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
-#define UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
-#define UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
-#define UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(_UP*)(expected), (UNITY_INTERNAL_PTR)(_UP*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
-#define UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualStringArray((const char**)(expected), (const char**)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line))
-#define UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements, line, message) UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(len), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(UNITY_PTR*)(expected), (UNITY_INTERNAL_PTR)(UNITY_PTR*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
+#define UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualStringArray((const char**)(expected), (const char**)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements, line, message) UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line))
 
 #ifdef UNITY_SUPPORT_64
-#define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UnityAssertEqualNumber((_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
-#define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UnityAssertEqualNumber((_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
-#define UNITY_TEST_ASSERT_EQUAL_HEX64(expected, actual, line, message)                           UnityAssertEqualNumber((_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
-#define UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
-#define UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
-#define UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
-#define UNITY_TEST_ASSERT_INT64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
-#define UNITY_TEST_ASSERT_UINT64_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((delta), (_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
-#define UNITY_TEST_ASSERT_HEX64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (_U_SINT)(expected), (_U_SINT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_INT64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_UINT64_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_HEX64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
 #else
 #define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
 #define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
@@ -706,17 +706,17 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN(actual, line, message)                                UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
 #define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
 #else
-#define UNITY_TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual, line, message)                   UnityAssertFloatsWithin((_UF)(delta), (_UF)(expected), (_UF)(actual), (message), (UNITY_LINE_TYPE)(line))
-#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_ASSERT_FLOAT_WITHIN((_UF)(expected) * (_UF)UNITY_FLOAT_PRECISION, (_UF)(expected), (_UF)(actual), (UNITY_LINE_TYPE)(line), (message))
-#define UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualFloatArray((_UF*)(expected), (_UF*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)(line))
-#define UNITY_TEST_ASSERT_FLOAT_IS_INF(actual, line, message)                                    UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
-#define UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF(actual, line, message)                                UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
-#define UNITY_TEST_ASSERT_FLOAT_IS_NAN(actual, line, message)                                    UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
-#define UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE(actual, line, message)                            UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
-#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF(actual, line, message)                                UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
-#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual, line, message)                            UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
-#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN(actual, line, message)                                UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
-#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UnityAssertFloatSpecial((_UF)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
+#define UNITY_TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual, line, message)                   UnityAssertFloatsWithin((UNITY_FLOAT)(delta), (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_ASSERT_FLOAT_WITHIN((UNITY_FLOAT)(expected) * (UNITY_FLOAT)UNITY_FLOAT_PRECISION, (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualFloatArray((UNITY_FLOAT*)(expected), (UNITY_FLOAT*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_FLOAT_IS_INF(actual, line, message)                                    UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NAN(actual, line, message)                                    UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
+#define UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE(actual, line, message)                            UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual, line, message)                            UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
 #endif
 
 #ifdef UNITY_EXCLUDE_DOUBLE
@@ -732,17 +732,17 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, line, message)                               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
 #define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
 #else
-#define UNITY_TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual, line, message)                  UnityAssertDoublesWithin((_UD)(delta), (_UD)(expected), (_UD)(actual), (message), (UNITY_LINE_TYPE)line)
-#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_ASSERT_DOUBLE_WITHIN((_UD)(expected) * (_UD)UNITY_DOUBLE_PRECISION, (_UD)expected, (_UD)actual, (UNITY_LINE_TYPE)(line), message)
-#define UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualDoubleArray((_UD*)(expected), (_UD*)(actual), (_UU32)(num_elements), (message), (UNITY_LINE_TYPE)line)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_INF(actual, line, message)                                   UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF(actual, line, message)                               UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_NAN(actual, line, message)                                   UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual, line, message)                           UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF(actual, line, message)                               UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, line, message)                           UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, line, message)                               UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
-#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
+#define UNITY_TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual, line, message)                  UnityAssertDoublesWithin((UNITY_DOUBLE)(delta), (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)line)
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_ASSERT_DOUBLE_WITHIN((UNITY_DOUBLE)(expected) * (UNITY_DOUBLE)UNITY_DOUBLE_PRECISION, (UNITY_DOUBLE)expected, (UNITY_DOUBLE)actual, (UNITY_LINE_TYPE)(line), message)
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualDoubleArray((UNITY_DOUBLE*)(expected), (UNITY_DOUBLE*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)line)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_INF(actual, line, message)                                   UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NAN(actual, line, message)                                   UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual, line, message)                           UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, line, message)                           UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
 #endif
 
 /* End of UNITY_INTERNALS_H */

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -171,7 +171,6 @@
 #undef UNITY_INCLUDE_FLOAT
 #undef UNITY_FLOAT_PRECISION
 #undef UNITY_FLOAT_TYPE
-#undef UNITY_FLOAT_VERBOSE
 
 #else
 
@@ -225,15 +224,19 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
   /* No Floating Point Support */
   #undef UNITY_DOUBLE_PRECISION
   #undef UNITY_DOUBLE_TYPE
-  #undef UNITY_DOUBLE_VERBOSE
 
   #ifdef UNITY_INCLUDE_DOUBLE
     #undef UNITY_INCLUDE_DOUBLE
   #endif
 
-  #ifdef UNITY_FLOAT_VERBOSE
-    typedef UNITY_FLOAT UNITY_DOUBLE;
-    /* For parameter in UnityPrintFloat, double promotion required */
+  #ifdef UNITY_EXCLUDE_FLOAT
+  #define UNITY_EXCLUDE_FLOAT_PRINT
+  #else
+  #ifndef UNITY_DOUBLE_TYPE
+  #define UNITY_DOUBLE_TYPE double
+  #endif
+  typedef UNITY_FLOAT UNITY_DOUBLE;
+  /* For parameter in UnityPrintFloat(UNITY_DOUBLE), which aliases to double or float */
   #endif
 
 #else
@@ -248,12 +251,6 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
   #endif
   typedef UNITY_DOUBLE_TYPE UNITY_DOUBLE;
 
-#endif
-
-#ifdef UNITY_DOUBLE_VERBOSE
-#ifndef UNITY_FLOAT_VERBOSE
-#define UNITY_FLOAT_VERBOSE
-#endif
 #endif
 
 /*-------------------------------------------------------
@@ -443,7 +440,7 @@ void UnityPrintNumber(const UNITY_INT number);
 void UnityPrintNumberUnsigned(const UNITY_UINT number);
 void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles);
 
-#ifdef UNITY_FLOAT_VERBOSE
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
 void UnityPrintFloat(const UNITY_DOUBLE number);
 #endif
 

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -11,11 +11,11 @@
 // Dividing by these constants produces +/- infinity.
 // The rationale is given in UnityAssertFloatIsInf's body.
 #ifndef UNITY_EXCLUDE_FLOAT
-static const _UF f_zero = 0.0f;
+static const UNITY_FLOAT f_zero = 0.0f;
 #endif
 
 #ifndef UNITY_EXCLUDE_DOUBLE
-static const _UD d_zero = 0.0;
+static const UNITY_DOUBLE d_zero = 0.0;
 #endif
 
 #define EXPECT_ABORT_BEGIN \
@@ -76,14 +76,14 @@ void tearDown(void)
 
 void testUnitySizeInitializationReminder(void)
 {
-    /* This test ensures that sizeof(struct _Unity) doesn't change. If this
+    /* This test ensures that sizeof(struct UNITY_STORAGE_T) doesn't change. If this
      * test breaks, go look at the initialization of the Unity global variable
      * in unity.c and make sure we're filling in the proper fields. */
-    const char* message = "Unexpected size for _Unity struct. Please check that "
+    const char* message = "Unexpected size for UNITY_STORAGE_T struct. Please check that "
                      "the initialization of the Unity symbol in unity.c is "
                      "still correct.";
 
-    /* Define a structure with all the same fields as `struct _Unity`. */
+    /* Define a structure with all the same fields as `struct UNITY_STORAGE_T`. */
 #ifdef UNITY_EXCLUDE_DETAILS
     struct {
         const char* TestFile;
@@ -267,7 +267,7 @@ void testNotEqualBits(void)
 
 void testNotEqualUInts(void)
 {
-    _UU16 v0, v1;
+    UNITY_UINT16 v0, v1;
 
     v0 = 9000;
     v1 = 9001;
@@ -279,7 +279,7 @@ void testNotEqualUInts(void)
 
 void testNotEqualUInt8s(void)
 {
-    _UU8 v0, v1;
+    UNITY_UINT8 v0, v1;
 
     v0 = 254;
     v1 = 255;
@@ -291,7 +291,7 @@ void testNotEqualUInt8s(void)
 
 void testNotEqualUInt16s(void)
 {
-    _UU16 v0, v1;
+    UNITY_UINT16 v0, v1;
 
     v0 = 65535;
     v1 = 65534;
@@ -303,7 +303,7 @@ void testNotEqualUInt16s(void)
 
 void testNotEqualUInt32s(void)
 {
-    _UU32 v0, v1;
+    UNITY_UINT32 v0, v1;
 
     v0 = 4294967295;
     v1 = 4294967294;
@@ -315,7 +315,7 @@ void testNotEqualUInt32s(void)
 
 void testNotEqualHex8s(void)
 {
-    _UU8 v0, v1;
+    UNITY_UINT8 v0, v1;
 
     v0 = 0x23;
     v1 = 0x22;
@@ -327,7 +327,7 @@ void testNotEqualHex8s(void)
 
 void testNotEqualHex8sIfSigned(void)
 {
-    _US8 v0, v1;
+    UNITY_INT8 v0, v1;
 
     v0 = -2;
     v1 = 2;
@@ -339,7 +339,7 @@ void testNotEqualHex8sIfSigned(void)
 
 void testNotEqualHex16s(void)
 {
-    _UU16 v0, v1;
+    UNITY_UINT16 v0, v1;
 
     v0 = 0x1234;
     v1 = 0x1235;
@@ -351,7 +351,7 @@ void testNotEqualHex16s(void)
 
 void testNotEqualHex16sIfSigned(void)
 {
-    _US16 v0, v1;
+    UNITY_INT16 v0, v1;
 
     v0 = -1024;
     v1 = -1028;
@@ -363,7 +363,7 @@ void testNotEqualHex16sIfSigned(void)
 
 void testNotEqualHex32s(void)
 {
-    _UU32 v0, v1;
+    UNITY_UINT32 v0, v1;
 
     v0 = 900000;
     v1 = 900001;
@@ -375,7 +375,7 @@ void testNotEqualHex32s(void)
 
 void testNotEqualHex32sIfSigned(void)
 {
-    _US32 v0, v1;
+    UNITY_INT32 v0, v1;
 
     v0 = -900000;
     v1 = 900001;
@@ -407,8 +407,8 @@ void testEqualInts(void)
 
 void testEqualInt8s(void)
 {
-    _US8 v0, v1;
-    _US8 *p0, *p1;
+    UNITY_INT8 v0, v1;
+    UNITY_INT8 *p0, *p1;
 
     v0 = 0x22;
     v1 = 0x22;
@@ -432,8 +432,8 @@ void testEqualInt8sWhenThereAreDifferencesOutside8Bits(void)
 
 void testEqualInt16s(void)
 {
-    _US16 v0, v1;
-    _US16 *p0, *p1;
+    UNITY_INT16 v0, v1;
+    UNITY_INT16 *p0, *p1;
 
     v0 = 0x7876;
     v1 = 0x7876;
@@ -451,8 +451,8 @@ void testEqualInt16s(void)
 
 void testEqualInt16sNegatives(void)
 {
-    _US16 v0, v1;
-    _US16 *p0, *p1;
+    UNITY_INT16 v0, v1;
+    UNITY_INT16 *p0, *p1;
 
     v0 = -7876;
     v1 = -7876;
@@ -476,8 +476,8 @@ void testEqualInt16sWhenThereAreDifferencesOutside16Bits(void)
 
 void testEqualInt32s(void)
 {
-    _US32 v0, v1;
-    _US32 *p0, *p1;
+    UNITY_INT32 v0, v1;
+    UNITY_INT32 *p0, *p1;
 
     v0 = 0x78760000;
     v1 = 0x78760000;
@@ -495,8 +495,8 @@ void testEqualInt32s(void)
 
 void testEqualInt32sNegatives(void)
 {
-    _US32 v0, v1;
-    _US32 *p0, *p1;
+    UNITY_INT32 v0, v1;
+    UNITY_INT32 *p0, *p1;
 
     v0 = -123456789;
     v1 = -123456789;
@@ -536,8 +536,8 @@ void testEqualUints(void)
 
 void testEqualUint8s(void)
 {
-    _UU8 v0, v1;
-    _UU8 *p0, *p1;
+    UNITY_UINT8 v0, v1;
+    UNITY_UINT8 *p0, *p1;
 
     v0 = 0x22;
     v1 = 0x22;
@@ -561,8 +561,8 @@ void testEqualUint8sWhenThereAreDifferencesOutside8Bits(void)
 
 void testEqualUint16s(void)
 {
-    _UU16 v0, v1;
-    _UU16 *p0, *p1;
+    UNITY_UINT16 v0, v1;
+    UNITY_UINT16 *p0, *p1;
 
     v0 = 0x9876;
     v1 = 0x9876;
@@ -586,8 +586,8 @@ void testEqualUint16sWhenThereAreDifferencesOutside16Bits(void)
 
 void testEqualUint32s(void)
 {
-    _UU32 v0, v1;
-    _UU32 *p0, *p1;
+    UNITY_UINT32 v0, v1;
+    UNITY_UINT32 *p0, *p1;
 
     v0 = 0x98760000;
     v1 = 0x98760000;
@@ -616,8 +616,8 @@ void testNotEqual(void)
 
 void testEqualHex8s(void)
 {
-    _UU8 v0, v1;
-    _UU8 *p0, *p1;
+    UNITY_UINT8 v0, v1;
+    UNITY_UINT8 *p0, *p1;
 
     v0 = 0x22;
     v1 = 0x22;
@@ -641,8 +641,8 @@ void testEqualHex8sWhenThereAreDifferencesOutside8Bits(void)
 
 void testEqualHex8sNegatives(void)
 {
-    _UU8 v0, v1;
-    _UU8 *p0, *p1;
+    UNITY_UINT8 v0, v1;
+    UNITY_UINT8 *p0, *p1;
 
     v0 = 0xDD;
     v1 = 0xDD;
@@ -660,8 +660,8 @@ void testEqualHex8sNegatives(void)
 
 void testEqualHex16s(void)
 {
-    _UU16 v0, v1;
-    _UU16 *p0, *p1;
+    UNITY_UINT16 v0, v1;
+    UNITY_UINT16 *p0, *p1;
 
     v0 = 0x9876;
     v1 = 0x9876;
@@ -685,8 +685,8 @@ void testEqualHex16sWhenThereAreDifferencesOutside16Bits(void)
 
 void testEqualHex32s(void)
 {
-    _UU32 v0, v1;
-    _UU32 *p0, *p1;
+    UNITY_UINT32 v0, v1;
+    UNITY_UINT32 *p0, *p1;
 
     v0 = 0x98765432ul;
     v1 = 0x98765432ul;
@@ -704,8 +704,8 @@ void testEqualHex32s(void)
 
 void testEqualBits(void)
 {
-    _UU32 v0 = 0xFF55AA00;
-    _UU32 v1 = 0x55550000;
+    UNITY_UINT32 v0 = 0xFF55AA00;
+    UNITY_UINT32 v1 = 0x55550000;
 
     TEST_ASSERT_BITS(v1, v0, 0x55550000);
     TEST_ASSERT_BITS(v1, v0, 0xFF55CC00);
@@ -720,7 +720,7 @@ void testEqualBits(void)
 
 void testNotEqualBitHigh(void)
 {
-    _UU32 v0 = 0x7F55AA00;
+    UNITY_UINT32 v0 = 0x7F55AA00;
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_BIT_HIGH(31, v0);
@@ -729,7 +729,7 @@ void testNotEqualBitHigh(void)
 
 void testNotEqualBitLow(void)
 {
-    _UU32 v0 = 0xFF55AA00;
+    UNITY_UINT32 v0 = 0xFF55AA00;
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_BIT_LOW(30, v0);
@@ -738,8 +738,8 @@ void testNotEqualBitLow(void)
 
 void testNotEqualBitsHigh(void)
 {
-    _UU32 v0 = 0xFF55AA00;
-    _UU32 v1 = 0x55550000;
+    UNITY_UINT32 v0 = 0xFF55AA00;
+    UNITY_UINT32 v1 = 0x55550000;
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_BITS_HIGH(v0, v1);
@@ -749,8 +749,8 @@ void testNotEqualBitsHigh(void)
 
 void testNotEqualBitsLow(void)
 {
-    _UU32 v0 = 0xFF55AA00;
-    _UU32 v1 = 0x55550000;
+    UNITY_UINT32 v0 = 0xFF55AA00;
+    UNITY_UINT32 v1 = 0x55550000;
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_BITS_LOW(v0, v1);
@@ -1624,8 +1624,8 @@ void testNotEqualIntArrays3(void)
 
 void testNotEqualIntArraysLengthZero(void)
 {
-    _UU32 p0[1] = {1};
-    _UU32 p1[1] = {1};
+    UNITY_UINT32 p0[1] = {1};
+    UNITY_UINT32 p1[1] = {1};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_INT_ARRAY(p0, p1, 0);
@@ -1714,10 +1714,10 @@ void testNotEqualPtrArrays3(void)
 
 void testEqualInt8Arrays(void)
 {
-    _US8 p0[] = {1, 8, 117, -2};
-    _US8 p1[] = {1, 8, 117, -2};
-    _US8 p2[] = {1, 8, 117, 2};
-    _US8 p3[] = {1, 50, 60, 70};
+    UNITY_INT8 p0[] = {1, 8, 117, -2};
+    UNITY_INT8 p1[] = {1, 8, 117, -2};
+    UNITY_INT8 p2[] = {1, 8, 117, 2};
+    UNITY_INT8 p3[] = {1, 50, 60, 70};
 
     TEST_ASSERT_EQUAL_INT8_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_INT8_ARRAY(p0, p0, 4);
@@ -1728,8 +1728,8 @@ void testEqualInt8Arrays(void)
 
 void testNotEqualInt8Arrays(void)
 {
-    _US8 p0[] = {1, 8, 36, -2};
-    _US8 p1[] = {1, 8, 36, 2};
+    UNITY_INT8 p0[] = {1, 8, 36, -2};
+    UNITY_INT8 p1[] = {1, 8, 36, 2};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_INT8_ARRAY(p0, p1, 4);
@@ -1782,10 +1782,10 @@ void testNotEqualUIntArrays3(void)
 
 void testEqualInt16Arrays(void)
 {
-    _US16 p0[] = {1, 8, 117, 3};
-    _US16 p1[] = {1, 8, 117, 3};
-    _US16 p2[] = {1, 8, 117, 2};
-    _US16 p3[] = {1, 50, 60, 70};
+    UNITY_INT16 p0[] = {1, 8, 117, 3};
+    UNITY_INT16 p1[] = {1, 8, 117, 3};
+    UNITY_INT16 p2[] = {1, 8, 117, 2};
+    UNITY_INT16 p3[] = {1, 50, 60, 70};
 
     TEST_ASSERT_EQUAL_INT16_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_INT16_ARRAY(p0, p0, 4);
@@ -1796,8 +1796,8 @@ void testEqualInt16Arrays(void)
 
 void testNotEqualInt16Arrays(void)
 {
-    _US16 p0[] = {1, 8, 127, 3};
-    _US16 p1[] = {1, 8, 127, 2};
+    UNITY_INT16 p0[] = {1, 8, 127, 3};
+    UNITY_INT16 p1[] = {1, 8, 127, 2};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_INT16_ARRAY(p0, p1, 4);
@@ -1806,10 +1806,10 @@ void testNotEqualInt16Arrays(void)
 
 void testEqualInt32Arrays(void)
 {
-    _US32 p0[] = {1, 8, 117, 3};
-    _US32 p1[] = {1, 8, 117, 3};
-    _US32 p2[] = {1, 8, 117, 2};
-    _US32 p3[] = {1, 50, 60, 70};
+    UNITY_INT32 p0[] = {1, 8, 117, 3};
+    UNITY_INT32 p1[] = {1, 8, 117, 3};
+    UNITY_INT32 p2[] = {1, 8, 117, 2};
+    UNITY_INT32 p3[] = {1, 50, 60, 70};
 
     TEST_ASSERT_EQUAL_INT32_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_INT32_ARRAY(p0, p0, 4);
@@ -1820,8 +1820,8 @@ void testEqualInt32Arrays(void)
 
 void testNotEqualInt32Arrays(void)
 {
-    _US32 p0[] = {1, 8, 127, 3};
-    _US32 p1[] = {1, 8, 127, 2};
+    UNITY_INT32 p0[] = {1, 8, 127, 3};
+    UNITY_INT32 p1[] = {1, 8, 127, 2};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_INT32_ARRAY(p0, p1, 4);
@@ -1830,10 +1830,10 @@ void testNotEqualInt32Arrays(void)
 
 void testEqualUINT8Arrays(void)
 {
-    _UU8 p0[] = {1, 8, 100, 127};
-    _UU8 p1[] = {1, 8, 100, 127};
-    _UU8 p2[] = {1, 8, 100, 2};
-    _UU8 p3[] = {1, 50, 60, 70};
+    UNITY_UINT8 p0[] = {1, 8, 100, 127};
+    UNITY_UINT8 p1[] = {1, 8, 100, 127};
+    UNITY_UINT8 p2[] = {1, 8, 100, 2};
+    UNITY_UINT8 p3[] = {1, 50, 60, 70};
 
     TEST_ASSERT_EQUAL_UINT8_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_UINT8_ARRAY(p0, p0, 4);
@@ -1919,10 +1919,10 @@ void testNotEqualUINT16Arrays3(void)
 
 void testEqualUINT32Arrays(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 987, 65132u};
-    _UU32 p2[] = {1, 8, 987, 2};
-    _UU32 p3[] = {1, 500, 600, 700};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p2[] = {1, 8, 987, 2};
+    UNITY_UINT32 p3[] = {1, 500, 600, 700};
 
     TEST_ASSERT_EQUAL_UINT32_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_UINT32_ARRAY(p0, p0, 4);
@@ -1933,8 +1933,8 @@ void testEqualUINT32Arrays(void)
 
 void testNotEqualUINT32Arrays1(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 987, 65131u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 987, 65131u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_UINT32_ARRAY(p0, p1, 4);
@@ -1943,8 +1943,8 @@ void testNotEqualUINT32Arrays1(void)
 
 void testNotEqualUINT32Arrays2(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {2, 8, 987, 65132u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {2, 8, 987, 65132u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_UINT32_ARRAY(p0, p1, 4);
@@ -1953,8 +1953,8 @@ void testNotEqualUINT32Arrays2(void)
 
 void testNotEqualUINT32Arrays3(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 986, 65132u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 986, 65132u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_UINT32_ARRAY(p0, p1, 4);
@@ -1963,10 +1963,10 @@ void testNotEqualUINT32Arrays3(void)
 
 void testEqualHEXArrays(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 987, 65132u};
-    _UU32 p2[] = {1, 8, 987, 2};
-    _UU32 p3[] = {1, 500, 600, 700};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p2[] = {1, 8, 987, 2};
+    UNITY_UINT32 p3[] = {1, 500, 600, 700};
 
     TEST_ASSERT_EQUAL_HEX_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_HEX_ARRAY(p0, p0, 4);
@@ -1977,8 +1977,8 @@ void testEqualHEXArrays(void)
 
 void testNotEqualHEXArrays1(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 987, 65131u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 987, 65131u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX32_ARRAY(p0, p1, 4);
@@ -1987,8 +1987,8 @@ void testNotEqualHEXArrays1(void)
 
 void testNotEqualHEXArrays2(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {2, 8, 987, 65132u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {2, 8, 987, 65132u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX32_ARRAY(p0, p1, 4);
@@ -1997,8 +1997,8 @@ void testNotEqualHEXArrays2(void)
 
 void testNotEqualHEXArrays3(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 986, 65132u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 986, 65132u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX_ARRAY(p0, p1, 4);
@@ -2007,10 +2007,10 @@ void testNotEqualHEXArrays3(void)
 
 void testEqualHEX32Arrays(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 987, 65132u};
-    _UU32 p2[] = {1, 8, 987, 2};
-    _UU32 p3[] = {1, 500, 600, 700};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p2[] = {1, 8, 987, 2};
+    UNITY_UINT32 p3[] = {1, 500, 600, 700};
 
     TEST_ASSERT_EQUAL_HEX32_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_HEX32_ARRAY(p0, p0, 4);
@@ -2021,8 +2021,8 @@ void testEqualHEX32Arrays(void)
 
 void testNotEqualHEX32Arrays1(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 987, 65131u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 987, 65131u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX32_ARRAY(p0, p1, 4);
@@ -2031,8 +2031,8 @@ void testNotEqualHEX32Arrays1(void)
 
 void testNotEqualHEX32Arrays2(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {2, 8, 987, 65132u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {2, 8, 987, 65132u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX32_ARRAY(p0, p1, 4);
@@ -2041,8 +2041,8 @@ void testNotEqualHEX32Arrays2(void)
 
 void testNotEqualHEX32Arrays3(void)
 {
-    _UU32 p0[] = {1, 8, 987, 65132u};
-    _UU32 p1[] = {1, 8, 986, 65132u};
+    UNITY_UINT32 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT32 p1[] = {1, 8, 986, 65132u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX32_ARRAY(p0, p1, 4);
@@ -2309,8 +2309,8 @@ void testPrintNumbers32(void)
     TEST_ASSERT_EQUAL_PRINT_NUMBERS("1", 1);
     TEST_ASSERT_EQUAL_PRINT_NUMBERS("-1", -1);
     TEST_ASSERT_EQUAL_PRINT_NUMBERS("2000000000", 2000000000);
-    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-2147483648", (_US32)0x80000000);
-    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-1",          (_US32)0xFFFFFFFF);
+    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-2147483648", (UNITY_INT32)0x80000000);
+    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-1",          (UNITY_INT32)0xFFFFFFFF);
 #endif
 }
 
@@ -2322,8 +2322,8 @@ void testPrintNumbersUnsigned32(void)
     TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("0", 0);
     TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("1", 1);
     TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("1500000000", 1500000000);
-    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("2147483648", (_UU32)0x80000000);
-    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("4294967295", (_UU32)0xFFFFFFFF);
+    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("2147483648", (UNITY_UINT32)0x80000000);
+    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("4294967295", (UNITY_UINT32)0xFFFFFFFF);
 #endif
 }
 
@@ -2339,8 +2339,8 @@ void testPrintNumbersInt64(void)
   #else
     TEST_ASSERT_EQUAL_PRINT_NUMBERS("0", 0);
     TEST_ASSERT_EQUAL_PRINT_NUMBERS("10000000000", 10000000000);
-    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-9223372036854775808", (_U_SINT)0x8000000000000000);
-    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-1", (_U_SINT)0xFFFFFFFFFFFFFFFF);
+    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-9223372036854775808", (UNITY_INT)0x8000000000000000);
+    TEST_ASSERT_EQUAL_PRINT_NUMBERS("-1", (UNITY_INT)0xFFFFFFFFFFFFFFFF);
   #endif
 #endif
 }
@@ -2355,8 +2355,8 @@ void testPrintNumbersUInt64(void)
   #else
     TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("0", 0);
     TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("70000000000", 70000000000);
-    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("9223372036854775808",  (_U_UINT)0x8000000000000000);
-    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("18446744073709551615", (_U_UINT)0xFFFFFFFFFFFFFFFF);
+    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("9223372036854775808",  (UNITY_UINT)0x8000000000000000);
+    TEST_ASSERT_EQUAL_PRINT_UNSIGNED_NUMBERS("18446744073709551615", (UNITY_UINT)0xFFFFFFFFFFFFFFFF);
   #endif
 #endif
 }
@@ -2366,8 +2366,8 @@ void testEqualHex64s(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 v0, v1;
-    _UU64 *p0, *p1;
+    UNITY_UINT64 v0, v1;
+    UNITY_UINT64 *p0, *p1;
 
     v0 = 0x9876543201234567;
     v1 = 0x9876543201234567;
@@ -2389,8 +2389,8 @@ void testEqualUint64s(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 v0, v1;
-    _UU64 *p0, *p1;
+    UNITY_UINT64 v0, v1;
+    UNITY_UINT64 *p0, *p1;
 
     v0 = 0x9876543201234567;
     v1 = 0x9876543201234567;
@@ -2412,11 +2412,11 @@ void testEqualInt64s(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _US64 v0, v1;
-    _US64 *p0, *p1;
+    UNITY_INT64 v0, v1;
+    UNITY_INT64 *p0, *p1;
 
-    v0 = (_US64)0x9876543201234567;
-    v1 = (_US64)0x9876543201234567;
+    v0 = (UNITY_INT64)0x9876543201234567;
+    v1 = (UNITY_INT64)0x9876543201234567;
     p0 = &v0;
     p1 = &v1;
 
@@ -2436,7 +2436,7 @@ void testNotEqualHex64s(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 v0, v1;
+    UNITY_UINT64 v0, v1;
 
     v0 = 9000000000;
     v1 = 9100000000;
@@ -2452,7 +2452,7 @@ void testNotEqualUint64s(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 v0, v1;
+    UNITY_UINT64 v0, v1;
 
     v0 = 9000000000;
     v1 = 9100000000;
@@ -2468,7 +2468,7 @@ void testNotEqualInt64s(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _US64 v0, v1;
+    UNITY_INT64 v0, v1;
 
     v0 = -9000000000;
     v1 = 9100000000;
@@ -2484,7 +2484,7 @@ void testNotEqualHex64sIfSigned(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _US64 v0, v1;
+    UNITY_INT64 v0, v1;
 
     v0 = -9000000000;
     v1 = 9000000000;
@@ -2599,10 +2599,10 @@ void testEqualHEX64Arrays(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 p0[] = {1, 8, 987, 65132u};
-    _UU64 p1[] = {1, 8, 987, 65132u};
-    _UU64 p2[] = {1, 8, 987, 2};
-    _UU64 p3[] = {1, 500, 600, 700};
+    UNITY_UINT64 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT64 p1[] = {1, 8, 987, 65132u};
+    UNITY_UINT64 p2[] = {1, 8, 987, 2};
+    UNITY_UINT64 p3[] = {1, 500, 600, 700};
 
     TEST_ASSERT_EQUAL_HEX64_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_HEX64_ARRAY(p0, p0, 4);
@@ -2617,10 +2617,10 @@ void testEqualUint64Arrays(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 p0[] = {1, 8, 987, 65132u};
-    _UU64 p1[] = {1, 8, 987, 65132u};
-    _UU64 p2[] = {1, 8, 987, 2};
-    _UU64 p3[] = {1, 500, 600, 700};
+    UNITY_UINT64 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT64 p1[] = {1, 8, 987, 65132u};
+    UNITY_UINT64 p2[] = {1, 8, 987, 2};
+    UNITY_UINT64 p3[] = {1, 500, 600, 700};
 
     TEST_ASSERT_EQUAL_UINT64_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_UINT64_ARRAY(p0, p0, 4);
@@ -2635,10 +2635,10 @@ void testEqualInt64Arrays(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _US64 p0[] = {1, 8, 987, -65132};
-    _US64 p1[] = {1, 8, 987, -65132};
-    _US64 p2[] = {1, 8, 987, -2};
-    _US64 p3[] = {1, 500, 600, 700};
+    UNITY_INT64 p0[] = {1, 8, 987, -65132};
+    UNITY_INT64 p1[] = {1, 8, 987, -65132};
+    UNITY_INT64 p2[] = {1, 8, 987, -2};
+    UNITY_INT64 p3[] = {1, 500, 600, 700};
 
     TEST_ASSERT_EQUAL_INT64_ARRAY(p0, p0, 1);
     TEST_ASSERT_EQUAL_INT64_ARRAY(p0, p0, 4);
@@ -2654,8 +2654,8 @@ void testNotEqualHEX64Arrays1(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 p0[] = {1, 8, 987, 65132u};
-    _UU64 p1[] = {1, 8, 987, 65131u};
+    UNITY_UINT64 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT64 p1[] = {1, 8, 987, 65131u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX64_ARRAY(p0, p1, 4);
@@ -2668,8 +2668,8 @@ void testNotEqualHEX64Arrays2(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 p0[] = {1, 8, 987, 65132u};
-    _UU64 p1[] = {2, 8, 987, 65132u};
+    UNITY_UINT64 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT64 p1[] = {2, 8, 987, 65132u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_HEX64_ARRAY(p0, p1, 4);
@@ -2682,8 +2682,8 @@ void testNotEqualUint64Arrays(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _UU64 p0[] = {1, 8, 987, 65132u};
-    _UU64 p1[] = {1, 8, 987, 65131u};
+    UNITY_UINT64 p0[] = {1, 8, 987, 65132u};
+    UNITY_UINT64 p1[] = {1, 8, 987, 65131u};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_UINT64_ARRAY(p0, p1, 4);
@@ -2696,8 +2696,8 @@ void testNotEqualInt64Arrays(void)
 #ifndef UNITY_SUPPORT_64
     TEST_IGNORE();
 #else
-    _US64 p0[] = {1, 8, 987, -65132};
-    _US64 p1[] = {1, 8, 987, -65131};
+    UNITY_INT64 p0[] = {1, 8, 987, -65132};
+    UNITY_INT64 p1[] = {1, 8, 987, -65131};
 
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_EQUAL_INT64_ARRAY(p0, p1, 4);


### PR DESCRIPTION
Unity Prints Floating Point By Default
When a floating point test assert fails the output now prints a number without enabling printing support.
* Breaks the dependency on `snprintf()`
* Uses a custom algorithm with a fixed format, similar to previous format (to six decimal places)
* Large numbers are printed in exponential form with 9 digits of precision: 1.8e+nn
* Examples: 12.654321, 1.25e+10, 1.0, -4100200300.0, NaN, -Inf
* Trims extra trailing 0's for human readable format, 2.0 vs. 2.000000 before
* Special indication for small numbers, 0.000000… vs. 0.0 before when < 5e-7 but not 0
* Twice as fast as `snprintf` in benchmarks, not that it matters for the occasional failure
* Numerical analysis shows correctness for all floats, unique values 16.0 and up
* A very small percent of doubles may round wrong in the last digit due to double precision arithmetic
* Rounds numbers to nearest value, and ties round to even (as is true for most floating point)
* Option to round ties away from 0, `UNITY_ROUND_TIES_AWAY_FROM_ZERO`
* Remove `UNITY_FLOAT_VERBOSE`, add option `UNITY_EXCLUDE_FLOAT_PRINT`
* Tests. Lots of corner cases and an optional test set running through all `float` values