### PR TITLE
Added notes on _MESSAGE assertions in UnityAssertionsReference.md

### DIFF
--- a/docs/UnityAssertionsReference.md
+++ b/docs/UnityAssertionsReference.md
@@ -104,6 +104,15 @@ becomes messageified like thus...
 
     TEST_ASSERT_X_MESSAGE( {modifiers}, {expected}, actual, {size/count}, message )
 
+Notes:
+- The `_MESSAGE` variants intentionally do not support `printf` style formatting 
+  since many embedded projects don't support or avoid `printf` for various reasons.
+  It is possible to use `sprintf` before the assertion to assemble a complex fail
+  message, if necessary.
+- If you want to output a counter value within an assertion fail message (e.g. from 
+  a loop) , building up an array of results and then using one of the `_ARRAY` 
+  assertions (see below) might be a handy alternative to `sprintf`.
+
 
 #### TEST_ASSERT_X_ARRAY Variants
 


### PR DESCRIPTION
Added notes, why _MESSAGE assertions do not support printf style formatting and how users can work around this limitation with sprintf() or _ARRAY assertions (see #331).