### PR TITLE
use unary minus on the incoming int instead of the casted uint

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -321,7 +321,7 @@ void UnityPrintNumber(const UNITY_INT number_to_print)
     {
         /* A negative number, including MIN negative */
         UNITY_OUTPUT_CHAR('-');
-        number = -number;
+        number = (UNITY_UINT)-number_to_print;
     }
     UnityPrintNumberUnsigned(number);
 }


### PR DESCRIPTION
This one causes an error with standard VS2017 settings.
/WX and probably -Werror on gcc/clang