### PR TITLE
Fix undefined behavior when printing INT_MIN/INT64_MIN.

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -183,7 +183,7 @@ void UnityPrintNumber(const UNITY_INT number_to_print)
     {
         /* A negative number, including MIN negative */
         UNITY_OUTPUT_CHAR('-');
-        number = (UNITY_UINT)(-number_to_print);
+        number = -number;
     }
     UnityPrintNumberUnsigned(number);
 }

--- a/src/unity.c
+++ b/src/unity.c
@@ -1019,22 +1019,22 @@ void UnityAssertNumbersWithin(const UNITY_UINT delta,
     {
         if (actual > expected)
         {
-            Unity.CurrentTestFailed = (UNITY_UINT)((UNITY_UINT)(actual - expected) > delta);
+            Unity.CurrentTestFailed = (((UNITY_UINT)actual - (UNITY_UINT)expected) > delta);
         }
         else
         {
-            Unity.CurrentTestFailed = (UNITY_UINT)((UNITY_UINT)(expected - actual) > delta);
+            Unity.CurrentTestFailed = (((UNITY_UINT)expected - (UNITY_UINT)actual) > delta);
         }
     }
     else
     {
         if ((UNITY_UINT)actual > (UNITY_UINT)expected)
         {
-            Unity.CurrentTestFailed = (UNITY_UINT)((UNITY_UINT)(actual - expected) > delta);
+            Unity.CurrentTestFailed = (((UNITY_UINT)actual - (UNITY_UINT)expected) > delta);
         }
         else
         {
-            Unity.CurrentTestFailed = (UNITY_UINT)((UNITY_UINT)(expected - actual) > delta);
+            Unity.CurrentTestFailed = (((UNITY_UINT)expected - (UNITY_UINT)actual) > delta);
         }
     }
 


### PR DESCRIPTION
Negating the most-negative signed integer results in overflow, which
is undefined behavior.  Fix this by casting to an unsigned type first
(unsigned overflow is well-defined as it uses modular arithmetic).