### PR TITLE
Always run the tearDown() even if test is ignored

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -276,7 +276,7 @@ class UnityTestRunnerGenerator
     output.puts("      TestFunc(#{va_args2}); \\")
     output.puts("    } Catch(e) { TEST_ASSERT_EQUAL_HEX32_MESSAGE(CEXCEPTION_NONE, e, \"Unhandled Exception!\"); } \\") if cexception
     output.puts("  } \\")
-    output.puts("  if (TEST_PROTECT() && !TEST_IS_IGNORED) \\")
+    output.puts("  if (TEST_PROTECT()) \\")
     output.puts("  { \\")
     output.puts("    #{@options[:teardown_name]}(); \\")
     output.puts("    CMock_Verify(); \\") unless (used_mocks.empty?)

--- a/src/unity.c
+++ b/src/unity.c
@@ -1275,7 +1275,7 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
         setUp();
         Func();
     }
-    if (TEST_PROTECT() && !(Unity.CurrentTestIgnored))
+    if (TEST_PROTECT())
     {
         tearDown();
     }

--- a/test/testdata/testRunnerGeneratorWithMocks.c
+++ b/test/testdata/testRunnerGeneratorWithMocks.c
@@ -183,9 +183,9 @@ void suitetest_ThisTestPassesWhenCustomSuiteSetupAndTeardownRan(void)
 
 void test_ShouldCallMockInitAndVerifyFunctionsForEachTest(void)
 {
-    int passes = (int)(Unity.NumberOfTests - Unity.TestFailures - Unity.TestIgnores);
+    int passesOrIgnores = (int)(Unity.NumberOfTests - Unity.TestFailures);
     TEST_ASSERT_EQUAL_MESSAGE(Unity.NumberOfTests,     mockMock_Init_Counter,    "Mock Init Should Be Called Once Per Test Started");
-    TEST_ASSERT_EQUAL_MESSAGE(passes,                  mockMock_Verify_Counter,  "Mock Verify Should Be Called Once Per Test Passed");
+    TEST_ASSERT_EQUAL_MESSAGE(passesOrIgnores,         mockMock_Verify_Counter,  "Mock Verify Should Be Called Once Per Test Passed");
     TEST_ASSERT_EQUAL_MESSAGE(Unity.NumberOfTests - 1, mockMock_Destroy_Counter, "Mock Destroy Should Be Called Once Per Test Completed");
     TEST_ASSERT_EQUAL_MESSAGE(0,                       CMockMemFreeFinalCounter, "Mock MemFreeFinal Should Not Be Called Until End");
 }

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -67,7 +67,11 @@ void tearDown(void)
 {
     endPutcharSpy(); /* Stop suppressing test output */
     if (SetToOneToFailInTearDown == 1)
+    {
+        /* These will be skipped internally if already failed/ignored */
         TEST_FAIL_MESSAGE("<= Failed in tearDown");
+        TEST_IGNORE_MESSAGE("<= Ignored in tearDown");
+    }
     if ((SetToOneMeanWeAlreadyCheckedThisGuy == 0) && (Unity.CurrentTestFailed > 0))
     {
         UnityPrint(": [[[[ Test Should Have Passed But Did Not ]]]]");


### PR DESCRIPTION
This is my proposal for resolution of #114.
I'm happy to close this PR if it's not the best solution. Consider it a proposal only, not necessarily a complete feature.

Always running tearDown feels like the best option for most users. The change may be significant to a minority of users, however, so proceeding with caution is wise.
Both `TEST_IGNORE()` calls and failed tests would run tearDown afterward. Any assertions in the tearDown are currently skipped inside the assertion call unless the test is passing. Execution continues past the assertion if the test called `TEST_IGNORE()` or failed.

Edit: I see this failed due to CMock_Verify() being called during tearDown (once more than expected, during the ignored tests). What is the desired behavior of calls to CMock_Verify()?