### PR TITLE
Add support for :mock_suffix

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -26,6 +26,7 @@ class UnityTestRunnerGenerator
       framework: :unity,
       test_prefix: 'test|spec|should',
       mock_prefix: 'Mock',
+      mock_suffix: '',
       setup_name: 'setUp',
       teardown_name: 'tearDown',
       main_name: 'main', # set to :auto to automatically generate each time
@@ -148,7 +149,7 @@ class UnityTestRunnerGenerator
     mock_headers = []
     includes.each do |include_path|
       include_file = File.basename(include_path)
-      mock_headers << include_path if include_file =~ /^#{@options[:mock_prefix]}/i
+      mock_headers << include_path if include_file =~ /^#{@options[:mock_prefix]}.*#{@options[:mock_suffix]}$/i
     end
     mock_headers
   end

--- a/docs/UnityHelperScriptsGuide.md
+++ b/docs/UnityHelperScriptsGuide.md
@@ -159,6 +159,12 @@ CMock (see CMock documentation). This generates extra variables required for
 everything to run smoothly. If you provide the same YAML to the generator as
 used in CMock's configuration, you've already configured the generator properly.
 
+##### `:mock_prefix` and `:mock_suffix`
+
+Unity automatically generates calls to Init, Verify and Destroy for every file
+included in the main test file that starts with the given mock prefix and ends
+with the given mock suffix, file extension not included. By default, Unity
+assumes a `Mock` prefix and no suffix.
 
 ##### `:plugins`
 


### PR DESCRIPTION
Adds support for `:mock_suffix` when generating mock setup and teardown
functions. Also documents both prefix and suffix in the helper script
guide.

I was not able to find any documentation for running the test suite, but I think this feature needs a couple of extra tests to make sure it picks up the mocks correctly.

I also couldn't find any documentation for this very convenient feature. I didn't know it existed before Unity started generating invalid mock-calls when I fed it a config file that sets the prefix to "".

Let me know if I've missed anything or if this needs additional changes. This issue is currently forcing us to manually call Init, Verify and Destroy on the mocks.