### PR TITLE
Fixture - Ability to set size of pointer list

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -305,8 +305,7 @@ struct PointerPair
     void* old_value;
 };
 
-enum { MAX_POINTERS = 50 };
-static struct PointerPair pointer_store[MAX_POINTERS];
+static struct PointerPair pointer_store[UNITY_MAX_POINTERS];
 static int pointer_index = 0;
 
 void UnityPointer_Init(void)
@@ -316,7 +315,7 @@ void UnityPointer_Init(void)
 
 void UnityPointer_Set(void** pointer, void* newValue, UNITY_LINE_TYPE line)
 {
-    if (pointer_index >= MAX_POINTERS)
+    if (pointer_index >= UNITY_MAX_POINTERS)
     {
         UNITY_TEST_FAIL(line, "Too many pointers set");
     }

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -40,6 +40,9 @@ void UnityConcludeFixtureTest(void);
 void UnityPointer_Set(void** ptr, void* newValue, UNITY_LINE_TYPE line);
 void UnityPointer_UndoAllSets(void);
 void UnityPointer_Init(void);
+#ifndef UNITY_MAX_POINTERS
+#define UNITY_MAX_POINTERS 5
+#endif
 
 #ifdef __cplusplus
 }

--- a/extras/fixture/test/unity_fixture_Test.c
+++ b/extras/fixture/test/unity_fixture_Test.c
@@ -465,7 +465,7 @@ TEST(LeakDetection, PointerSettingMax)
     TEST_IGNORE();
 #else
     int i;
-    for (i = 0; i < 50; i++) UT_PTR_SET(pointer1, &int1);
+    for (i = 0; i < UNITY_MAX_POINTERS; i++) UT_PTR_SET(pointer1, &int1);
     UnityOutputCharSpy_Enable(1);
     EXPECT_ABORT_BEGIN
     UT_PTR_SET(pointer1, &int1);


### PR DESCRIPTION
The pointer setting/unsetting storage was not configurable, now it is. In turn, that allows the default size to be smaller, which gives a smaller binary size.
5 pointers seems like enough for the common use case, so the default is 5.