### PR TITLE
Fix "rake scripts" when running on Windows.

### DIFF
--- a/test/rakefile_helper.rb
+++ b/test/rakefile_helper.rb
@@ -91,7 +91,7 @@ module RakefileHelpers
     defines = if $cfg['compiler']['defines']['items'].nil?
                 ''
               else
-                squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'] + ['UNITY_OUTPUT_CHAR=putcharSpy'] + ['UNITY_OUTPUT_CHAR_HEADER_DECLARATION=putcharSpy\(int\)'] + inject_defines)
+                squash($cfg['compiler']['defines']['prefix'], $cfg['compiler']['defines']['items'] + ['UNITY_OUTPUT_CHAR=putcharSpy'] + ['UNITY_OUTPUT_CHAR_HEADER_DECLARATION="putcharSpy(int)"'] + inject_defines)
               end
     options = squash('', $cfg['compiler']['options'])
     includes = squash($cfg['compiler']['includes']['prefix'], $cfg['compiler']['includes']['items'])


### PR DESCRIPTION
cmd.exe does not recognize backslash as an escape character,
leading to errors like the following:

    error: stray '\' in program
    note: in definition of macro 'UNITY_OUTPUT_CHAR_HEADER_DECLARATION'

It does, however, recognize double quotes, so we can use those as
a portable method of escaping special characters on both Windows
and UNIX.