### PR TITLE
Align definition and declaration of UnityPrintFloat

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -269,12 +269,17 @@ static void UnityPrintDecimalAndNumberWithLeadingZeros(UNITY_INT32 fraction_part
  *  else                                                 snprintf(buf, sizeof buf, "%.6f", number);
  *  UnityPrint(buf);
  */
-void UnityPrintFloat(UNITY_DOUBLE number)
+void UnityPrintFloat(const UNITY_DOUBLE input_number)
 {
-    if (number < 0)
+    UNITY_DOUBLE number;
+
+    if (input_number < 0)
     {
         UNITY_OUTPUT_CHAR('-');
-        number = -number;
+        number = -input_number;
+    } else
+    {
+        number = input_number;
     }
 
     if (isnan(number)) UnityPrint(UnityStrNaN);

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -427,7 +427,7 @@ void UnityPrintNumberUnsigned(const UNITY_UINT number);
 void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles);
 
 #ifndef UNITY_EXCLUDE_FLOAT_PRINT
-void UnityPrintFloat(const UNITY_DOUBLE number);
+void UnityPrintFloat(const UNITY_DOUBLE input_number);
 #endif
 
 /*-------------------------------------------------------


### PR DESCRIPTION
As reported in #256 there is a mismatch between declaration and definition of UnitPrintFloat. Removing const from the parameter, so that definition and declaration match.