### PR TITLE
Fix Meson build system support.

### DIFF
--- a/examples/example_4/meson.build
+++ b/examples/example_4/meson.build
@@ -1,6 +1,6 @@
 ###################################################################################
 #                                                                                 #
-# NAME: examples/example_4/meson.build                                            #
+# NAME: meson.build                                                               #
 #                                                                                 #
 # AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
 # WRITTEN BY: Michael Brockus.                                                    #
@@ -9,12 +9,9 @@
 #                                                                                 #
 ###################################################################################
 
-
 project('example-4', 'c')
 
 unity_dep = dependency('unity', fallback : ['unity', 'unity_dep'])
-
-example_dir = include_directories('.', join_paths('.', 'src'))
 
 subdir('src')
 subdir('test')

--- a/examples/example_4/src/meson.build
+++ b/examples/example_4/src/meson.build
@@ -1,6 +1,6 @@
 ###################################################################################
 #                                                                                 #
-# NAME: examples/example_4/src/meson.build                                        #
+# NAME: meson.build                                                               #
 #                                                                                 #
 # AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
 # WRITTEN BY: Michael Brockus.                                                    #
@@ -9,23 +9,13 @@
 #                                                                                 #
 ###################################################################################
 
+inc_dir = include_directories('.')
+lib_list = {'a': ['ProductionCode.c' ], 'b': ['ProductionCode2.c']}
 
+foreach lib, src : lib_list
+    set_variable(lib + '_lib', 
+        static_library(lib + '_lib', sources: src, include_directories: inc_dir))
+endforeach
 
-a_lib = library(
-    'production-code-1', 
-    'ProductionCode.c',
-    include_directories: example_dir)
-
-b_lib = library(
-    'production-code-2',
-    'ProductionCode2.c',
-    include_directories: example_dir)
-
-
-a_dep = declare_dependency(
-    link_with: a_lib,
-    include_directories: example_dir)
-
-b_dep = declare_dependency(
-    link_with: b_lib,
-    include_directories: example_dir)
+a_dep = declare_dependency(link_with: a_lib, include_directories: inc_dir)
+b_dep = declare_dependency(link_with: b_lib, include_directories: inc_dir)

--- a/examples/example_4/test/meson.build
+++ b/examples/example_4/test/meson.build
@@ -1,6 +1,6 @@
 ###################################################################################
 #                                                                                 #
-# NAME: examples/example_4/test/meson.build                                       #
+# NAME: meson.build                                                               #
 #                                                                                 #
 # AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
 # WRITTEN BY: Michael Brockus.                                                    #
@@ -8,7 +8,5 @@
 # License: MIT                                                                    #
 #                                                                                 #
 ###################################################################################
-
-
 
 subdir('test_runners')

--- a/examples/example_4/test/test_runners/meson.build
+++ b/examples/example_4/test/test_runners/meson.build
@@ -1,6 +1,6 @@
 ###################################################################################
 #                                                                                 #
-# NAME: examples/example_4/test/test_runners/meson.build                          #
+# NAME: meson.build                                                               #
 #                                                                                 #
 # AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
 # WRITTEN BY: Michael Brockus.                                                    #
@@ -9,16 +9,8 @@
 #                                                                                 #
 ###################################################################################
 
+cases = [['TestProductionCode_Runner.c',  join_paths('..' ,'TestProductionCode.c')], 
+        ['TestProductionCode2_Runner.c', join_paths('..' ,'TestProductionCode2.c')]]
 
-
-test_src_1 = [ 
-    'TestProductionCode_Runner.c',
-    join_paths('..' ,'TestProductionCode.c')
-    ]
-test_src_2 = [ 
-    'TestProductionCode2_Runner.c',
-    join_paths('..' ,'TestProductionCode2.c') 
-    ]
-
-test('Test production code one', executable('test-1', test_src_1, dependencies: [ a_dep, unity_dep ]))
-test('Test production code two', executable('test-2', test_src_2, dependencies: [ b_dep, unity_dep ]))
+test('Running: 01-test-case', executable('01-test-case', cases[0], dependencies: [ a_dep, unity_dep ]))
+test('Running: 02-test-case', executable('02-test-case', cases[1], dependencies: [ b_dep, unity_dep ]))

