### PR TITLE
Flush unity output before a longjmp

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -14,8 +14,8 @@ void UNITY_OUTPUT_CHAR(int);
 #endif
 
 /* Helpful macros for us to use here in Assert functions */
-#define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; TEST_ABORT(); }
-#define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; TEST_ABORT(); }
+#define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; UNITY_OUTPUT_FLUSH(); TEST_ABORT(); }
+#define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; UNITY_OUTPUT_FLUSH(); TEST_ABORT(); }
 #define RETURN_IF_FAIL_OR_IGNORE if (Unity.CurrentTestFailed || Unity.CurrentTestIgnored) return
 
 struct UNITY_STORAGE_T Unity;


### PR DESCRIPTION
Flush the unity stdout buffer before calling TEST_ABORT().
This is because if TEST_PROTECT() has not previously been called this will cause a segmentation fault and the stdout buffer will fail to print

Although the segmentation fault will still occur, the error that caused it will at least be displayed