### PR TITLE
Make CMock_Verify() available as UnityRunner_Verify()

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -231,7 +231,7 @@ class UnityTestRunnerGenerator
 
   def create_mock_management(output, mock_headers)
     output.puts("\n/*=======Mock Management=====*/")
-    output.puts('static void CMock_Init(void)')
+    output.puts('void UnityRunner_Init(void)')
     output.puts('{')
 
     if @options[:enforce_strict_ordering]
@@ -247,7 +247,7 @@ class UnityTestRunnerGenerator
     end
     output.puts("}\n")
 
-    output.puts('static void CMock_Verify(void)')
+    output.puts('void UnityRunner_Verify(void)')
     output.puts('{')
     mocks.each do |mock|
       mock_clean = TypeSanitizer.sanitize_c_identifier(mock)
@@ -255,7 +255,7 @@ class UnityTestRunnerGenerator
     end
     output.puts("}\n")
 
-    output.puts('static void CMock_Destroy(void)')
+    output.puts('void UnityRunner_Destroy(void)')
     output.puts('{')
     mocks.each do |mock|
       mock_clean = TypeSanitizer.sanitize_c_identifier(mock)
@@ -300,9 +300,9 @@ class UnityTestRunnerGenerator
     output.puts("void #{@options[:test_reset_name]}(void)")
     output.puts('{')
     output.puts("  #{@options[:teardown_name]}();")
-    output.puts('  CMock_Verify();')
-    output.puts('  CMock_Destroy();')
-    output.puts('  CMock_Init();')
+    output.puts('  UnityRunner_Verify();')
+    output.puts('  UnityRunner_Destroy();')
+    output.puts('  UnityRunner_Init();')
     output.puts("  #{@options[:setup_name]}();")
     output.puts('}')
   end

--- a/auto/run_test.erb
+++ b/auto/run_test.erb
@@ -10,7 +10,7 @@ static void run_test(UnityTestFunction func, const char* name, int line_num)
     Unity.NumberOfTests++;
     UNITY_CLR_DETAILS();
     UNITY_EXEC_TIME_START();
-    CMock_Init();
+    UnityRunner_Init();
     if (TEST_PROTECT())
     {
 <% if @options[:plugins].include?(:cexception) %>
@@ -28,9 +28,9 @@ static void run_test(UnityTestFunction func, const char* name, int line_num)
     if (TEST_PROTECT())
     {
         <%= @options[:teardown_name] %>();
-        CMock_Verify();
+        UnityRunner_Verify();
     }
-    CMock_Destroy();
+    UnityRunner_Destroy();
     UNITY_EXEC_TIME_STOP();
     UnityConcludeTest();
 }

--- a/src/unity.h
+++ b/src/unity.h
@@ -41,6 +41,15 @@ void suiteSetUp(void);
 int suiteTearDown(int num_failures);
 
 /*-------------------------------------------------------
+ * Test Runner Interface
+ *-------------------------------------------------------*/
+
+/* These functions are provided by the generated test runner. */
+void UnityRunner_Init(void);
+void UnityRunner_Verify(void);
+void UnityRunner_Destroy(void);
+
+/*-------------------------------------------------------
  * Configuration Options
  *-------------------------------------------------------
  * All options described below should be passed as a compiler flag to all files using Unity. If you must add #defines, place them BEFORE the #include above.


### PR DESCRIPTION
Having UnityRunner_Verify() accessible from within tests is useful for verifying the call chain halfway through a longer, integration-style test.

This PR is basically equivalent to #376, only rebased on #454 and minimized.