### PR TITLE
Use Pass string from unity.c in unity_fixture.c to garuntee colour behavior

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -419,7 +419,8 @@ void UnityConcludeFixtureTest(void)
     {
         if (UnityFixture.Verbose)
         {
-            UnityPrint(" PASS");
+            UnityPrint(" ");
+            UnityPrint(UnityStrPass);
             UNITY_EXEC_TIME_STOP();
             UNITY_PRINT_EXEC_TIME();
             UNITY_PRINT_EOL();

--- a/src/unity.c
+++ b/src/unity.c
@@ -21,15 +21,15 @@ void UNITY_OUTPUT_CHAR(int);
 struct UNITY_STORAGE_T Unity;
 
 #ifdef UNITY_OUTPUT_COLOR
-static const char UnityStrOk[]                     = "\033[42mOK\033[00m";
-static const char UnityStrPass[]                   = "\033[42mPASS\033[00m";
-static const char UnityStrFail[]                   = "\033[41mFAIL\033[00m";
-static const char UnityStrIgnore[]                 = "\033[43mIGNORE\033[00m";
+const char UnityStrOk[]                            = "\033[42mOK\033[00m";
+const char UnityStrPass[]                          = "\033[42mPASS\033[00m";
+const char UnityStrFail[]                          = "\033[41mFAIL\033[00m";
+const char UnityStrIgnore[]                        = "\033[43mIGNORE\033[00m";
 #else
-static const char UnityStrOk[]                     = "OK";
-static const char UnityStrPass[]                   = "PASS";
-static const char UnityStrFail[]                   = "FAIL";
-static const char UnityStrIgnore[]                 = "IGNORE";
+const char UnityStrOk[]                            = "OK";
+const char UnityStrPass[]                          = "PASS";
+const char UnityStrFail[]                          = "FAIL";
+const char UnityStrIgnore[]                        = "IGNORE";
 #endif
 static const char UnityStrNull[]                   = "NULL";
 static const char UnityStrSpacer[]                 = ". ";

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -639,6 +639,11 @@ UNITY_INTERNAL_PTR UnityDoubleToPtr(const double num);
  * Error Strings We Might Need
  *-------------------------------------------------------*/
 
+extern const char UnityStrOk[];
+extern const char UnityStrPass[];
+extern const char UnityStrFail[];
+extern const char UnityStrIgnore[];
+
 extern const char UnityStrErrFloat[];
 extern const char UnityStrErrDouble[];
 extern const char UnityStrErr64[];


### PR DESCRIPTION
This make the unity_fixture aware of certain strings defined int unity.c so if enabled the coloured versions can be used. Fixes #320.

before:
![image](https://user-images.githubusercontent.com/24949495/56083911-4bb67780-5df9-11e9-85c0-0a04667bc00c.png)

after:
![image](https://user-images.githubusercontent.com/24949495/56083896-14e06180-5df9-11e9-870f-9c348aca7638.png)
