### PR TITLE
Optional UNITY_EXCLUDE_SETJMP_H, different control flow

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -480,32 +480,32 @@ static void UnityPrintExpectedAndActualStringsLen(const char* expected, const ch
  * Assertion & Control Helpers
  *-----------------------------------------------*/
 
-static int UnityCheckArraysForNull(UNITY_INTERNAL_PTR expected, UNITY_INTERNAL_PTR actual, const UNITY_LINE_TYPE lineNumber, const char* msg)
+static int UnityIsOneArrayNull(UNITY_INTERNAL_PTR expected,
+                               UNITY_INTERNAL_PTR actual,
+                               const UNITY_LINE_TYPE lineNumber,
+                               const char* msg)
 {
-    /* return true if they are both NULL */
-    if ((expected == NULL) && (actual == NULL))
-        return 1;
+    if (expected == actual) return 0; /* Both are NULL or same pointer */
 
-    /* throw error if just expected is NULL */
+    /* print and return true if just expected is NULL */
     if (expected == NULL)
     {
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrNullPointerForExpected);
         UnityAddMsgIfSpecified(msg);
-        UNITY_FAIL_AND_BAIL;
+        return 1;
     }
 
-    /* throw error if just actual is NULL */
+    /* print and return true if just actual is NULL */
     if (actual == NULL)
     {
         UnityTestResultsFailBegin(lineNumber);
         UnityPrint(UnityStrNullPointerForActual);
         UnityAddMsgIfSpecified(msg);
-        UNITY_FAIL_AND_BAIL;
+        return 1;
     }
 
-    /* return false if neither is NULL */
-    return 0;
+    return 0; /* return false if neither is NULL */
 }
 
 /*-----------------------------------------------
@@ -578,8 +578,9 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
         UnityPrintPointlessAndBail();
     }
 
-    if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
-        return;
+    if (expected == actual) return; /* Both are NULL or same pointer */
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+        UNITY_FAIL_AND_BAIL;
 
     while (elements--)
     {
@@ -685,8 +686,9 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
         UnityPrintPointlessAndBail();
     }
 
-    if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
-        return;
+    if (expected == actual) return; /* Both are NULL or same pointer */
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+        UNITY_FAIL_AND_BAIL;
 
     while (elements--)
     {
@@ -810,8 +812,9 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
         UnityPrintPointlessAndBail();
     }
 
-    if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
-        return;
+    if (expected == actual) return; /* Both are NULL or same pointer */
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+        UNITY_FAIL_AND_BAIL;
 
     while (elements--)
     {
@@ -1047,8 +1050,9 @@ void UnityAssertEqualStringArray( const char** expected,
         UnityPrintPointlessAndBail();
     }
 
-    if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
-        return;
+    if (expected == actual) return; /* Both are NULL or same pointer */
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+        UNITY_FAIL_AND_BAIL;
 
     do
     {
@@ -1107,8 +1111,9 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
         UnityPrintPointlessAndBail();
     }
 
-    if (UnityCheckArraysForNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg) == 1)
-        return;
+    if (expected == actual) return; /* Both are NULL or same pointer */
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+        UNITY_FAIL_AND_BAIL;
 
     while (elements--)
     {

--- a/src/unity.c
+++ b/src/unity.c
@@ -573,7 +573,10 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if (num_elements == 0) UnityPrintPointlessAndBail();
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
@@ -673,10 +676,15 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
                                 const UNITY_LINE_TYPE lineNumber)
 {
     UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_actual = actual;
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if (num_elements == 0) UnityPrintPointlessAndBail();
+    if (elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
@@ -684,17 +692,17 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
 
     while (elements--)
     {
-        if (!UnityFloatsWithin(*expected * UNITY_FLOAT_PRECISION, *expected, *actual))
+        if (!UnityFloatsWithin(*ptr_expected * UNITY_FLOAT_PRECISION, *ptr_expected, *ptr_actual))
         {
             UnityTestResultsFailBegin(lineNumber);
             UnityPrint(UnityStrElement);
             UnityPrintNumberUnsigned(num_elements - elements - 1);
-            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*expected, *actual);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*ptr_expected, *ptr_actual);
             UnityAddMsgIfSpecified(msg);
             UNITY_FAIL_AND_BAIL;
         }
-        expected++;
-        actual++;
+        ptr_expected++;
+        ptr_actual++;
     }
 }
 
