### PR TITLE
Test runner generation: Wrap setjmp.h inclusion in ifdefs

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -162,7 +162,9 @@ class UnityTestRunnerGenerator
     output.puts('#endif')
     output.puts("#include \"#{@options[:framework]}.h\"")
     output.puts('#include "cmock.h"') unless mocks.empty?
+    output.puts('#ifndef UNITY_EXCLUDE_SETJMP_H')
     output.puts('#include <setjmp.h>')
+    output.puts("#endif")
     output.puts('#include <stdio.h>')
     if @options[:defines] && !@options[:defines].empty?
       @options[:defines].each { |d| output.puts("#define #{d}") }


### PR DESCRIPTION
Auto generated test runner should generate a code  which includes
setjmp.h only if UNITY_EXCLUDE_SETJMP_H is not defined