### PR TITLE
fix float compare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,15 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 project(unity LANGUAGES C DESCRIPTION "C Unit testing framework.")
 
+set(custom_compiler_flags)
+
+list(APPEND custom_compiler_flags -Wfloat-equal)
+
+# apply custom compiler flags
+foreach(compiler_flag ${custom_compiler_flags})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${compiler_flag}")
+endforeach()
+
 add_subdirectory(src)
 target_include_directories(unity
     PUBLIC 

--- a/src/unity.c
+++ b/src/unity.c
@@ -74,6 +74,20 @@ static const char PROGMEM UnityStrDetail2Name[]            = " " UNITY_DETAIL2_N
  *-----------------------------------------------*/
 
 /*-----------------------------------------------*/
+static int compare_float(float a, float b)
+{
+    return (fabs(a - b) <= UNITY_FLOAT_PRECISION);
+}
+
+#ifndef UNITY_EXCLUDE_DOUBLE
+/*-----------------------------------------------*/
+static int compare_double(double a, double b)
+{
+    return (fabs(a - b) <= UNITY_DOUBLE_PRECISION);
+}
+#endif /* not UNITY_EXCLUDE_DOUBLE */
+
+/*-----------------------------------------------*/
 /* Local helper function to print characters. */
 static void UnityPrintChar(const char* pch)
 {
@@ -468,7 +482,7 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
     }
 
     /* handle zero, NaN, and +/- infinity */
-    if (number == 0.0f)
+    if (compare_double(number, 0.0f))
     {
         UnityPrint("0");
     }
@@ -533,7 +547,7 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
 
 #ifndef UNITY_ROUND_TIES_AWAY_FROM_ZERO
         /* round to even if exactly between two integers */
-        if ((n & 1) && (((UNITY_DOUBLE)n - number) == 0.5f))
+        if ((n & 1) && (compare_double(((UNITY_DOUBLE)n - number), 0.5f)))
             n--;
 #endif
 

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -7,9 +7,9 @@
 #ifndef UNITY_INTERNALS_H
 #define UNITY_INTERNALS_H
 
-#ifdef UNITY_INCLUDE_CONFIG_H
-#include "unity_config.h"
-#endif
+/*#ifdef UNITY_INCLUDE_CONFIG_H*/
+#include "../examples/unity_config.h"
+/*#endif*/
 
 #ifndef UNITY_EXCLUDE_SETJMP_H
 #include <setjmp.h>
@@ -208,7 +208,7 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
 #ifndef isnan
 /* NaN is the only floating point value that does NOT equal itself.
  * Therefore if n != n, then it is NaN. */
-#define isnan(n) ((n != n) ? 1 : 0)
+#define isnan(n) ((fabs(n - n) >= UNITY_FLOAT_PRECISION) ? 1 : 0)
 #endif
 
 #endif


### PR DESCRIPTION
when `-Wfloat-equal` option is configured, float number compared with `==` will report an error, replace it with `fabs(a-b) < PRECISION` is more safe.