### PR TITLE
add a blank line after #include "unity.h"

### DIFF
--- a/auto/generate_module.rb
+++ b/auto/generate_module.rb
@@ -14,6 +14,7 @@ require 'pathname'
 
 # TEMPLATE_TST
 TEMPLATE_TST ||= '#include "unity.h"
+
 %2$s#include "%1$s.h"
 
 void setUp(void)


### PR DESCRIPTION
The include must be in the first line, else you may expect some issues.
Some autoformat tools could sort the includes alphabetically and could
break the test.