### PR TITLE
Expliticly show test failures of unequal strings

### DIFF
--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1852,6 +1852,20 @@ void testNotEqualStringLen_ActualStringIsNull(void)
     VERIFY_FAILS_END
 }
 
+void testNotEqualString_ExpectedStringIsLonger(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING("foo2", "foo");
+    VERIFY_FAILS_END
+}
+
+void testNotEqualString_ActualStringIsLonger(void)
+{
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_EQUAL_STRING("foo", "foo2");
+    VERIFY_FAILS_END
+}
+
 void testEqualStringArrays(void)
 {
     const char *testStrings[] = { "foo", "boo", "woo", "moo" };


### PR DESCRIPTION
Adds explicit test cases for #407.