### PR TITLE
TEST_ASSERT_INT_ARRAY_WITHIN in unity

### DIFF
--- a/docs/UnityAssertionsReference.md
+++ b/docs/UnityAssertionsReference.md
@@ -391,7 +391,6 @@ of 7 - 13.
 
 ##### `TEST_ASSERT_HEX64_WITHIN (delta, expected, actual)`
 
-
 ### Structs and Strings
 
 ##### `TEST_ASSERT_EQUAL_PTR (expected, actual)`
@@ -466,6 +465,42 @@ match. Failure messages specify the array index of the failed comparison.
 
 `len` is the memory in bytes to be compared at each array element.
 
+### Integer Array Ranges (of all sizes)
+
+These assertions verify that the `expected` array parameter is within +/- `delta`
+(inclusive) of the `actual` array parameter. For example, if the expected value is
+\[10, 12\] and the delta is 3 then the assertion will fail for any value
+outside the range of \[7 - 13, 9 - 15\].
+
+##### `TEST_ASSERT_INT_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_INT8_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_INT16_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_INT32_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_INT64_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_UINT_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_UINT8_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_UINT16_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_UINT32_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_UINT64_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_HEX_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_HEX8_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_HEX16_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_HEX32_ARRAY_WITHIN (delta, expected, actual)`
+
+##### `TEST_ASSERT_HEX64_ARRAY_WITHIN (delta, expected, actual)`
 
 ### Each Equal (Arrays to Single Value)
 

--- a/src/unity.c
+++ b/src/unity.c
@@ -1248,6 +1248,116 @@ void UnityAssertNumbersWithin(const UNITY_UINT delta,
 }
 
 /*-----------------------------------------------*/
