### PR TITLE
Some minor changes for parse_output.rb

### DIFF
--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -208,7 +208,7 @@ class ParseOutput
 
     return unless @xml_out
 
-    heading = '<testsuite name="' + @test_suite + '" tests="' + @total_tests.to_s + '" failures="' + test_fail.to_s + '"' + ' skips="' + test_ignore.to_s + '">'
+    heading = '<testsuite name="' + @test_suite.to_s + '" tests="' + @total_tests.to_s + '" failures="' + test_fail.to_s + '"' + ' skips="' + test_ignore.to_s + '">'
     @array_list.insert(0, heading)
     write_xml_output
   end

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -123,7 +123,7 @@ class ParseOutput
     return unless @xml_out
 
     @array_list.push '     <testcase classname="' + @test_suite + '" name="' + test_name + '">'
-    @array_list.push '            <failure type="ASSERT FAILED"> ' + reason + '</failure>'
+    @array_list.push '            <failure type="ASSERT FAILED">' + reason + '</failure>'
     @array_list.push '     </testcase>'
   end
 


### PR DESCRIPTION
If i understand correctly this is the script for the raw unity output to JUnit style xml and overall test summary. I modified the script in four different ways to get it working:

- The String split now works correctly didn't work correct on windows ("\") platforms and unix based ("/") platforms. 

- Removed the unnecessary whitespaces in the xml output, i needed this for the interpretation of the tools. It was really ugly and sometimes there were 2 whitespaces at front of a message. 

- Added support for the TEST_IGNORE() macro which outputs no message. This wasn't considered in the summary at all.

- Added the name property to the testsuite tag in the xml output for completeness reasons.