### PR TITLE
Fix unsigned integer underflow in UnityAssertEqualIntArray

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -556,7 +556,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
         UNITY_FAIL_AND_BAIL;
 
-    while (elements--)
+    while ((elements > 0) && elements--)
     {
         UNITY_INT expect_val;
         UNITY_INT actual_val;


### PR DESCRIPTION
This was caught by using Clang's integer/undefined behaviour sanitizer.

The error was like so -
```
unity.c:559:20: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'UNITY_UINT32' (aka 'unsigned int')
```