### PR TITLE
Color test results using ANSI escape codes

### DIFF
--- a/docs/UnityConfigurationGuide.md
+++ b/docs/UnityConfigurationGuide.md
@@ -337,6 +337,13 @@ things anyway, though... so this option exists for those situations.
 _Example:_
         #define UNITY_EXCLUDE_SETJMP
 
+##### `UNITY_OUTPUT_COLOR`
+
+If you want to add color using ANSI escape codes you can use this define.
+t
+_Example:_
+        #define UNITY_OUTPUT_COLOR
+
 
 
 ## Getting Into The Guts

--- a/src/unity.c
+++ b/src/unity.c
@@ -19,10 +19,17 @@ void UNITY_OUTPUT_CHAR(int);
 
 struct UNITY_STORAGE_T Unity;
 
+#ifdef UNITY_OUTPUT_COLOR
+static const char UnityStrOk[]                     = "\033[42mOK\033[00m";
+static const char UnityStrPass[]                   = "\033[42mPASS\033[00m";
+static const char UnityStrFail[]                   = "\033[41mFAIL\033[00m";
+static const char UnityStrIgnore[]                 = "\033[43mIGNORE\033[00m";
+#else
 static const char UnityStrOk[]                     = "OK";
 static const char UnityStrPass[]                   = "PASS";
 static const char UnityStrFail[]                   = "FAIL";
 static const char UnityStrIgnore[]                 = "IGNORE";
+#endif
 static const char UnityStrNull[]                   = "NULL";
 static const char UnityStrSpacer[]                 = ". ";
 static const char UnityStrExpected[]               = " Expected ";
@@ -83,6 +90,18 @@ void UnityPrint(const char* string)
                 UNITY_OUTPUT_CHAR('\\');
                 UNITY_OUTPUT_CHAR('n');
             }
+#ifdef UNITY_OUTPUT_COLOR
+            /* print ANSI escape code */
+            else if (*pch == 27 && *(pch + 1) == '[')
+            {
+                while (*pch && *pch != 'm')
+                {
+                    UNITY_OUTPUT_CHAR(*pch);
+                    pch++;
+                }
+                UNITY_OUTPUT_CHAR('m');
+            }
+#endif
             /* unprintable characters are shown as codes */
             else
             {


### PR DESCRIPTION
Help error detection by adding specific colors for test results. This
behavior is activated only when unity if compiled with UNITY_COLOR flag.

-----

This small modification really helped me to detect errors on a serial terminal on Windows for test executed on an embedded target. On my Unix terminal, the colored tests look like this (I modified a test to get an error, dont panic !)

![unity_colored_tests_screenshot](https://user-images.githubusercontent.com/676719/31772939-69eb9c16-b4e1-11e7-949e-2c465c22128d.png)

If you think this feature is not in Unity philosophy no problem, I would perfectly understand. If you think it's a good idea but need modifications, I will be glad to modify my code until it's perfect for you.

Thanks for your great framework,


Victor