### PR TITLE
auto: Only create run_test() function if it's needed.

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -92,7 +92,7 @@ class UnityTestRunnerGenerator
       create_suite_setup(output)
       create_suite_teardown(output)
       create_reset(output)
-      create_run_test(output)
+      create_run_test(output) unless tests.empty?
       create_args_wrappers(output, tests)
       create_main(output, input_file, tests, used_mocks)
     end
@@ -325,8 +325,8 @@ class UnityTestRunnerGenerator
 
   def create_run_test(output)
     require 'erb'
-    template = ERB.new(File.read(File.join(__dir__, 'run_test.erb')))
-    output.puts(template.result(binding))
+    template = ERB.new(File.read(File.join(__dir__, 'run_test.erb')), nil, '<>')
+    output.puts("\n" + template.result(binding))
   end
 
   def create_args_wrappers(output, tests)
@@ -346,7 +346,7 @@ class UnityTestRunnerGenerator
   end
 
   def create_main(output, filename, tests, used_mocks)
-    output.puts("\n\n/*=======MAIN=====*/")
+    output.puts("\n/*=======MAIN=====*/")
     main_name = @options[:main_name].to_sym == :auto ? "main_#{filename.gsub('.c', '')}" : (@options[:main_name]).to_s
     if @options[:cmdline_args]
       if main_name != 'main'

--- a/auto/run_test.erb
+++ b/auto/run_test.erb
@@ -16,13 +16,14 @@ static void run_test(UnityTestFunction func, const char* name, int line_num)
 <% if @options[:plugins].include?(:cexception) %>
         CEXCEPTION_T e;
         Try {
-<% end %>
             <%= @options[:setup_name] %>();
             func();
-<% if @options[:plugins].include?(:cexception) %>
         } Catch(e) {
             TEST_ASSERT_EQUAL_HEX32_MESSAGE(CEXCEPTION_NONE, e, "Unhandled Exception!");
         }
+<% else %>
+        <%= @options[:setup_name] %>();
+        func();
 <% end %>
     }
     if (TEST_PROTECT())


### PR DESCRIPTION
Also fix some whitespace consistency issues.
Use 2 newlines (not 1 or 3) before /*====Heading====*/ comments.