### PR TITLE
MISRA - param names match; macro params in parens

### DIFF
--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -78,6 +78,6 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
 #endif
 
 /* You must compile with malloc replacement, as defined in unity_fixture_malloc_overrides.h */
-void UnityMalloc_MakeMallocFailAfterCount(int count);
+void UnityMalloc_MakeMallocFailAfterCount(int countdown);
 
 #endif /* UNITY_FIXTURE_H_ */

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -24,7 +24,7 @@ extern struct UNITY_FIXTURE_T UnityFixture;
 
 typedef void unityfunction(void);
 void UnityTestRunner(unityfunction* setup,
-                     unityfunction* body,
+                     unityfunction* testBody,
                      unityfunction* teardown,
                      const char* printableName,
                      const char* group,
@@ -37,7 +37,7 @@ void UnityMalloc_EndTest(void);
 int UnityGetCommandLineOptions(int argc, const char* argv[]);
 void UnityConcludeFixtureTest(void);
 
-void UnityPointer_Set(void** ptr, void* newValue, UNITY_LINE_TYPE line);
+void UnityPointer_Set(void** pointer, void* newValue, UNITY_LINE_TYPE line);
 void UnityPointer_UndoAllSets(void);
 void UnityPointer_Init(void);
 #ifndef UNITY_MAX_POINTERS

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -442,9 +442,9 @@ void UnityPrint(const char* string);
 void UnityPrintLen(const char* string, const UNITY_UINT32 length);
 void UnityPrintMask(const UNITY_UINT mask, const UNITY_UINT number);
 void UnityPrintNumberByStyle(const UNITY_INT number, const UNITY_DISPLAY_STYLE_T style);
-void UnityPrintNumber(const UNITY_INT number);
+void UnityPrintNumber(const UNITY_INT number_to_print);
 void UnityPrintNumberUnsigned(const UNITY_UINT number);
-void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles);
+void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print);
 
 #ifndef UNITY_EXCLUDE_FLOAT_PRINT
 void UnityPrintFloat(const UNITY_DOUBLE input_number);
@@ -518,9 +518,9 @@ void UnityAssertNumbersWithin(const UNITY_UINT delta,
                               const UNITY_LINE_TYPE lineNumber,
                               const UNITY_DISPLAY_STYLE_T style);
 
-void UnityFail(const char* message, const UNITY_LINE_TYPE line);
+void UnityFail(const char* msg, const UNITY_LINE_TYPE line);
 
-void UnityIgnore(const char* message, const UNITY_LINE_TYPE line);
+void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line);
 
 #ifndef UNITY_EXCLUDE_FLOAT
 void UnityAssertFloatsWithin(const UNITY_FLOAT delta,


### PR DESCRIPTION
Fix a few small MISRA non-compliance issues:
* parameter name should match between declaration and definition.
* parentheses around all macro parameters