### PR TITLE
Fix undefined behavior in UnityPrintNumber

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -327,7 +327,11 @@ void UnityPrintNumber(const UNITY_INT number_to_print)
     {
         /* A negative number, including MIN negative */
         UNITY_OUTPUT_CHAR('-');
-        number = (UNITY_UINT)-number_to_print;
+        /* Take the two's complement of the unsigned value.  We could use
+           unary minus here except that the Micros**t compiler complains
+           about that.  Negating the signed value doesn't work because
+           that's undefined behavior for the most-negative integer. */
+        number = (~number) + 1;
     }
     UnityPrintNumberUnsigned(number);
 }

--- a/test/targets/gcc_32.yml
+++ b/test/targets/gcc_32.yml
@@ -10,6 +10,10 @@ compiler:
     - '-Wno-address'
     - '-std=c99'
     - '-pedantic'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
+    - '-fno-sanitize-recover=all'
+    - '-fno-common'
   includes:
     prefix: '-I'
     items:
@@ -35,6 +39,8 @@ linker:
   options:
     - -lm
     - '-m32'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
   includes:
     prefix: '-I'
   object_files:

--- a/test/targets/gcc_64.yml
+++ b/test/targets/gcc_64.yml
@@ -10,6 +10,10 @@ compiler:
     - '-Wno-address'
     - '-std=c99'
     - '-pedantic'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
+    - '-fno-sanitize-recover=all'
+    - '-fno-common'
   includes:
     prefix: '-I'
     items:
@@ -36,6 +40,8 @@ linker:
   options:
     - -lm
     - '-m64'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
   includes:
     prefix: '-I'
   object_files:

--- a/test/targets/gcc_auto_limits.yml
+++ b/test/targets/gcc_auto_limits.yml
@@ -10,6 +10,10 @@ compiler:
     - '-Wno-address'
     - '-std=c99'
     - '-pedantic'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
+    - '-fno-sanitize-recover=all'
+    - '-fno-common'
   includes:
     prefix: '-I'
     items:
@@ -33,6 +37,8 @@ linker:
   options:
     - -lm
     - '-m64'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
   includes:
     prefix: '-I'
   object_files:

--- a/test/targets/gcc_auto_stdint.yml
+++ b/test/targets/gcc_auto_stdint.yml
@@ -23,6 +23,10 @@ compiler:
     - '-Wstrict-prototypes'
     - '-Wundef'
     - '-Wold-style-definition'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
+    - '-fno-sanitize-recover=all'
+    - '-fno-common'
   includes:
     prefix: '-I'
     items:
@@ -45,6 +49,8 @@ linker:
   options:
     - -lm
     - '-m64'
+    - '-fsanitize=undefined'
+    - '-fsanitize=address'
   includes:
     prefix: '-I'
   object_files:


### PR DESCRIPTION
And add sanitizers to the GCC build flags so that no-one breaks this again.