### PR TITLE
Update for the meson build support.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,49 +27,64 @@ project('unity', 'c',
 cc = meson.get_compiler('c')
 args_for_langs = 'c'
 
+##
+#
+# Meson: Add compiler flags
+#
+##
 if cc.get_id() == 'clang'
     add_project_arguments(
-        '-Wweak-vtables', 
-        '-Wexit-time-destructors',
-        '-Wglobal-constructors', 
-        '-Wmissing-noreturn', language: args_for_langs)
+        cc.get_supported_arguments(
+            [
+            '-Wweak-vtables', 
+            '-Wexit-time-destructors',
+            '-Wglobal-constructors', 
+            '-Wmissing-noreturn' 
+            ]
+        ), language: args_for_langs)
 endif
 
 if cc.get_argument_syntax() == 'gcc'
     add_project_arguments(
-        '-Wall', 
-        '-Wextra', 
-        '-Wunreachable-code', 
-        '-Wmissing-declarations',
-        '-Wmissing-prototypes',
-        '-Wredundant-decls',
-        '-Wundef',
-        '-Wwrite-strings',
-        '-Wformat',
-        '-Wformat-nonliteral',
-        '-Wformat-security',
-        '-Wold-style-definition',
-        '-Winit-self',
-        '-Wmissing-include-dirs',
-        '-Waddress',
-        '-Waggregate-return',
-        '-Wno-multichar',
-        '-Wdeclaration-after-statement',
-        '-Wvla',
-        '-Wpointer-arith',language: args_for_langs)
+        cc.get_supported_arguments(
+            [
+            '-Wunreachable-code', 
+            '-Wmissing-declarations',
+            '-Wmissing-prototypes',
+            '-Wundef',
+            '-Wwrite-strings',
+            '-Wformat',
+            '-Wformat-nonliteral',
+            '-Wformat-security',
+            '-Wold-style-definition',
+            '-Winit-self',
+            '-Wmissing-include-dirs',
+            '-Waddress',
+            '-Waggregate-return',
+            '-Wno-multichar',
+            '-Wno-parentheses',
+            '-Wno-unused-parameter',
+            '-Wno-type-limits',
+            '-Wdeclaration-after-statement',
+            '-Wvla',
+            '-Wpointer-arith'
+            ]
+        ), language: args_for_langs)
 endif
 
 if cc.get_id() == 'msvc'
     add_project_arguments(
-        '/W4', 
-        '/w44265', 
-        '/w44061', 
-        '/w44062', 
-        '/wd4018', # implicit signed/unsigned conversion
-        '/wd4146', # unary minus on unsigned (beware INT_MIN)
-        '/wd4244', # lossy type conversion (e.g. double -> int)
-        '/wd4305', # truncating type conversion (e.g. double -> float)
-        mesno.get_supported_arguments(['/utf-8']), language: args_for_langs)
+        cc.get_supported_arguments(
+            [
+            '/w44265', 
+            '/w44061', 
+            '/w44062', 
+            '/wd4018', # implicit signed/unsigned conversion
+            '/wd4146', # unary minus on unsigned (beware INT_MIN)
+            '/wd4244', # lossy type conversion (e.g. double -> int)
+            '/wd4305', # truncating type conversion (e.g. double -> float)
+            ]
+        ), language: args_for_langs)
 endif
 
 subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@
 
 
 project('unity', 'c',
-    version         : '2.4.3',
+    version         : '2.4.4',
     license         : 'MIT',
     meson_version   : '>=0.50.0',
     default_options : 


### PR DESCRIPTION
I just saw that the version number was changed so I update the build script so where on the same page.
Also fixed and issue where one of the compiler flags was complaining about the uselessness of `setUp` and `tearDown`.  