### PR TITLE
Fixed typo for TEST_PROTECT in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example:
 
     main()
     {
-        if (TEST_PROTECT() == 0)
+        if (TEST_PROTECT())
         {
             MyTest();
         }


### PR DESCRIPTION
`setjmp` returns 0 on direct invocation, and non-zero when returned to from `longjmp`. Because `TEST_PROTECT` checks the return value of `setjmp` against 0, checking the return value of `TEST_PROTECT` against 0 is incorrect in the readme.