### PR TITLE
Allow test to assert that expectations so far have been met

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -217,7 +217,7 @@ class UnityTestRunnerGenerator
     end
     output.puts("}\n")
 
-    output.puts('static void CMock_Verify(void)')
+    output.puts('void CMock_Verify(void)')
     output.puts('{')
     mocks.each do |mock|
       mock_clean = TypeSanitizer.sanitize_c_identifier(mock)

--- a/src/unity.h
+++ b/src/unity.h
@@ -332,6 +332,8 @@ void tearDown(void);
 #define TEST_ASSERT_DOUBLE_IS_NOT_NAN_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN((actual), __LINE__, (message))
 #define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, (message))
 
+#define TEST_ASSERT_EXPECTATIONS_MET()                                                             do { UNITY_LINE_TYPE _old_line = Unity.CurrentTestLineNumber; Unity.CurrentTestLineNumber = __LINE__; CMock_Verify(); Unity.CurrentTestLineNumber = _old_line;} while (0)
+
 /* end of UNITY_FRAMEWORK_H */
 #ifdef __cplusplus
 }

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -402,6 +402,7 @@ void UnityBegin(const char* filename);
 int  UnityEnd(void);
 void UnityConcludeTest(void);
 void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum);
+void CMock_Verify(void);
 
 /*-------------------------------------------------------
  * Details Support


### PR DESCRIPTION
For debugging a failing test with a lot of expects, I frequently would like to be able to assert that all the expects I have set up so far have been met, rather than waiting until the end of the test. Since usually if an expect is not met I just get the line number of the test, it can be hard to tell how far through the test got before the missing expectation.

This is not a complete pull request, just a demonstration of how my proposed feature could potentially work - looking for input on the best way to implement it, which header file to put it in, what to call it and so on. Please let me know how you would like it done and I will clean it up before you pull.