### PR TITLE
Fixed maximum number of nibbles for processor where sizeof() operator…

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -352,9 +352,9 @@ void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print)
     int nibble;
     char nibbles = nibbles_to_print;
 
-    if ((unsigned)nibbles > (2 * sizeof(number)))
+    if ((unsigned)nibbles > UNITY_MAX_NIBBLES)
     {
-        nibbles = 2 * sizeof(number);
+        nibbles = UNITY_MAX_NIBBLES;
     }
 
     while (nibbles > 0)

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -122,18 +122,20 @@
  * 64-bit Support
  *-------------------------------------------------------*/
 
+/* Auto-detect 64 Bit Support */
 #ifndef UNITY_SUPPORT_64
   #if UNITY_LONG_WIDTH == 64 || UNITY_POINTER_WIDTH == 64
     #define UNITY_SUPPORT_64
   #endif
 #endif
 
+/* 64-Bit Support Dependent Configuration */
 #ifndef UNITY_SUPPORT_64
     /* No 64-bit Support */
     typedef UNITY_UINT32 UNITY_UINT;
     typedef UNITY_INT32 UNITY_INT;
+    #define UNITY_MAX_NIBBLES (8)  /* Maximum number of nibbles in a UNITY_(U)INT */
 #else
-
   /* 64-bit Support */
   #if (UNITY_LONG_WIDTH == 32)
     typedef unsigned long long UNITY_UINT64;
@@ -146,7 +148,7 @@
   #endif
     typedef UNITY_UINT64 UNITY_UINT;
     typedef UNITY_INT64 UNITY_INT;
-
+    #define UNITY_MAX_NIBBLES (16) /* Maximum number of nibbles in a UNITY_(U)INT */
 #endif
 
 /*-------------------------------------------------------


### PR DESCRIPTION
… doesn't return the size of a type in 8-bit bytes (e.g. the TI C2000 series). This patch makes the code more explicit and readable. 

See also: #394 #392 #403 