--- a/meson.build
+++ b/meson.build
@@ -15,61 +15,54 @@ project('unity', 'c',
     version         : '2.4.3',
     license         : 'MIT',
     meson_version   : '>=0.50.0',
-    default_options : 
-    [ 
-        'werror=true',
+    default_options: [
+        'buildtype=minsize',
         'optimization=3', 
-        'warning_level=3', 
-        'b_sanitize=address,undefined', 
-        'b_lto=true', 
-        'b_lundef=true'
-    ])
-cc = meson.get_compiler('c')
-args_for_langs = 'c'
+        'warning_level=3',
+        'werror=true',
+        ]
+)
+lang = 'c'
+cc = meson.get_compiler(lang)
 
+
+##
+#
+# Meson: Add compiler flags
+#
+##
 if cc.get_id() == 'clang'
-    add_project_arguments(
-        '-Wweak-vtables', 
-        '-Wexit-time-destructors',
-        '-Wglobal-constructors', 
-        '-Wmissing-noreturn', language: args_for_langs)
+    add_project_arguments(cc.get_supported_arguments(
+            [
+            '-Wweak-vtables', '-Wexit-time-destructors',
+            '-Wglobal-constructors', '-Wmissing-noreturn' 
+            ]
+        ), language: lang)
 endif
 
 if cc.get_argument_syntax() == 'gcc'
-    add_project_arguments(
-        '-Wall', 
-        '-Wextra', 
-        '-Wunreachable-code', 
-        '-Wmissing-declarations',
-        '-Wmissing-prototypes',
-        '-Wredundant-decls',
-        '-Wundef',
-        '-Wwrite-strings',
-        '-Wformat',
-        '-Wformat-nonliteral',
-        '-Wformat-security',
-        '-Wold-style-definition',
-        '-Winit-self',
-        '-Wmissing-include-dirs',
-        '-Waddress',
-        '-Waggregate-return',
-        '-Wno-multichar',
-        '-Wdeclaration-after-statement',
-        '-Wvla',
-        '-Wpointer-arith',language: args_for_langs)
+    add_project_arguments(cc.get_supported_arguments(
+            [
+            '-Wformat', '-Waddress', '-Winit-self', '-Wno-multichar',
+            '-Wpointer-arith'       , '-Wwrite-strings'              , 
+            '-Wno-parentheses'      , '-Wno-type-limits'             , 
+            '-Wformat-security'     , '-Wunreachable-code'           , 
+            '-Waggregate-return'    , '-Wformat-nonliteral'          ,
+            '-Wmissing-prototypes'  , '-Wold-style-definition'       ,
+            '-Wmissing-declarations', '-Wmissing-include-dirs'       , 
+            '-Wno-unused-parameter' , '-Wdeclaration-after-statement'
+            ]
+        ), language: lang)
 endif
 
 if cc.get_id() == 'msvc'
-    add_project_arguments(
-        '/W4', 
-        '/w44265', 
-        '/w44061', 
-        '/w44062', 
-        '/wd4018', # implicit signed/unsigned conversion
-        '/wd4146', # unary minus on unsigned (beware INT_MIN)
-        '/wd4244', # lossy type conversion (e.g. double -> int)
-        '/wd4305', # truncating type conversion (e.g. double -> float)
-        mesno.get_supported_arguments(['/utf-8']), language: args_for_langs)
+    add_project_arguments(cc.get_supported_arguments(
+            [
+            '/w44265', '/w44061', '/w44062', 
+            '/wd4018', '/wd4146', '/wd4244',
+            '/wd4305',
+            ]
+        ), language: lang)
 endif
 
 subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,6 @@
 
 
 project('unity', 'c',
-    version         : '2.4.3',
     license         : 'MIT',
     meson_version   : '>=0.50.0',
     default_options: [
@@ -67,7 +66,4 @@ endif
 
 subdir('src')
 
-unity_dep = declare_dependency(
-    version: meson.project_version(),
-    link_with: unity_lib,
-    include_directories: unity_dir)
+unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 ###################################################################################
 #                                                                                 #
-# NAME: src/meson.build                                                           #
+# NAME: meson.build                                                               #
 #                                                                                 #
 # AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
 # WRITTEN BY: Michael Brockus.                                                    #
@@ -9,12 +9,8 @@
 #                                                                                 #
 ###################################################################################
 
-
-
-unity_src = files('unity.c')
-
 unity_dir = include_directories('.')
 
-unity_lib = library(meson.project_name(), 
-    sources: unity_src,
+unity_lib = static_library(meson.project_name(), 
+    sources: ['unity.c'],
     include_directories: unity_dir)


### PR DESCRIPTION
I had some issues with the Meson support in the Unity repo so I fixed them.  The build scripts should be cleaner and readable, build your library as a static library for embedded development and work as expected after testing the changes.  The Meson example is updated to better show Meson build readability.