### PR TITLE
Fix gcc warning with ubsan and -Wconversion

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -194,7 +194,7 @@ void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print)
     while (nibbles > 0)
     {
         nibbles--;
-        nibble = (number >> (nibbles * 4)) & 0x0F;
+        nibble = (int)(number >> (nibbles * 4)) & 0x0F;
         if (nibble <= 9)
         {
             UNITY_OUTPUT_CHAR((char)('0' + nibble));


### PR DESCRIPTION
This fixes a compiler warning about a lossy conversion from `long
unsigned int` to `int` when compiling unity with gcc 6.3.1 and
the options `-std=c89 -Wconversion -fsanitize=undefined`