### PR TITLE
Meson support upgrade to version 0.52.0.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 *.md        text
 makefile    text
 rakefile    text
+meson.build text
 
 
 #These files are binary and should not be normalized

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+builddir/
 test/sandbox
 .DS_Store
 examples/example_1/test1.exe
@@ -7,3 +8,4 @@ examples/example_2/all_tests.exe
 examples/example_1/test1.out
 examples/example_1/test2.out
 examples/example_2/all_tests.out
+examples/example_4/builddir

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 
 project('unity', 'c',
     license         : 'MIT',
-    meson_version   : '>=0.50.0',
+    meson_version   : '>=0.52.0',
     default_options: [
         'buildtype=minsize',
         'optimization=3', 


### PR DESCRIPTION
I have upgraded Meson build system support because 0.52.0 because it’s the most resonant and stable version at this time.  Also added entries in both gitattributes and gitignore files.