@@ -794,10 +802,15 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
                                  const UNITY_LINE_TYPE lineNumber)
 {
     UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_actual = actual;
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if (num_elements == 0) UnityPrintPointlessAndBail();
+    if (elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
@@ -805,17 +818,17 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
 
     while (elements--)
     {
-        if (!UnityDoublesWithin(*expected * UNITY_DOUBLE_PRECISION, *expected, *actual))
+        if (!UnityDoublesWithin(*ptr_expected * UNITY_DOUBLE_PRECISION, *ptr_expected, *ptr_actual))
         {
             UnityTestResultsFailBegin(lineNumber);
             UnityPrint(UnityStrElement);
             UnityPrintNumberUnsigned(num_elements - elements - 1);
-            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*expected, *actual);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*ptr_expected, *ptr_actual);
             UnityAddMsgIfSpecified(msg);
             UNITY_FAIL_AND_BAIL;
         }
-        expected++;
-        actual++;
+        ptr_expected++;
+        ptr_actual++;
     }
 }
 
@@ -1032,7 +1045,10 @@ void UnityAssertEqualStringArray( const char** expected,
     RETURN_IF_FAIL_OR_IGNORE;
 
     /* if no elements, it's an error */
-    if (num_elements == 0) UnityPrintPointlessAndBail();
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
@@ -1090,7 +1106,10 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if (num_elements == 0 || length == 0) UnityPrintPointlessAndBail();
+    if ((elements == 0) || (length == 0))
+    {
+        UnityPrintPointlessAndBail();
+    }
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))

--- a/src/unity.c
+++ b/src/unity.c
@@ -13,8 +13,8 @@ void UNITY_OUTPUT_CHAR(int);
 #endif
 
 /* Helpful macros for us to use here in Assert functions */
-#define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
-#define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
+#define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; TEST_ABORT(); }
+#define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; TEST_ABORT(); }
 #define RETURN_IF_FAIL_OR_IGNORE if (Unity.CurrentTestFailed || Unity.CurrentTestIgnored) return
 
 struct UNITY_STORAGE_T Unity;

--- a/src/unity.c
+++ b/src/unity.c
@@ -573,10 +573,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if (num_elements == 0)
-    {
-        UnityPrintPointlessAndBail();
-    }
+    if (num_elements == 0) UnityPrintPointlessAndBail();
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
@@ -676,15 +673,10 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
                                 const UNITY_LINE_TYPE lineNumber)
 {
     UNITY_UINT32 elements = num_elements;
-    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_expected = expected;
-    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_actual = actual;
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if (elements == 0)
-    {
-        UnityPrintPointlessAndBail();
-    }
+    if (num_elements == 0) UnityPrintPointlessAndBail();
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
@@ -692,17 +684,17 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
 
     while (elements--)
     {
-        if (!UnityFloatsWithin(*ptr_expected * UNITY_FLOAT_PRECISION, *ptr_expected, *ptr_actual))
+        if (!UnityFloatsWithin(*expected * UNITY_FLOAT_PRECISION, *expected, *actual))
         {
             UnityTestResultsFailBegin(lineNumber);
             UnityPrint(UnityStrElement);
             UnityPrintNumberUnsigned(num_elements - elements - 1);
-            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*ptr_expected, *ptr_actual);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*expected, *actual);
             UnityAddMsgIfSpecified(msg);
             UNITY_FAIL_AND_BAIL;
         }
-        ptr_expected++;
-        ptr_actual++;
+        expected++;
+        actual++;
     }
 }
 
@@ -802,15 +794,10 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
                                  const UNITY_LINE_TYPE lineNumber)
 {
     UNITY_UINT32 elements = num_elements;
-    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_expected = expected;
-    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_actual = actual;
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if (elements == 0)
-    {
-        UnityPrintPointlessAndBail();
-    }
+    if (num_elements == 0) UnityPrintPointlessAndBail();
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
@@ -818,17 +805,17 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
 
     while (elements--)
     {
-        if (!UnityDoublesWithin(*ptr_expected * UNITY_DOUBLE_PRECISION, *ptr_expected, *ptr_actual))
+        if (!UnityDoublesWithin(*expected * UNITY_DOUBLE_PRECISION, *expected, *actual))
         {
             UnityTestResultsFailBegin(lineNumber);
             UnityPrint(UnityStrElement);
             UnityPrintNumberUnsigned(num_elements - elements - 1);
-            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*ptr_expected, *ptr_actual);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*expected, *actual);
             UnityAddMsgIfSpecified(msg);
             UNITY_FAIL_AND_BAIL;
         }
-        ptr_expected++;
-        ptr_actual++;
+        expected++;
+        actual++;
     }
 }
 
@@ -1045,10 +1032,7 @@ void UnityAssertEqualStringArray( const char** expected,
     RETURN_IF_FAIL_OR_IGNORE;
 
     /* if no elements, it's an error */
-    if (num_elements == 0)
-    {
-        UnityPrintPointlessAndBail();
-    }
+    if (num_elements == 0) UnityPrintPointlessAndBail();
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
@@ -1106,10 +1090,7 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
 
     RETURN_IF_FAIL_OR_IGNORE;
 
-    if ((elements == 0) || (length == 0))
-    {
-        UnityPrintPointlessAndBail();
-    }
+    if (num_elements == 0 || length == 0) UnityPrintPointlessAndBail();
 
     if (expected == actual) return; /* Both are NULL or same pointer */
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))

