### PR TITLE
Keep Meson support back to 0.50.0:

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 
 project('unity', 'c',
     license         : 'MIT',
-    meson_version   : '>=0.52.0',
+    meson_version   : '>=0.50.0',
     default_options: ['warning_level=3', 'werror=true', 'c_std=c11']
 )
 lang = 'c'

--- a/meson.build
+++ b/meson.build
@@ -14,12 +14,7 @@
 project('unity', 'c',
     license         : 'MIT',
     meson_version   : '>=0.52.0',
-    default_options: [
-        'buildtype=minsize',
-        'optimization=3', 
-        'warning_level=3',
-        'werror=true',
-        ]
+    default_options: ['warning_level=3', 'werror=true', 'c_std=c11']
 )
 lang = 'c'
 cc = meson.get_compiler(lang)
@@ -33,8 +28,10 @@ cc = meson.get_compiler(lang)
 if cc.get_id() == 'clang'
     add_project_arguments(cc.get_supported_arguments(
             [
-            '-Wweak-vtables', '-Wexit-time-destructors',
-            '-Wglobal-constructors', '-Wmissing-noreturn' 
+                '-Wcast-qual', '-Wshadow', '-Wcast-align', '-Wweak-vtables',
+                '-Wold-style-cast', '-Wpointer-arith', '-Wconversion',
+                '-Wexit-time-destructors', '-Wglobal-constructors',
+                '-Wmissing-noreturn', '-Wmissing-prototypes', '-Wno-missing-braces'
             ]
         ), language: lang)
 endif
@@ -42,14 +39,14 @@ endif
 if cc.get_argument_syntax() == 'gcc'
     add_project_arguments(cc.get_supported_arguments(
             [
-            '-Wformat', '-Waddress', '-Winit-self', '-Wno-multichar',
-            '-Wpointer-arith'       , '-Wwrite-strings'              , 
-            '-Wno-parentheses'      , '-Wno-type-limits'             , 
-            '-Wformat-security'     , '-Wunreachable-code'           , 
-            '-Waggregate-return'    , '-Wformat-nonliteral'          ,
-            '-Wmissing-prototypes'  , '-Wold-style-definition'       ,
-            '-Wmissing-declarations', '-Wmissing-include-dirs'       , 
-            '-Wno-unused-parameter' , '-Wdeclaration-after-statement'
+                '-Wformat', '-Waddress', '-Winit-self', '-Wno-multichar',
+                '-Wpointer-arith'       , '-Wwrite-strings'              ,
+                '-Wno-parentheses'      , '-Wno-type-limits'             ,
+                '-Wformat-security'     , '-Wunreachable-code'           ,
+                '-Waggregate-return'    , '-Wformat-nonliteral'          ,
+                '-Wmissing-prototypes'  , '-Wold-style-definition'       ,
+                '-Wmissing-declarations', '-Wmissing-include-dirs'       ,
+                '-Wno-unused-parameter' , '-Wdeclaration-after-statement'
             ]
         ), language: lang)
 endif
@@ -57,9 +54,9 @@ endif
 if cc.get_id() == 'msvc'
     add_project_arguments(cc.get_supported_arguments(
             [
-            '/w44265', '/w44061', '/w44062', 
-            '/wd4018', '/wd4146', '/wd4244',
-            '/wd4305',
+                '/w44265', '/w44061', '/w44062',
+                '/wd4018', '/wd4146', '/wd4244',
+                '/wd4305', '/D _CRT_SECURE_NO_WARNINGS'
             ]
         ), language: lang)
 endif


### PR DESCRIPTION
Just going to keep Meson support back to 0.50.0 so more developers can use Unity
Also cleaned compiler flags.