### PR TITLE
Make unity.c compatible with c90

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1523,8 +1523,9 @@ int UnityParseOptions(int argc, char** argv)
 {
     UnityOptionIncludeNamed = NULL;
     UnityOptionExcludeNamed = NULL;
+    int i;
 
-    for (int i = 1; i < argc; i++)
+    for (i = 1; i < argc; i++)
     {
         if (argv[i][0] == '-')
         {


### PR DESCRIPTION
Avoid declaring the loop variable inside the for statement to keep
compatibility with c90:

unity.c:1408: error: for' loop initial declaration used outside C99 mode


Got a report from a user trying to compile for a very old unix ( https://github.com/zeromq/libzmq/issues/3371 ). This simple change is all that's required for C90 compatibility.