### PR TITLE
Patch fix for Unity Meson build scripts.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,49 +27,65 @@ project('unity', 'c',
 cc = meson.get_compiler('c')
 args_for_langs = 'c'
 
+##
+#
+# Meson: Add compiler flags
+#
+##
 if cc.get_id() == 'clang'
     add_project_arguments(
-        '-Wweak-vtables', 
-        '-Wexit-time-destructors',
-        '-Wglobal-constructors', 
-        '-Wmissing-noreturn', language: args_for_langs)
+        cc.get_supported_arguments(
+            [
+            '-Wweak-vtables', 
+            '-Wexit-time-destructors',
+            '-Wglobal-constructors', 
+            '-Wmissing-noreturn' 
+            ]
+        ), language: args_for_langs)
 endif
 
 if cc.get_argument_syntax() == 'gcc'
     add_project_arguments(
-        '-Wall', 
-        '-Wextra', 
-        '-Wunreachable-code', 
-        '-Wmissing-declarations',
-        '-Wmissing-prototypes',
-        '-Wredundant-decls',
-        '-Wundef',
-        '-Wwrite-strings',
-        '-Wformat',
-        '-Wformat-nonliteral',
-        '-Wformat-security',
-        '-Wold-style-definition',
-        '-Winit-self',
-        '-Wmissing-include-dirs',
-        '-Waddress',
-        '-Waggregate-return',
-        '-Wno-multichar',
-        '-Wdeclaration-after-statement',
-        '-Wvla',
-        '-Wpointer-arith',language: args_for_langs)
+        cc.get_supported_arguments(
+            [
+            '-Wunreachable-code', 
+            '-Wmissing-declarations',
+            '-Wmissing-prototypes',
+            '-Wredundant-decls',
+            '-Wundef',
+            '-Wwrite-strings',
+            '-Wformat',
+            '-Wformat-nonliteral',
+            '-Wformat-security',
+            '-Wold-style-definition',
+            '-Winit-self',
+            '-Wmissing-include-dirs',
+            '-Waddress',
+            '-Waggregate-return',
+            '-Wno-multichar',
+            '-Wno-parentheses',
+            '-Wno-unused-parameter',
+            '-Wno-type-limits',
+            '-Wdeclaration-after-statement',
+            '-Wvla',
+            '-Wpointer-arith'
+            ]
+        ), language: args_for_langs)
 endif
 
 if cc.get_id() == 'msvc'
     add_project_arguments(
-        '/W4', 
-        '/w44265', 
-        '/w44061', 
-        '/w44062', 
-        '/wd4018', # implicit signed/unsigned conversion
-        '/wd4146', # unary minus on unsigned (beware INT_MIN)
-        '/wd4244', # lossy type conversion (e.g. double -> int)
-        '/wd4305', # truncating type conversion (e.g. double -> float)
-        mesno.get_supported_arguments(['/utf-8']), language: args_for_langs)
+        cc.get_supported_arguments(
+            [
+            '/w44265', 
+            '/w44061', 
+            '/w44062', 
+            '/wd4018', # implicit signed/unsigned conversion
+            '/wd4146', # unary minus on unsigned (beware INT_MIN)
+            '/wd4244', # lossy type conversion (e.g. double -> int)
+            '/wd4305', # truncating type conversion (e.g. double -> float)
+            ]
+        ), language: args_for_langs)
 endif
 
 subdir('src')

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,6 @@ unity_src = files('unity.c')
 
 unity_dir = include_directories('.')
 
-unity_lib = library(meson.project_name(), 
+unity_lib = static_library(meson.project_name(), 
     sources: unity_src,
     include_directories: unity_dir)


### PR DESCRIPTION
This pull request well fix how the compiler flags are found by finding C flags only and the library well now be built as a static only library because there was some issues when linking against it as shared.