### PR TITLE
Test for printing max width of a hex number, back to 100% test coverage

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ coverage: $(BUILD_DIR)/testunityRunner.c
 	cd $(BUILD_DIR) && \
 	$(CC) $(CFLAGS) $(DEFINES) $(foreach i,$(SRC), ../$i) $(COV_FLAGS) -o ../$(TARGET)
 	rm -f $(BUILD_DIR)/*.gcda
-	./$(TARGET) | grep Tests -A1
+	./$(TARGET) | grep 'Tests\|]]]' -A1
 	cd $(BUILD_DIR) && \
 	gcov unity.c | head -3
 	grep '###' $(BUILD_DIR)/unity.c.gcov -C2 || true
@@ -60,4 +60,4 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 clean:
-	rm -f $(BUILD_DIR)/$(TARGET) $(BUILD_DIR)/*.gc* $(BUILD_DIR)/testunityRunner.c
+	rm -f $(TARGET) $(BUILD_DIR)/*.gc* $(BUILD_DIR)/testunityRunner.c

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -2306,6 +2306,18 @@ void testCstringsEscapeSequence(void)
 #endif
 }
 
+void testHexPrintsUpToMaxNumberOfNibbles(void)
+{
+#ifndef USING_OUTPUT_SPY
+    TEST_IGNORE();
+#else
+    startPutcharSpy();
+    UnityPrintNumberHex(0xBEE, 21);
+    endPutcharSpy();
+    TEST_ASSERT_EQUAL_INT(sizeof(UNITY_INT)*2, strlen(getBufferPutcharSpy()));
+#endif
+}
+
 #define TEST_ASSERT_EQUAL_PRINT_NUMBERS(expected, actual) {             \
         startPutcharSpy(); UnityPrintNumber((actual)); endPutcharSpy(); \
         TEST_ASSERT_EQUAL_STRING((expected), getBufferPutcharSpy());    \


### PR DESCRIPTION
Correct `clean` target and print test fails during `coverage` in Makefile