### PR TITLE
Fix travis config: Use ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       compiler: gcc
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.1 && rvm use 2.1 && ruby -v; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.3 && rvm use 2.3 && ruby -v; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install --assume-yes --quiet gcc-multilib; fi
 install:
   - gem install rspec


### PR DESCRIPTION
Fixes the travis config so the OSX build can work again. Similar fix was needed for both Ceedling and CMock