### PR TITLE
Allow specifying custom header declaration

### DIFF
--- a/examples/unity_config.h
+++ b/examples/unity_config.h
@@ -201,10 +201,12 @@
  * `stdout` option. You decide to route your test result output to a custom
  * serial `RS232_putc()` function you wrote like thus:
  */
-/* #define UNITY_OUTPUT_CHAR(a)    RS232_putc(a) */
-/* #define UNITY_OUTPUT_FLUSH()    RS232_flush() */
-/* #define UNITY_OUTPUT_START()    RS232_config(115200,1,8,0) */
-/* #define UNITY_OUTPUT_COMPLETE() RS232_close() */
+/* #define UNITY_OUTPUT_CHAR(a)                    RS232_putc(a) */
+/* #define UNITY_OUTPUT_CHAR_HEADER_DECLARATION    RS232_putc(int) */
+/* #define UNITY_OUTPUT_FLUSH()                    RS232_flush() */
+/* #define UNITY_OUTPUT_FLUSH_HEADER_DECLARATION   RS232_flush(void) */
+/* #define UNITY_OUTPUT_START()                    RS232_config(115200,1,8,0) */
+/* #define UNITY_OUTPUT_COMPLETE()                 RS232_close() */
 
 /* For some targets, Unity can make the otherwise required `setUp()` and
  * `tearDown()` functions optional. This is a nice convenience for test writers

--- a/extras/fixture/rakefile_helper.rb
+++ b/extras/fixture/rakefile_helper.rb
@@ -53,7 +53,7 @@ module RakefileHelpers
     defines = if $cfg['compiler']['defines']['items'].nil?
                 ''
               else
-                squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'] + ['UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar'])
+                squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'] + ['UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar'] + ['UNITY_OUTPUT_CHAR_HEADER_DECLARATION=UnityOutputCharSpy_OutputChar\(int\)'])
               end
     options  = squash('', $cfg['compiler']['options'])
     includes = squash($cfg['compiler']['includes']['prefix'], $cfg['compiler']['includes']['items'])

--- a/extras/fixture/test/Makefile
+++ b/extras/fixture/test/Makefile
@@ -6,6 +6,7 @@ endif
 CFLAGS += -std=c99 -pedantic -Wall -Wextra -Werror
 CFLAGS += $(DEBUG)
 DEFINES = -D UNITY_OUTPUT_CHAR=UnityOutputCharSpy_OutputChar
+DEFINES += -D UNITY_OUTPUT_CHAR_HEADER_DECLARATION=UnityOutputCharSpy_OutputChar\(int\)
 SRC = ../src/unity_fixture.c \
       ../../../src/unity.c   \
       unity_fixture_Test.c   \

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -246,8 +246,8 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
 #define UNITY_OUTPUT_CHAR(a) (void)putchar(a)
 #else
   /* If defined as something else, make sure we declare it here so it's ready for use */
-  #ifndef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
-extern void UNITY_OUTPUT_CHAR(int);
+  #ifdef UNITY_OUTPUT_CHAR_HEADER_DECLARATION
+extern void UNITY_OUTPUT_CHAR_HEADER_DECLARATION;
   #endif
 #endif
 
@@ -255,22 +255,22 @@ extern void UNITY_OUTPUT_CHAR(int);
 #ifdef UNITY_USE_FLUSH_STDOUT
 /* We want to use the stdout flush utility */
 #include <stdio.h>
-#define UNITY_OUTPUT_FLUSH (void)fflush(stdout)
+#define UNITY_OUTPUT_FLUSH() (void)fflush(stdout)
 #else
 /* We've specified nothing, therefore flush should just be ignored */
-#define UNITY_OUTPUT_FLUSH
+#define UNITY_OUTPUT_FLUSH()
 #endif
 #else
 /* We've defined flush as something else, so make sure we declare it here so it's ready for use */
-#ifndef UNITY_OMIT_OUTPUT_FLUSH_HEADER_DECLARATION
-extern void UNITY_OUTPUT_FLUSH(void);
+#ifdef UNITY_OUTPUT_FLUSH_HEADER_DECLARATION
+extern void UNITY_OMIT_OUTPUT_FLUSH_HEADER_DECLARATION;
 #endif
 #endif
 
 #ifndef UNITY_OUTPUT_FLUSH
 #define UNITY_FLUSH_CALL()
 #else
-#define UNITY_FLUSH_CALL() UNITY_OUTPUT_FLUSH
+#define UNITY_FLUSH_CALL() UNITY_OUTPUT_FLUSH()
 #endif
 
 #ifndef UNITY_PRINT_EOL

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,7 @@ CFLAGS += -Wbad-function-cast -Wcast-qual -Wold-style-definition -Wshadow -Wstri
 #DEBUG = -O0 -g
 CFLAGS += $(DEBUG)
 DEFINES =  -D UNITY_OUTPUT_CHAR=putcharSpy
+DEFINES += -D UNITY_OUTPUT_CHAR_HEADER_DECLARATION=putcharSpy\(int\)
 DEFINES += -D UNITY_SUPPORT_64 -D UNITY_INCLUDE_DOUBLE
 SRC = ../src/unity.c tests/testunity.c build/testunityRunner.c
 INC_DIR = -I ../src

--- a/test/rakefile_helper.rb
+++ b/test/rakefile_helper.rb
@@ -91,7 +91,7 @@ module RakefileHelpers
     defines = if $cfg['compiler']['defines']['items'].nil?
                 ''
               else
-                squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'] + ['UNITY_OUTPUT_CHAR=putcharSpy'] + inject_defines)
+                squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'] + ['UNITY_OUTPUT_CHAR=putcharSpy'] + ['UNITY_OUTPUT_CHAR_HEADER_DECLARATION=putcharSpy\(int\)'] + inject_defines)
               end
     options = squash('', $cfg['compiler']['options'])
     includes = squash($cfg['compiler']['includes']['prefix'], $cfg['compiler']['includes']['items'])


### PR DESCRIPTION
Currently when you define custom `UNITY_OUTPUT_FLUSH` without `UNITY_OMIT_OUTPUT_FLUSH_HEADER_DECLARATION` you add a declaration of the flush function. That causes a compilation problem.
For example:
```c
#define UNITY_OUTPUT_FLUSH()    RS232_flush()
```
Then we get the following declaration:
```c
extern void UNITY_OUTPUT_FLUSH(void)
```
That result is the following error:
```
error: macro "UNITY_OUTPUT_FLUSH" passed 1 arguments, but takes just 0
 extern void UNITY_OUTPUT_FLUSH(void);
```


The `UNITY_OUTPUT_CHAR` declaration actually works because when you define:
```c
#define UNITY_OUTPUT_CHAR(a)    RS232_putc(a)
```
The declaration works because:
```c
extern void UNITY_OUTPUT_CHAR(int)
```
is being translated to:
```c
extern void RS232_putc(int)
```

We can probably solve that problem with a patch by changing:
```c
extern void UNITY_OUTPUT_FLUSH(void);
```
to:
```c
extern void UNITY_OUTPUT_FLUSH();
```

I suggest making a bigger change that will allow more flexibility by changing `UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION` and `UNITY_OMIT_OUTPUT_FLUSH_HEADER_DECLARATION` to `UNITY_OUTPUT_CHAR_HEADER_DECLARATION` and `UNITY_OMIT_OUTPUT_FLUSH_HEADER_DECLARATION` thus allowing any function declaration.