### PR TITLE
Update CMakeLists.txt minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # License: MIT                                                                    #
 #                                                                                 #
 ###################################################################################
-cmake_minimum_required(VERSION 3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 
 project(unity LANGUAGES C DESCRIPTION "C Unit testing framework.")


### PR DESCRIPTION
Update the CMAKE minimum version from `3` to `3.0` to fix error in Windows 10 x64 with CMAKE 3.15.4:

`cmake_minimum_required could not parse VERSION "3".`

While I was adding `Unity` to a new project using the provided CMakeLists.txt, I received the following error:

`    -- Building for: Visual Studio 12 2013
    CMake Error at CMakeLists.txt:11 (cmake_minimum_required):
      cmake_minimum_required could not parse VERSION "3".


    -- The C compiler identification is MSVC 18.0.21005.1
    -- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/bin/cl.exe
    -- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/bin/cl.exe -- works
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Configuring incomplete, errors occurred!
    See also "C:/git/Unity/output/CMakeFiles/CMakeOutput.log".
`

I was able to fix this exception by changing the minimum version from `3` to `3.0`.

Procedure
----------

1. Clone Unity (git clone https://github.com/ThrowTheSwitch/Unity)
2. Run CMAKE (cmake -S Unity -B output)

System Information
--------------------

Windows 10 x64 
CMAKE 3.15.4
Git 2.19.1.windows.1