### PR TITLE
Add support for strings in TEST_CASE()

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -90,12 +90,25 @@ class UnityTestRunnerGenerator
   def find_tests(source)
     tests_and_line_numbers = []
 
+    # contains characters which will be substituted from within strings, doing
+    # this prevents these characters from interferring with scrubbers
+    # @ is not a valid C character, so there should be no clashes with files genuinely containing these markers
+    substring_subs = { '{' => '@co@', '}' => '@cc@', ';' => '@ss@', '/' => '@fs@' }
+    substring_re = Regexp.union(substring_subs.keys)
+    substring_unsubs = substring_subs.invert                   # the inverse map will be used to fix the strings afterwords
+    substring_unsubs['@quote@'] = '\\"'
+    substring_unsubs['@apos@'] = '\\\''
+    substring_unre = Regexp.union(substring_unsubs.keys)
     source_scrubbed = source.clone
-    source_scrubbed = source_scrubbed.gsub(/"[^"\n]*"/, '') # remove things in strings
+    source_scrubbed = source_scrubbed.gsub(/\\"/, '@quote@')   # hide escaped quotes to allow capture of the full string/char
+    source_scrubbed = source_scrubbed.gsub(/\\'/, '@apos@')    # hide escaped apostrophes to allow capture of the full string/char
+    source_scrubbed = source_scrubbed.gsub(/("[^"\n]*")|('[^'\n]*')/) { |s| s.gsub(substring_re, substring_subs) } # temporarily hide problematic
+                                                                                                                   # characters within strings
     source_scrubbed = source_scrubbed.gsub(/\/\/.*$/, '')      # remove line comments
     source_scrubbed = source_scrubbed.gsub(/\/\*.*?\*\//m, '') # remove block comments
     lines = source_scrubbed.split(/(^\s*\#.*$)                 # Treat preprocessor directives as a logical line
                               | (;|\{|\}) /x)                  # Match ;, {, and } as end of lines
+                           .map { |line| line.gsub(substring_unre, substring_unsubs) } # unhide the problematic characters previously removed
 
     lines.each_with_index do |line, _index|
       # find tests

--- a/test/tests/testparameterized.c
+++ b/test/tests/testparameterized.c
@@ -46,6 +46,14 @@ void flushSpy(void) {}
 
 int SetToOneToFailInTearDown;
 int SetToOneMeanWeAlreadyCheckedThisGuy;
+static unsigned NextExpectedStringIndex;
+static unsigned NextExpectedCharIndex;
+
+void suiteSetUp(void)
+{
+    NextExpectedStringIndex = 0;
+    NextExpectedCharIndex = 0;
+}
 
 void setUp(void)
 {
@@ -111,3 +119,56 @@ void test_NormalFailsStillWork(void)
     TEST_ASSERT_TRUE(0);
     VERIFY_FAILS_END
 }
+
+TEST_CASE(0, "abc")
+TEST_CASE(1, "{")
+TEST_CASE(2, "}")
+TEST_CASE(3, ";")
+TEST_CASE(4, "\"quoted\"")
+void test_StringsArePreserved(unsigned index, const char * str)
+{
+    static const char * const expected[] = 
+    {
+        "abc",
+        "{",
+        "}",
+        ";",
+        "\"quoted\""
+    };
+
+    /* Ensure that no test cases are skipped by tracking the next expected index */
+    TEST_ASSERT_EQUAL_UINT32(NextExpectedStringIndex, index);
+    TEST_ASSERT_LESS_THAN(sizeof(expected) / sizeof(expected[0]), index);
+    TEST_ASSERT_EQUAL_STRING(expected[index], str);
+
+    NextExpectedStringIndex++;
+}
+
+TEST_CASE(0, 'x')
+TEST_CASE(1, '{')
+TEST_CASE(2, '}')
+TEST_CASE(3, ';')
+TEST_CASE(4, '\'')
+TEST_CASE(5, '"')
+void test_CharsArePreserved(unsigned index, char c)
+{
+    static const char expected[] =
+    {
+        'x',
+        '{',
+        '}',
+        ';',
+        '\'',
+        '"'
+    };
+
+    /* Ensure that no test cases are skipped by tracking the next expected index */
+    TEST_ASSERT_EQUAL_UINT32(NextExpectedCharIndex, index);
+    TEST_ASSERT_LESS_THAN(sizeof(expected) / sizeof(expected[0]), index);
+    TEST_ASSERT_EQUAL(expected[index], c);
+
+    NextExpectedCharIndex++;
+}
+
+
+


### PR DESCRIPTION
Modified generate_test_runner to support strings in parameterized tests

Fixes #361 #328 #282 