### PR TITLE
Option to omit UnityBegin/UnityEnd calls in generate_test_runner

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1825,6 +1825,12 @@ void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int
 }
 
 /*-----------------------------------------------*/
+void UnitySetTestFile(const char* filename)
+{
+	Unity.TestFile = filename;
+}
+
+/*-----------------------------------------------*/
 void UnityBegin(const char* filename)
 {
     Unity.TestFile = filename;

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -477,6 +477,7 @@ extern struct UNITY_STORAGE_T Unity;
 
 void UnityBegin(const char* filename);
 int  UnityEnd(void);
+void UnitySetTestFile(const char* filename);
 void UnityConcludeTest(void);
 void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum);
 


### PR DESCRIPTION
By passing --omit_begin_end=1 to generate_test_runner.rb, the script
will now omit calls to UnityBegin and UnityEnd when running tests in a
suite.

This allows multiple suites to be executed in a row, and then have an overall
summary of the tests which were executed across all suites.