+void UnityAssertNumbersArrayWithin(const UNITY_UINT delta,
+                                   UNITY_INTERNAL_PTR expected,
+                                   UNITY_INTERNAL_PTR actual,
+                                   const UNITY_UINT32 num_elements,
+                                   const char* msg,
+                                   const UNITY_LINE_TYPE lineNumber,
+                                   const UNITY_DISPLAY_STYLE_T style,
+                                   const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements = num_elements;
+    unsigned int length   = style & 0xF;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while ((elements > 0) && (elements--))
+    {
+        UNITY_INT expect_val;
+        UNITY_INT actual_val;
+
+        switch (length)
+        {
+            case 1:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)actual;
+                break;
+            case 2:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)actual;
+                break;
+#ifdef UNITY_SUPPORT_64
+            case 8:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)actual;
+                break;
+#endif
+            default: /* length 4 bytes */
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)actual;
+                length = 4;
+                break;
+        }
+
+        if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+        {
+            if (actual_val > expect_val)
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)actual_val - (UNITY_UINT)expect_val) > delta);
+            }
+            else
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)expect_val - (UNITY_UINT)actual_val) > delta);
+            }
+        }
+        else
+        {
+            if ((UNITY_UINT)actual_val > (UNITY_UINT)expect_val)
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)actual_val - (UNITY_UINT)expect_val) > delta);
+            }
+            else
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)expect_val - (UNITY_UINT)actual_val) > delta);
+            }
+        }
+
+        if (Unity.CurrentTestFailed)
+        {
+            if ((style & UNITY_DISPLAY_RANGE_UINT) && (length < sizeof(expect_val)))
+            {   /* For UINT, remove sign extension (padding 1's) from signed type casts above */
+                UNITY_INT mask = 1;
+                mask = (mask << 8 * length) - 1;
+                expect_val &= mask;
+                actual_val &= mask;
+            }
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrDelta);
+            UnityPrintNumberByStyle((UNITY_INT)delta, style);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UnityPrint(UnityStrExpected);
+            UnityPrintNumberByStyle(expect_val, style);
+            UnityPrint(UnityStrWas);
+            UnityPrintNumberByStyle(actual_val, style);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            expected = (UNITY_INTERNAL_PTR)(length + (const char*)expected);
+        }
+        actual   = (UNITY_INTERNAL_PTR)(length + (const char*)actual);
+    }
+
+}
+
+/*-----------------------------------------------*/
 void UnityAssertEqualString(const char* expected,
                             const char* actual,
                             const char* msg,

--- a/src/unity.h
+++ b/src/unity.h
@@ -230,6 +230,24 @@ int suiteTearDown(int num_failures);
 #define TEST_ASSERT_HEX32_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
 #define TEST_ASSERT_HEX64_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX64_WITHIN((delta), (expected), (actual), __LINE__, NULL)
 
+/* Integer Array Ranges (of all sizes) */
+#define TEST_ASSERT_INT_ARRAY_WITHIN(delta, expected, actual, num_elements)                        UNITY_TEST_ASSERT_INT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT8_ARRAY_WITHIN(delta, expected, actual, num_elements)                       UNITY_TEST_ASSERT_INT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT16_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_INT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT32_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_INT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT64_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT_ARRAY_WITHIN(delta, expected, actual, num_elements)                       UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT8_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_UINT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT16_ARRAY_WITHIN(delta, expected, actual, num_elements)                     UNITY_TEST_ASSERT_UINT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT32_ARRAY_WITHIN(delta, expected, actual, num_elements)                     UNITY_TEST_ASSERT_UINT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT64_ARRAY_WITHIN(delta, expected, actual, num_elements)                     UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX_ARRAY_WITHIN(delta, expected, actual, num_elements)                        UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX8_ARRAY_WITHIN(delta, expected, actual, num_elements)                       UNITY_TEST_ASSERT_HEX8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX16_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_HEX16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX32_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX64_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+
+
 /* Structs and Strings */
 #define TEST_ASSERT_EQUAL_PTR(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_STRING(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_STRING((expected), (actual), __LINE__, NULL)
@@ -421,6 +439,24 @@ int suiteTearDown(int num_failures);
 #define TEST_ASSERT_HEX16_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX16_WITHIN((delta), (expected), (actual), __LINE__, (message))
 #define TEST_ASSERT_HEX32_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, (message))
 #define TEST_ASSERT_HEX64_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX64_WITHIN((delta), (expected), (actual), __LINE__, (message))
+
+/* Integer Array Ranges (of all sizes) */
+#define TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)       UNITY_TEST_ASSERT_INT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)      UNITY_TEST_ASSERT_INT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_INT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT32_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_INT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)      UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_UINT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)    UNITY_TEST_ASSERT_UINT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT32_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)    UNITY_TEST_ASSERT_UINT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)    UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)       UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)      UNITY_TEST_ASSERT_HEX8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_HEX16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+
 
 /* Structs and Strings */
 #define TEST_ASSERT_EQUAL_PTR_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, (message))

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -579,6 +579,15 @@ void UnityAssertNumbersWithin(const UNITY_UINT delta,
                               const UNITY_LINE_TYPE lineNumber,
                               const UNITY_DISPLAY_STYLE_T style);
 
+void UnityAssertNumbersArrayWithin(const UNITY_UINT delta,
+                                   UNITY_INTERNAL_PTR expected,
+                                   UNITY_INTERNAL_PTR actual,
+                                   const UNITY_UINT32 num_elements,
+                                   const char* msg,
+                                   const UNITY_LINE_TYPE lineNumber,
+                                   const UNITY_DISPLAY_STYLE_T style,
+                                   const UNITY_FLAGS_T flags);
+
 void UnityFail(const char* message, const UNITY_LINE_TYPE line);
 
 void UnityIgnore(const char* message, const UNITY_LINE_TYPE line);
@@ -800,6 +809,20 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_HEX16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
 #define UNITY_TEST_ASSERT_HEX32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
 
+
+#define UNITY_TEST_ASSERT_INT_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)     UnityAssertNumbersArrayWithin((delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_INT8_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)    UnityAssertNumbersArrayWithin((UNITY_UINT8 )(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_INT16_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_INT32_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)    UnityAssertNumbersArrayWithin((delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT8_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin((UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT16_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin((UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT32_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX8_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)    UnityAssertNumbersArrayWithin((UNITY_UINT8 )(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX16_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32, UNITY_ARRAY_TO_ARRAY)
+
+
 #define UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_PTR_TO_INT)(expected), (UNITY_PTR_TO_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
 #define UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, line, message)                          UnityAssertEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)(line))
 #define UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, line, message)                 UnityAssertEqualStringLen((const char*)(expected), (const char*)(actual), (UNITY_UINT32)(len), (message), (UNITY_LINE_TYPE)(line))
@@ -860,6 +883,9 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
 #define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
 #define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64, UNITY_ARRAY_TO_ARRAY)
 #else
 #define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
 #define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
@@ -882,6 +908,9 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
 #define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64(threshold, actual, line, message)              UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
 #define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
 #endif
 
 #ifdef UNITY_EXCLUDE_FLOAT

--- a/test/tests/testunity.c
+++ b/test/tests/testunity.c
@@ -1318,8 +1318,1477 @@ void testINT8sNotWithinDeltaAndCustomMessage(void)
     VERIFY_FAILS_END
 }
 
