### PR TITLE
Fixture - Remove duplicate output of test name in verbose mode

### DIFF
--- a/examples/example_2/makefile
+++ b/examples/example_2/makefile
@@ -43,7 +43,6 @@ CFLAGS += -Wundef
 CFLAGS += -Wold-style-definition
 CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wmissing-declarations
-CFLAGS += -DUNITY_FIXTURES
 
 TARGET_BASE1=all_tests
 TARGET1 = $(TARGET_BASE1)$(TARGET_EXTENSION)

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -81,7 +81,12 @@ void UnityTestRunner(unityfunction* setup,
         if (!UnityFixture.Verbose)
             UNITY_OUTPUT_CHAR('.');
         else
+        {
             UnityPrint(printableName);
+        #ifndef UNITY_REPEAT_TEST_NAME
+            Unity.CurrentTestName = NULL;
+        #endif
+        }
 
         Unity.NumberOfTests++;
         UnityMalloc_StartTest();

--- a/src/unity.c
+++ b/src/unity.c
@@ -357,28 +357,19 @@ void UnityPrintOk(void)
 static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line);
 static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 {
-#ifndef UNITY_FIXTURES
     UnityPrint(file);
     UNITY_OUTPUT_CHAR(':');
     UnityPrintNumber((UNITY_INT)line);
     UNITY_OUTPUT_CHAR(':');
     UnityPrint(Unity.CurrentTestName);
     UNITY_OUTPUT_CHAR(':');
-#else
-    UNITY_UNUSED(file);
-    UNITY_UNUSED(line);
-#endif
 }
 
 /*-----------------------------------------------*/
 static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line);
 static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line)
 {
-#ifndef UNITY_FIXTURES
     UnityTestResultsBegin(Unity.TestFile, line);
-#else
-    UNITY_UNUSED(line);
-#endif
     UnityPrint(UnityStrFail);
     UNITY_OUTPUT_CHAR(':');
 }

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -597,8 +597,6 @@ extern const char UnityStrErr64[];
 #define UNITY_END() UnityEnd()
 #endif
 
-#define UNITY_UNUSED(x) (void)(sizeof(x))
-
 /*-----------------------------------------------
  * Command Line Argument Support
  *-----------------------------------------------*/


### PR DESCRIPTION
It is redundant to print the test name twice during a failure. Option to keep the old output.

Remove UNITY_FIXTURES option, which was probably not doing what was
originally indended. It was suppressing the test name even in quiet mode.