### PR TITLE
Redefine name of resetTest in generated runner

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -27,6 +27,7 @@ class UnityTestRunnerGenerator
       mock_suffix: '',
       setup_name: 'setUp',
       teardown_name: 'tearDown',
+      test_reset_name: 'resetTest',
       main_name: 'main', # set to :auto to automatically generate each time
       main_export_decl: '',
       cmdline_args: false,
@@ -322,8 +323,8 @@ class UnityTestRunnerGenerator
 
   def create_reset(output, used_mocks)
     output.puts("\n/*=======Test Reset Option=====*/")
-    output.puts('void resetTest(void);')
-    output.puts('void resetTest(void)')
+    output.puts("void #{@options[:test_reset_name]}(void);")
+    output.puts("void #{@options[:test_reset_name]}(void)")
     output.puts('{')
     output.puts('  CMock_Verify();') unless used_mocks.empty?
     output.puts('  CMock_Destroy();') unless used_mocks.empty?
@@ -457,6 +458,7 @@ if $0 == __FILE__
           '    --teardown_name=""    - redefine tearDown func name to something else',
           '    --main_name=""        - redefine main func name to something else',
           '    --test_prefix=""      - redefine test prefix from default test|spec|should',
+          '    --test_reset_name=""  - redefine resetTest func name to something else',
           '    --suite_setup=""      - code to execute for setup of entire suite',
           '    --suite_teardown=""   - code to execute for teardown of entire suite',
           '    --use_param_tests=1   - enable parameterized tests (disabled by default)',


### PR DESCRIPTION
This adds the ability to rename the extern function "resetTest" in the generated runner files.

This is to allow multiple runners to be compiled into the same executable.