+//------------------------
+
+void testInt64ArrayWithinDelta(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+    UNITY_INT64 acutalSmallDelta[] = {12345001, -12344996, 12345005};
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    TEST_ASSERT_INT64_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_INT64_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+#endif
+}
+
+void testInt64ArrayWithinDeltaAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+    UNITY_INT64 acutalSmallDelta[] = {12345001, -12344996, 12345005};
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+#endif
+}
+
+void tesUInt64ArrayNotWithinDelta(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayNotWithinDeltaAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayWithinDeltaPointless(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT64_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayWithinDeltaPointlessAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayWithinDeltaExpectedNull(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT64_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 acutalBigDelta[] = {12345101, -12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayWithinDeltaActualNull(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT64_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayWithinDeltaActualNullAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testInt64ArrayWithinDeltaSamePointer(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(110, expected, expected, 3);
+#endif
+}
+
+void testInt64ArrayWithinDeltaSamePointerAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_INT64 expected[] = {12345000, -12344995, 12345005};
+
+    TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+#endif
+}
+
+void testIntArrayWithinDelta(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+    UNITY_INT acutalSmallDelta[] = {5001, -4996, 5005};
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    TEST_ASSERT_INT_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_INT_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+}
+
+void testIntArrayWithinDeltaAndMessage(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+    UNITY_INT acutalSmallDelta[] = {5001, -4996, 5005};
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testIntArrayNotWithinDelta(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testIntArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testIntArrayWithinDeltaPointless(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testIntArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testIntArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testIntArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_INT acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testIntArrayWithinDeltaActualNull(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testIntArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testIntArrayWithinDeltaSamePointer(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+
+    TEST_ASSERT_INT_ARRAY_WITHIN(110, expected, expected, 3);
+}
+
+void testIntArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_INT expected[] = {5000, -4995, 5005};
+
+    TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+}
+
+void testInt16ArrayWithinDelta(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+    UNITY_INT16 acutalSmallDelta[] = {5001, -4996, 5005};
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    TEST_ASSERT_INT16_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_INT16_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+}
+
+void testInt16ArrayWithinDeltaAndMessage(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+    UNITY_INT16 acutalSmallDelta[] = {5001, -4996, 5005};
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testInt16ArrayNotWithinDelta(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayWithinDeltaPointless(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT16_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT16_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_INT16 acutalBigDelta[] = {5101, -4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayWithinDeltaActualNull(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT16_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt16ArrayWithinDeltaSamePointer(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+
+    TEST_ASSERT_INT16_ARRAY_WITHIN(110, expected, expected, 3);
+}
+
+void testInt16ArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_INT16 expected[] = {5000, -4995, 5005};
+
+    TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+}
+
+void testInt8ArrayWithinDelta(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+    UNITY_INT8 acutalSmallDelta[] = {21, -94, 55};
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    TEST_ASSERT_INT8_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_INT8_ARRAY_WITHIN(11, expected, acutalBigDelta, 3);
+}
+
+void testInt8ArrayWithinDeltaAndMessage(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+    UNITY_INT8 acutalSmallDelta[] = {21, -94, 55};
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(11, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testInt8ArrayNotWithinDelta(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayWithinDeltaPointless(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN(11, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(11, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN(11, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_INT8 acutalBigDelta[] = {11, -86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(11, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayWithinDeltaActualNull(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN(11, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(11, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testInt8ArrayWithinDeltaSamePointer(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+
+    TEST_ASSERT_INT8_ARRAY_WITHIN(11, expected, expected, 3);
+}
+
+void testInt8ArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_INT8 expected[] = {20, -95, 55};
+
+    TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(11, expected, expected, 3, "Custom Message.");
+}
+
+void testUInt64ArrayWithinDelta(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+    UNITY_UINT64 acutalSmallDelta[] = {12345001, 12344996, 12345005};
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+#endif
+}
+
+void testUInt64ArrayWithinDeltaAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+    UNITY_UINT64 acutalSmallDelta[] = {12345001, 12344996, 12345005};
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+#endif
+}
+
+void testUInt64ArrayNotWithinDelta(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayNotWithinDeltaAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayWithinDeltaPointless(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayWithinDeltaPointlessAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayWithinDeltaExpectedNull(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 acutalBigDelta[] = {12345101, 12344896, 12345055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayWithinDeltaActualNull(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayWithinDeltaActualNullAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testUInt64ArrayWithinDeltaSamePointer(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+
+    TEST_ASSERT_UINT64_ARRAY_WITHIN(110, expected, expected, 3);
+#endif
+}
+
+void testUInt64ArrayWithinDeltaSamePointerAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {12345000, 12344995, 12345005};
+
+    TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+#endif
+}
+
+void testUIntArrayWithinDelta(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+    UNITY_UINT acutalSmallDelta[] = {125001, 124996, 125005};
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    TEST_ASSERT_UINT_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_UINT_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+}
+
+void testUIntArrayWithinDeltaAndMessage(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+    UNITY_UINT acutalSmallDelta[] = {125001, 124996, 125005};
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testUIntArrayNotWithinDelta(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayWithinDeltaPointless(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_UINT acutalBigDelta[] = {125101, 124896, 125055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayWithinDeltaActualNull(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUIntArrayWithinDeltaSamePointer(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+
+    TEST_ASSERT_UINT_ARRAY_WITHIN(110, expected, expected, 3);
+}
+
+void testUIntArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_UINT expected[] = {125000, 124995, 125005};
+
+    TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+}
+
+void testUInt16ArrayWithinDelta(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+    UNITY_UINT16 acutalSmallDelta[] = {5001, 4996, 5005};
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+}
+
+void testUInt16ArrayWithinDeltaAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+    UNITY_UINT16 acutalSmallDelta[] = {5001, 4996, 5005};
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testUInt16ArrayNotWithinDelta(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayWithinDeltaPointless(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_UINT16 acutalBigDelta[] = {5101, 4896, 5055};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayWithinDeltaActualNull(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt16ArrayWithinDeltaSamePointer(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+
+    TEST_ASSERT_UINT16_ARRAY_WITHIN(110, expected, expected, 3);
+}
+
+void testUInt16ArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {5000, 4995, 5005};
+
+    TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+}
+
+void testUInt8ArrayWithinDelta(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+    UNITY_UINT8 acutalSmallDelta[] = {21, 94, 55};
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    TEST_ASSERT_UINT8_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_UINT8_ARRAY_WITHIN(11, expected, acutalBigDelta, 3);
+}
+
+void testUInt8ArrayWithinDeltaAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+    UNITY_UINT8 acutalSmallDelta[] = {21, 94, 55};
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(11, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testUInt8ArrayNotWithinDelta(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayWithinDeltaPointless(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN(11, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(11, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN(11, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_UINT8 acutalBigDelta[] = {11, 86, 45};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(11, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayWithinDeltaActualNull(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN(11, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(11, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testUInt8ArrayWithinDeltaSamePointer(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+
+    TEST_ASSERT_UINT8_ARRAY_WITHIN(11, expected, expected, 3);
+}
+
+void testUInt8ArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {20, 95, 55};
+
+    TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(11, expected, expected, 3, "Custom Message.");
+}
+
+
+void testHEX64ArrayWithinDelta(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT64 acutalSmallDelta[] = {0xABCD1235, 0xABCD1121, 0xABCD1277};
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    TEST_ASSERT_HEX64_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_HEX64_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+#endif
+}
+
+void testHEX64ArrayWithinDeltaAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT64 acutalSmallDelta[] = {0xABCD1235, 0xABCD1121, 0xABCD1277};
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+#endif
+}
+
+void testHEX64ArrayNotWithinDelta(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayNotWithinDeltaAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayWithinDeltaPointless(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayWithinDeltaPointlessAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayWithinDeltaExpectedNull(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayWithinDeltaActualNull(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayWithinDeltaActualNullAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+#endif
+}
+
+void testHEX64ArrayWithinDeltaSamePointer(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+
+    TEST_ASSERT_HEX64_ARRAY_WITHIN(110, expected, expected, 3);
+#endif
+}
+
+void testHEX64ArrayWithinDeltaSamePointerAndMessage(void)
+{
+#ifndef UNITY_SUPPORT_64
+    TEST_IGNORE();
+#else
+    UNITY_UINT64 expected[] = {0xABCD11234, 0xABCD1122, 0xABCD1277};
+
+    TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+#endif
+}
+
+
+void testHEX32ArrayWithinDelta(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT acutalSmallDelta[] = {0xABCD1235, 0xABCD1121, 0xABCD1277};
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    TEST_ASSERT_HEX32_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_HEX32_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+}
+
+void testHEX32ArrayWithinDeltaAndMessage(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT acutalSmallDelta[] = {0xABCD1235, 0xABCD1121, 0xABCD1277};
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testHEX32ArrayNotWithinDelta(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayWithinDeltaPointless(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_UINT acutalBigDelta[] = {0xABCD1267, 0xABCD1188, 0xABCD12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayWithinDeltaActualNull(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX32ArrayWithinDeltaSamePointer(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+
+    TEST_ASSERT_HEX32_ARRAY_WITHIN(110, expected, expected, 3);
+}
+
+void testHEX32ArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_UINT expected[] = {0xABCD1234, 0xABCD1122, 0xABCD1277};
+
+    TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+}
+
+
+void testHEX16ArrayWithinDelta(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+    UNITY_UINT16 acutalSmallDelta[] = {0x1235, 0x1121, 0x1277};
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    TEST_ASSERT_HEX16_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_HEX16_ARRAY_WITHIN(110, expected, acutalBigDelta, 3);
+}
+
+void testHEX16ArrayWithinDeltaAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+    UNITY_UINT16 acutalSmallDelta[] = {0x1235, 0x1121, 0x1277};
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testHEX16ArrayNotWithinDelta(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayWithinDeltaPointless(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN(110, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(110, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN(110, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_UINT16 acutalBigDelta[] = {0x1267, 0x1188, 0x12AC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(110, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayWithinDeltaActualNull(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN(110, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(110, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX16ArrayWithinDeltaSamePointer(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+
+    TEST_ASSERT_HEX16_ARRAY_WITHIN(110, expected, expected, 3);
+}
+
+void testHEX16ArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_UINT16 expected[] = {0x1234, 0x1122, 0x1277};
+
+    TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(110, expected, expected, 3, "Custom Message.");
+}
+
+void testHEX8ArrayWithinDelta(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+    UNITY_UINT8 acutalSmallDelta[] = {0x35, 0x21, 0x77};
+    UNITY_UINT8 acutalBigDelta[] = {0x47, 0x48, 0x4C};
+
+    TEST_ASSERT_HEX8_ARRAY_WITHIN(1, expected, acutalSmallDelta, 3);
+    TEST_ASSERT_HEX8_ARRAY_WITHIN(60, expected, acutalBigDelta, 3);
+}
+
+void testHEX8ArrayWithinDeltaAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+    UNITY_UINT8 acutalSmallDelta[] = {0x35, 0x21, 0x77};
+    UNITY_UINT8 acutalBigDelta[] = {0x47, 0x48, 0x4C};
+
+    TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(1, expected, acutalSmallDelta, 3, "Custom Message.");
+    TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(60, expected, acutalBigDelta, 3, "Custom Message.");
+}
+
+void testHEX8ArrayNotWithinDelta(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+    UNITY_UINT8 acutalBigDelta[] = {0x67, 0x88, 0xAC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN(1, expected, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayNotWithinDeltaAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+    UNITY_UINT8 acutalBigDelta[] = {0x67, 0x88, 0xAC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(1, expected, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayWithinDeltaPointless(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+    UNITY_UINT8 acutalBigDelta[] = {0x67, 0x88, 0xAC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN(60, expected, acutalBigDelta, 0);
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayWithinDeltaPointlessAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+    UNITY_UINT8 acutalBigDelta[] = {0x67, 0x88, 0xAC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(60, expected, acutalBigDelta, 0, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayWithinDeltaExpectedNull(void)
+{
+    UNITY_UINT8 acutalBigDelta[] = {0x67, 0x88, 0xAC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN(60, NULL, acutalBigDelta, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayWithinDeltaExpectedNullAndMessage(void)
+{
+    UNITY_UINT8 acutalBigDelta[] = {0x67, 0x88, 0xAC};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(60, NULL, acutalBigDelta, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayWithinDeltaActualNull(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN(60, expected, NULL, 3);
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayWithinDeltaActualNullAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+
+    EXPECT_ABORT_BEGIN
+    TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(60, expected, NULL, 3, "Custom Message.");
+    VERIFY_FAILS_END
+}
+
+void testHEX8ArrayWithinDeltaSamePointer(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+
+    TEST_ASSERT_HEX8_ARRAY_WITHIN(60, expected, expected, 3);
+}
+
+void testHEX8ArrayWithinDeltaSamePointerAndMessage(void)
+{
+    UNITY_UINT8 expected[] = {0x34, 0x22, 0x77};
+
+    TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(60, expected, expected, 3, "Custom Message.");
+}
 
 //-----------------
+
 void testGreaterThan(void)
 {
     UNITY_INT v0, v1;


### PR DESCRIPTION
This addresses #396  and adds the TEST_ASSERT_*_ARRAY_WITHIN to unity. It has all typical flavors of types.