### PR TITLE
Cleanup Greater than and Less than asserts from other PR (#264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Another way of calling TEST_ASSERT_EQUAL_INT
 Asserts that the actual value is within plus or minus delta of the expected value.  This also comes in
 size specific variants.
 
+
+    TEST_ASSERT_GREATER_THAN(threshold, actual)
+
+Asserts that the actual value is greater than the threshold. This also comes in size specific variants.
+
+
+    TEST_ASSERT_LESS_THAN(threshold, actual)
+
+Asserts that the actual value is less than the threshold. This also comes in size specific variants.
+
+
 Arrays
 ------
 

--- a/docs/UnityAssertionsReference.md
+++ b/docs/UnityAssertionsReference.md
@@ -290,6 +290,60 @@ Asserts the specified bit of the `actual` parameter is high.
 
 Asserts the specified bit of the `actual` parameter is low.
 
+### Integer Less Than / Greater Than
+
+These assertions verify that the `actual` parameter is less than or greater
+than `threshold` (exclusive). For example, if the threshold value is 0 for the
+greater than assertion will fail if it is 0 or less.
+
+##### `TEST_ASSERT_GREATER_THAN (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_INT (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_INT8 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_INT16 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_INT32 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_UINT (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_UINT8 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_UINT16 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_UINT32 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_HEX8 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_HEX16 (threshold, actual)`
+
+##### `TEST_ASSERT_GREATER_THAN_HEX32 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_INT (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_INT8 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_INT16 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_INT32 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_UINT (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_UINT8 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_UINT16 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_UINT32 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_HEX8 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_HEX16 (threshold, actual)`
+
+##### `TEST_ASSERT_LESS_THAN_HEX32 (threshold, actual)`
+
 
 ### Integer Ranges (of all sizes)
 

--- a/src/unity.c
+++ b/src/unity.c
@@ -27,6 +27,8 @@ static const char UnityStrNull[]                   = "NULL";
 static const char UnityStrSpacer[]                 = ". ";
 static const char UnityStrExpected[]               = " Expected ";
 static const char UnityStrWas[]                    = " Was ";
+static const char UnityStrGt[]                     = " to be greater than ";
+static const char UnityStrLt[]                     = " to be less than ";
 static const char UnityStrElement[]                = " Element ";
 static const char UnityStrByte[]                   = " Byte ";
 static const char UnityStrMemory[]                 = " Memory Mismatch.";
@@ -525,6 +527,50 @@ void UnityAssertEqualNumber(const UNITY_INT expected,
         UNITY_FAIL_AND_BAIL;
     }
 }
