### PR TITLE
Generate runner defines with #ifndef guards

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -179,7 +179,7 @@ class UnityTestRunnerGenerator
     output.puts('#endif')
     output.puts('#include <stdio.h>')
     if @options[:defines] && !@options[:defines].empty?
-      @options[:defines].each { |d| output.puts("#define #{d}") }
+      @options[:defines].each { |d| output.puts("#ifndef #{d}\n#define #{d}\n#endif /* #{d} */") }
     end
     if @options[:header_file] && !@options[:header_file].empty?
       output.puts("#include \"#{File.basename(@options[:header_file])}\"")


### PR DESCRIPTION
This relates to https://github.com/ThrowTheSwitch/Ceedling/issues/255.  All this commit does is add a guard to any added defines. This prevents any redefinition so if the user accidentally defines it while compiling the file (like Ceedling does) it won't be a compiler warning.