### PR TITLE
silent mode in unity fixture

### DIFF
--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -79,14 +79,20 @@ void UnityTestRunner(unityfunction* setup,
         Unity.TestFile = file;
         Unity.CurrentTestName = printableName;
         Unity.CurrentTestLineNumber = line;
-        if (!UnityFixture.Verbose)
-            UNITY_OUTPUT_CHAR('.');
-        else
+        if (UnityFixture.Verbose)
         {
             UnityPrint(printableName);
         #ifndef UNITY_REPEAT_TEST_NAME
             Unity.CurrentTestName = NULL;
         #endif
+        }
+        else if (UnityFixture.Silent)
+        {
+            /* Do Nothing */
+        }
+        else
+        {
+            UNITY_OUTPUT_CHAR('.');
         }
 
         Unity.NumberOfTests++;
@@ -120,12 +126,18 @@ void UnityIgnoreTest(const char* printableName, const char* group, const char* n
     {
         Unity.NumberOfTests++;
         Unity.TestIgnores++;
-        if (!UnityFixture.Verbose)
-            UNITY_OUTPUT_CHAR('!');
-        else
+        if (UnityFixture.Verbose)
         {
             UnityPrint(printableName);
             UNITY_PRINT_EOL();
+        }
+        else if (UnityFixture.Silent)
+        {
+            /* Do Nothing */
+        }
+        else
+        {
+            UNITY_OUTPUT_CHAR('!');
         }
     }
 }
@@ -350,6 +362,7 @@ int UnityGetCommandLineOptions(int argc, const char* argv[])
 {
     int i;
     UnityFixture.Verbose = 0;
+    UnityFixture.Silent = 0;
     UnityFixture.GroupFilter = 0;
     UnityFixture.NameFilter = 0;
     UnityFixture.RepeatCount = 1;
@@ -362,6 +375,11 @@ int UnityGetCommandLineOptions(int argc, const char* argv[])
         if (strcmp(argv[i], "-v") == 0)
         {
             UnityFixture.Verbose = 1;
+            i++;
+        }
+        else if (strcmp(argv[i], "-s") == 0)
+        {
+            UnityFixture.Silent = 1;
             i++;
         }
         else if (strcmp(argv[i], "-g") == 0)

--- a/extras/fixture/src/unity_fixture_internals.h
+++ b/extras/fixture/src/unity_fixture_internals.h
@@ -16,6 +16,7 @@ extern "C"
 struct UNITY_FIXTURE_T
 {
     int Verbose;
+    int Silent;
     unsigned int RepeatCount;
     const char* NameFilter;
     const char* GroupFilter;


### PR DESCRIPTION
This PR address #270 by adding a silent mode flag to unity fixtures. By adding the -s, unity will not output dots. See example output below.

![silentmode](https://user-images.githubusercontent.com/24949495/57185584-6cc03480-6e9c-11e9-846c-988269833558.png)