+
+/*-----------------------------------------------*/
+void UnityAssertGreaterNumber(const UNITY_INT threshold,
+                              const UNITY_INT actual,
+                              const char *msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (!(actual > threshold))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(actual, style);
+        UnityPrint(UnityStrGt);
+        UnityPrintNumberByStyle(threshold, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertSmallerNumber(const UNITY_INT threshold,
+                              const UNITY_INT actual,
+                              const char *msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (!(actual < threshold))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(actual, style);
+        UnityPrint(UnityStrLt);
+        UnityPrintNumberByStyle(threshold, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+
 
 #define UnityPrintPointlessAndBail()       \
 {                                          \

--- a/src/unity.h
+++ b/src/unity.h
@@ -114,6 +114,35 @@ void tearDown(void);
 #define TEST_ASSERT_BIT_HIGH(bit, actual)                                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, NULL)
 #define TEST_ASSERT_BIT_LOW(bit, actual)                                                           UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, NULL)
 
+/* Integer Greater Than/ Less Than (of all sizes) */
+#define TEST_ASSERT_GREATER_THAN(threshold, actual)                                                UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT(threshold, actual)                                            UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT8(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT16(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT32(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT8(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT16(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT32(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX8(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX16(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX32(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX32((threshold), (actual), __LINE__, NULL)
+
+
+#define TEST_ASSERT_LESS_THAN(threshold, actual)                                                   UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT(threshold, actual)                                               UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT8(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT16(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT32(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT8(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT16(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT32(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX8(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX16(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX32(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX32((threshold), (actual), __LINE__, NULL)
+
+
 /* Integer Ranges (of all sizes) */
 #define TEST_ASSERT_INT_WITHIN(delta, expected, actual)                                            UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
 #define TEST_ASSERT_INT8_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_INT8_WITHIN((delta), (expected), (actual), __LINE__, NULL)
@@ -156,6 +185,8 @@ void tearDown(void);
 #define TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements)                        UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((expected), (actual), (len), (num_elements), __LINE__, NULL)
+
+
 
 /* Arrays Compared To Single Value */
 #define TEST_ASSERT_EACH_EQUAL_INT(expected, actual, num_elements)                                 UNITY_TEST_ASSERT_EACH_EQUAL_INT((expected), (actual), (num_elements), __LINE__, NULL)
@@ -240,6 +271,35 @@ void tearDown(void);
 #define TEST_ASSERT_BITS_LOW_MESSAGE(mask, actual, message)                                        UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(0), (actual), __LINE__, (message))
 #define TEST_ASSERT_BIT_HIGH_MESSAGE(bit, actual, message)                                         UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, (message))
 #define TEST_ASSERT_BIT_LOW_MESSAGE(bit, actual, message)                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, (message))
+
+/* Integer Greater Than/ Less Than (of all sizes) */
+#define TEST_ASSERT_GREATER_THAN_MESSAGE(threshold, actual, message)                               UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT8_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT16_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT32_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT8_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT16_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT32_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX8_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX16_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX32_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX32((threshold), (actual), __LINE__, (message))
+
+
+#define TEST_ASSERT_LESS_THAN_MESSAGE(threshold, actual, message)                                  UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT_MESSAGE(threshold, actual, message)                              UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT8_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT16_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT32_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX32((threshold), (actual), __LINE__, (message))
+
 
 /* Integer Ranges (of all sizes) */
 #define TEST_ASSERT_INT_WITHIN_MESSAGE(delta, expected, actual, message)                           UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, (message))

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -455,6 +455,18 @@ void UnityAssertEqualNumber(const UNITY_INT expected,
                             const UNITY_LINE_TYPE lineNumber,
                             const UNITY_DISPLAY_STYLE_T style);
 
+void UnityAssertGreaterNumber(const UNITY_INT threshold,
+                            const UNITY_INT actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_DISPLAY_STYLE_T style);
+
+void UnityAssertSmallerNumber(const UNITY_INT threshold,
+                            const UNITY_INT actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_DISPLAY_STYLE_T style);
+
 void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
                               UNITY_INTERNAL_PTR actual,
                               const UNITY_UINT32 num_elements,
@@ -651,6 +663,34 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_EQUAL_HEX16(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
 #define UNITY_TEST_ASSERT_EQUAL_HEX32(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
 #define UNITY_TEST_ASSERT_BITS(mask, expected, actual, line, message)                            UnityAssertBits((UNITY_INT)(mask), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line))
+
+
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT8(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT16(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT32(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT8(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT16(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT32(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX8(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX16(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX32(threshold, actual, line, message)               UnityAssertGreaterNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+
+
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT8(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT16(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT32(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT8(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT16(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT32(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX8(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX16(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX32(threshold, actual, line, message)               UnityAssertSmallerNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+
+
 
 #define UNITY_TEST_ASSERT_INT_WITHIN(delta, expected, actual, line, message)                     UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
 #define UNITY_TEST_ASSERT_INT8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -764,8 +764,9 @@ void testNotEqualBitsLow(void)
     EXPECT_ABORT_BEGIN
     TEST_ASSERT_BITS_LOW(v0, v1);
     VERIFY_FAILS_END
-
 }
+
+
 void testEqualShorts(void)
 {
     short v0, v1;
@@ -1305,6 +1306,415 @@ void testINT8sNotWithinDeltaAndCustomMessage(void)
     VERIFY_FAILS_END
 }
 
+
+//-----------------
+void testGreaterThan(void)
+{
+    UNITY_INT v0, v1;
+    UNITY_INT *p0, *p1;
+
+    v0 = 0;
+    v1 = 1;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN(v0, v1);
+    TEST_ASSERT_GREATER_THAN(*p0, v1);
+    TEST_ASSERT_GREATER_THAN(v0, *p1);
+    TEST_ASSERT_GREATER_THAN(*p0, *p1);
+}
+
+void testGreaterThanINT(void)
+{
+    UNITY_INT v0, v1;
+    UNITY_INT *p0, *p1;
+
+    v0 = 302;
+    v1 = 3334;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_INT(v0, v1);
+    TEST_ASSERT_GREATER_THAN_INT(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_INT(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_INT(*p0, *p1);
+}
+
+
+void testGreaterThanINT8(void)
+{
+    UNITY_INT8 v0, v1;
+    UNITY_INT8 *p0, *p1;
+
+    v0 = -128;
+    v1 = 127;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_INT8(v0, v1);
+    TEST_ASSERT_GREATER_THAN_INT8(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_INT8(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_INT8(*p0, *p1);
+}
+
+void testGreaterThanINT16(void)
+{
+    UNITY_INT16 v0, v1;
+    UNITY_INT16 *p0, *p1;
+
+    v0 = -32768;
+    v1 = 32767;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_INT16(v0, v1);
+    TEST_ASSERT_GREATER_THAN_INT16(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_INT16(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_INT16(*p0, *p1);
+}
+
+void testGreaterThanINT32(void)
+{
+    UNITY_INT32 v0, v1;
+    UNITY_INT32 *p0, *p1;
+
+    v0 = -214783648;
+    v1 = 214783647;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_INT32(v0, v1);
+    TEST_ASSERT_GREATER_THAN_INT32(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_INT32(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_INT32(*p0, *p1);
+}
+
+void testGreaterThanUINT(void)
+{
+    UNITY_UINT v0, v1;
+    UNITY_UINT *p0, *p1;
+
+    v0 = 0;
+    v1 = 1;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_UINT(v0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_UINT(*p0, *p1);
+}
+
+
+void testGreaterThanUINT8(void)
+{
+    UNITY_UINT8 v0, v1;
+    UNITY_UINT8 *p0, *p1;
+
+    v0 = 0;
+    v1 = 255;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_UINT8(v0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT8(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT8(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_UINT8(*p0, *p1);
+}
+
+void testGreaterThanUINT16(void)
+{
+    UNITY_UINT16 v0, v1;
+    UNITY_UINT16 *p0, *p1;
+
+    v0 = 0;
+    v1 = 65535;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_UINT16(v0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT16(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT16(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_UINT16(*p0, *p1);
+}
+
+void testGreaterThanUINT32(void)
+{
+    UNITY_UINT32 v0, v1;
+    UNITY_UINT32 *p0, *p1;
+
+    v0 = 0;
+    v1 = 4294967295;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_UINT32(v0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT32(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_UINT32(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_UINT32(*p0, *p1);
+}
+
+void testGreaterThanHEX8(void)
+{
+    UNITY_UINT8 v0, v1;
+    UNITY_UINT8 *p0, *p1;
+
+    v0 = 0x00;
+    v1 = 0xFF;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_HEX8(v0, v1);
+    TEST_ASSERT_GREATER_THAN_HEX8(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_HEX8(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_HEX8(*p0, *p1);
+}
+
+void testGreaterThanHEX16(void)
+{
+    UNITY_UINT16 v0, v1;
+    UNITY_UINT16 *p0, *p1;
+
+    v0 = 0x0000;
+    v1 = 0xFFFF;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_HEX16(v0, v1);
+    TEST_ASSERT_GREATER_THAN_HEX16(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_HEX16(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_HEX16(*p0, *p1);
+}
+
+void testGreaterThanHEX32(void)
+{
+    UNITY_UINT32 v0, v1;
+    UNITY_UINT32 *p0, *p1;
+
+    v0 = 0x00000000;
+    v1 = 0xFFFFFFFF;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_GREATER_THAN_HEX32(v0, v1);
+    TEST_ASSERT_GREATER_THAN_HEX32(*p0, v1);
+    TEST_ASSERT_GREATER_THAN_HEX32(v0, *p1);
+    TEST_ASSERT_GREATER_THAN_HEX32(*p0, *p1);
+}
+
+
+void testNotGreaterThan(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_GREATER_THAN(0, -1);
+    VERIFY_FAILS_END
+}
+
+void testLessThan(void)
+{
+    UNITY_INT v0, v1;
+    UNITY_INT *p0, *p1;
+
+    v0 = 0;
+    v1 = -1;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN(v0, v1);
+    TEST_ASSERT_LESS_THAN(*p0, v1);
+    TEST_ASSERT_LESS_THAN(v0, *p1);
+    TEST_ASSERT_LESS_THAN(*p0, *p1);
+}
+
+void testLessThanINT(void)
+{
+    UNITY_INT v0, v1;
+    UNITY_INT *p0, *p1;
+
+    v0 = 3334;
+    v1 = 302;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_INT(v0, v1);
+    TEST_ASSERT_LESS_THAN_INT(*p0, v1);
+    TEST_ASSERT_LESS_THAN_INT(v0, *p1);
+    TEST_ASSERT_LESS_THAN_INT(*p0, *p1);
+}
+
+
+void testLessThanINT8(void)
+{
+    UNITY_INT8 v0, v1;
+    UNITY_INT8 *p0, *p1;
+
+    v0 = 127;
+    v1 = -128;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_INT8(v0, v1);
+    TEST_ASSERT_LESS_THAN_INT8(*p0, v1);
+    TEST_ASSERT_LESS_THAN_INT8(v0, *p1);
+    TEST_ASSERT_LESS_THAN_INT8(*p0, *p1);
+}
+
+void testLessThanINT16(void)
+{
+    UNITY_INT16 v0, v1;
+    UNITY_INT16 *p0, *p1;
+
+    v0 = 32767;
+    v1 = -32768;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_INT16(v0, v1);
+    TEST_ASSERT_LESS_THAN_INT16(*p0, v1);
+    TEST_ASSERT_LESS_THAN_INT16(v0, *p1);
+    TEST_ASSERT_LESS_THAN_INT16(*p0, *p1);
+}
+
+void testLessThanINT32(void)
+{
+    UNITY_INT32 v0, v1;
+    UNITY_INT32 *p0, *p1;
+
+    v0 = 214783647;
+    v1 = -214783648;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_INT32(v0, v1);
+    TEST_ASSERT_LESS_THAN_INT32(*p0, v1);
+    TEST_ASSERT_LESS_THAN_INT32(v0, *p1);
+    TEST_ASSERT_LESS_THAN_INT32(*p0, *p1);
+}
+
+void testLessThanUINT(void)
+{
+    UNITY_UINT v0, v1;
+    UNITY_UINT *p0, *p1;
+
+    v0 = 1;
+    v1 = 0;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_UINT(v0, v1);
+    TEST_ASSERT_LESS_THAN_UINT(*p0, v1);
+    TEST_ASSERT_LESS_THAN_UINT(v0, *p1);
+    TEST_ASSERT_LESS_THAN_UINT(*p0, *p1);
+}
+
+
+void testLessThanUINT8(void)
+{
+    UNITY_UINT8 v0, v1;
+    UNITY_UINT8 *p0, *p1;
+
+    v0 = 255;
+    v1 = 0;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_UINT8(v0, v1);
+    TEST_ASSERT_LESS_THAN_UINT8(*p0, v1);
+    TEST_ASSERT_LESS_THAN_UINT8(v0, *p1);
+    TEST_ASSERT_LESS_THAN_UINT8(*p0, *p1);
+}
+
+void testLessThanUINT16(void)
+{
+    UNITY_UINT16 v0, v1;
+    UNITY_UINT16 *p0, *p1;
+
+    v0 = 65535;
+    v1 = 0;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_UINT16(v0, v1);
+    TEST_ASSERT_LESS_THAN_UINT16(*p0, v1);
+    TEST_ASSERT_LESS_THAN_UINT16(v0, *p1);
+    TEST_ASSERT_LESS_THAN_UINT16(*p0, *p1);
+}
+
+void testLessThanUINT32(void)
+{
+    UNITY_UINT32 v0, v1;
+    UNITY_UINT32 *p0, *p1;
+
+    v0 = 4294967295;
+    v1 = 0;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_UINT32(v0, v1);
+    TEST_ASSERT_LESS_THAN_UINT32(*p0, v1);
+    TEST_ASSERT_LESS_THAN_UINT32(v0, *p1);
+    TEST_ASSERT_LESS_THAN_UINT32(*p0, *p1);
+}
+
+void testLessThanHEX8(void)
+{
+    UNITY_UINT8 v0, v1;
+    UNITY_UINT8 *p0, *p1;
+
+    v0 = 0xFF;
+    v1 = 0x00;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_HEX8(v0, v1);
+    TEST_ASSERT_LESS_THAN_HEX8(*p0, v1);
+    TEST_ASSERT_LESS_THAN_HEX8(v0, *p1);
+    TEST_ASSERT_LESS_THAN_HEX8(*p0, *p1);
+}
+
+void testLessThanHEX16(void)
+{
+    UNITY_UINT16 v0, v1;
+    UNITY_UINT16 *p0, *p1;
+
+    v0 = 0xFFFF;
+    v1 = 0x0000;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_HEX16(v0, v1);
+    TEST_ASSERT_LESS_THAN_HEX16(*p0, v1);
+    TEST_ASSERT_LESS_THAN_HEX16(v0, *p1);
+    TEST_ASSERT_LESS_THAN_HEX16(*p0, *p1);
+}
+
+void testLessThanHEX32(void)
+{
+    UNITY_UINT32 v0, v1;
+    UNITY_UINT32 *p0, *p1;
+
+    v0 = 0xFFFFFFFF;
+    v1 = 0x00000000;
+    p0 = &v0;
+    p1 = &v1;
+
+    TEST_ASSERT_LESS_THAN_HEX32(v0, v1);
+    TEST_ASSERT_LESS_THAN_HEX32(*p0, v1);
+    TEST_ASSERT_LESS_THAN_HEX32(v0, *p1);
+    TEST_ASSERT_LESS_THAN_HEX32(*p0, *p1);
+}
+
+
+void testNotLessThan(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_LESS_THAN(0, 1);
+    VERIFY_FAILS_END
+}
+
+
+
+//-----------------
 void testEqualStrings(void)
 {
     const char *testString = "foo";


### PR DESCRIPTION
This is a clean up and integration of #264 . There are a few key differences including:


- Added tests
- Added docs
- Added message & size variants for each
- Switched comparison in assertion so it fits better with the rest of the asserts. I.E. TEST_ASSERT_GREATER_THAN(0, 1) asserting true rather than  TEST_ASSERT_GREATER_THAN(1, 0) which was in the original PR.