--- a/src/unity.h
+++ b/src/unity.h
@@ -72,7 +72,7 @@ void tearDown(void);
 
 /* It is not necessary for you to call PASS. A PASS condition is assumed if nothing fails.
  * This method allows you to abort a test immediately with a PASS state, ignoring the remainder of the test. */
-#define TEST_PASS()                                                                                longjmp(Unity.AbortFrame, 1)
+#define TEST_PASS()                                                                                TEST_ABORT()
 
 /*-------------------------------------------------------
  * Test Asserts (simple)

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -11,7 +11,9 @@
 #include "unity_config.h"
 #endif
 
+#ifndef UNITY_EXCLUDE_SETJMP_H
 #include <setjmp.h>
+#endif
 
 #ifndef UNITY_EXCLUDE_MATH_H
 #include <math.h>
@@ -371,7 +373,9 @@ struct UNITY_STORAGE_T
     UNITY_COUNTER_TYPE TestIgnores;
     UNITY_COUNTER_TYPE CurrentTestFailed;
     UNITY_COUNTER_TYPE CurrentTestIgnored;
+#ifndef UNITY_EXCLUDE_SETJMP_H
     jmp_buf AbortFrame;
+#endif
 };
 
 extern struct UNITY_STORAGE_T Unity;
@@ -534,9 +538,13 @@ extern const char UnityStrErr64[];
  * Test Running Macros
  *-------------------------------------------------------*/
 
+#ifndef UNITY_EXCLUDE_SETJMP_H
 #define TEST_PROTECT() (setjmp(Unity.AbortFrame) == 0)
-
 #define TEST_ABORT() longjmp(Unity.AbortFrame, 1)
+#else
+#define TEST_PROTECT() 1
+#define TEST_ABORT() return
+#endif
 
 /* This tricky series of macros gives us an optional line argument to treat it as RUN_TEST(func, num=__LINE__) */
 #ifndef RUN_TEST

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -536,7 +536,7 @@ extern const char UnityStrErr64[];
 
 #define TEST_PROTECT() (setjmp(Unity.AbortFrame) == 0)
 
-#define TEST_ABORT() {longjmp(Unity.AbortFrame, 1);}
+#define TEST_ABORT() longjmp(Unity.AbortFrame, 1)
 
 /* This tricky series of macros gives us an optional line argument to treat it as RUN_TEST(func, num=__LINE__) */
 #ifndef RUN_TEST

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -99,7 +99,9 @@ void testUnitySizeInitializationReminder(void)
         UNITY_COUNTER_TYPE TestIgnores;
         UNITY_COUNTER_TYPE CurrentTestFailed;
         UNITY_COUNTER_TYPE CurrentTestIgnored;
+#ifndef UNITY_EXCLUDE_SETJMP_H
         jmp_buf AbortFrame;
+#endif
     } _Expected_Unity;
 #else
     struct {
@@ -113,7 +115,9 @@ void testUnitySizeInitializationReminder(void)
         UNITY_COUNTER_TYPE TestIgnores;
         UNITY_COUNTER_TYPE CurrentTestFailed;
         UNITY_COUNTER_TYPE CurrentTestIgnored;
+#ifndef UNITY_EXCLUDE_SETJMP_H
         jmp_buf AbortFrame;
+#endif
     } _Expected_Unity;
 #endif
 


### PR DESCRIPTION
This option requires replacing all `longjmp` calls with `return`. Unity's control flow is different if a test fails **and** there is more code after the failing line. Instead of exiting immediately to `tearDown()`, the rest of the test executes first.
Since this is targeted for very constrained systems, the compromise seems realistic. It keeps this feature very simple, too. One can write tests to avoid side-effects, as appropriate.
Passing tests behave exactly the same.
A feature like this was brought up in the closed issue #181.

* Condense all `longjmp` calls into TEST_ABORT()
The `setjmp` calls are all in TEST_PROTECT() already
* Rename Array Check helper, always `return`, never `longjmp`
Move longjump inside caller, to functions returning `void`
This single function needed to change to allow optional `setjmp.h`
* Cleanup Assert Array idiom to be the same everywhere
* Option to exclude setjump/longjmp, `setjmp.h`
Using this option changes the control flow of Unity, but is useful on
constrained embedded systems. You can't fully simulate the power of
`longjmp` with just `return`, but Unity still works well, all tests pass.