### PR TITLE
Execution time improvements

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -299,6 +299,7 @@ class UnityTestRunnerGenerator
     output.puts('  Unity.CurrentTestLineNumber = TestLineNum; \\')
     output.puts('  if (UnityTestMatches()) { \\') if @options[:cmdline_args]
     output.puts('  Unity.NumberOfTests++; \\')
+    output.puts('  UNITY_EXEC_TIME_START(); \\')
     output.puts('  CMock_Init(); \\') unless used_mocks.empty?
     output.puts('  UNITY_CLR_DETAILS(); \\') unless used_mocks.empty?
     output.puts('  if (TEST_PROTECT()) \\')
@@ -315,6 +316,7 @@ class UnityTestRunnerGenerator
     output.puts('    CMock_Verify(); \\') unless used_mocks.empty?
     output.puts('  } \\')
     output.puts('  CMock_Destroy(); \\') unless used_mocks.empty?
+    output.puts('  UNITY_EXEC_TIME_STOP(); \\')
     output.puts('  UnityConcludeTest(); \\')
     output.puts('  } \\') if @options[:cmdline_args]
     output.puts("}\n")

--- a/src/unity.c
+++ b/src/unity.c
@@ -599,7 +599,7 @@ void UnityConcludeTest(void)
 
     Unity.CurrentTestFailed = 0;
     Unity.CurrentTestIgnored = 0;
-    UNITY_EXEC_TIME_RESET();
+    UNITY_PRINT_EXEC_TIME();
     UNITY_PRINT_EOL();
     UNITY_FLUSH_CALL();
 }
@@ -1589,6 +1589,7 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
     Unity.CurrentTestLineNumber = (UNITY_LINE_TYPE)FuncLineNum;
     Unity.NumberOfTests++;
     UNITY_CLR_DETAILS();
+    UNITY_EXEC_TIME_START();
     if (TEST_PROTECT())
     {
         setUp();
@@ -1598,6 +1599,7 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
     {
         tearDown();
     }
+    UNITY_EXEC_TIME_STOP();
     UnityConcludeTest();
 }
 
@@ -1612,7 +1614,6 @@ void UnityBegin(const char* filename)
     Unity.TestIgnores = 0;
     Unity.CurrentTestFailed = 0;
     Unity.CurrentTestIgnored = 0;
-    UNITY_EXEC_TIME_RESET();
 
     UNITY_CLR_DETAILS();
     UNITY_OUTPUT_START();

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -104,8 +104,8 @@ void testUnitySizeInitializationReminder(void)
         UNITY_COUNTER_TYPE CurrentTestFailed;
         UNITY_COUNTER_TYPE CurrentTestIgnored;
 #ifdef UNITY_INCLUDE_EXEC_TIME
-        UNITY_COUNTER_TYPE CurrentTestStartTime;
-        UNITY_COUNTER_TYPE CurrentTestStopTime;
+        UNITY_TIME_TYPE CurrentTestStartTime;
+        UNITY_TIME_TYPE CurrentTestStopTime;
 #endif
 #ifndef UNITY_EXCLUDE_SETJMP_H
         jmp_buf AbortFrame;


### PR DESCRIPTION
Improvements to the execution time implementation:
- more portable, it is possible to override every macro where previously it was not
- auto test runner RUN_TEST will call the time macros
- default test runner will call the time macros
- detect windows/unix platform and provide a default implementation, previous default implementation only worked on windows
- for other platforms, time can be implemented by defining a single macro UNITY_CLOCK_MS