### PR TITLE
Add UNITY_PRINT_TEST_CONTEXT.

### DIFF
--- a/docs/UnityConfigurationGuide.md
+++ b/docs/UnityConfigurationGuide.md
@@ -350,7 +350,7 @@ specifying `UNITY_USE_FLUSH_STDOUT`. No other defines are required.
 ##### `UNITY_OUTPUT_FOR_QT_CREATOR`
 
 When managing your own builds, it is often handy to have messages output in a format which is
-recognized by your IDE. These are some standard formats which can be supported. If you're using 
+recognized by your IDE. These are some standard formats which can be supported. If you're using
 Ceedling to manage your builds, it is better to stick with the standard format (leaving these
 all undefined) and allow Ceedling to use its own decorators.
 
@@ -378,6 +378,24 @@ _Example:_
 #define UNITY_PRINT_EOL { UNITY_OUTPUT_CHAR('\r'); UNITY_OUTPUT_CHAR('\n') }
 ```
 
+##### `UNITY_PRINT_TEST_CONTEXT`
+
+This option allows you to specify your own function to print additional context
+as part of the error message when a test has failed.  It can be useful if you
+want to output some specific information about the state of the test at the
+point of failure, and `UNITY_SET_DETAILS` isn't flexible enough for your needs.
+
+_Example:_
+```C
+#define UNITY_PRINT_TEST_CONTEXT PrintIterationCount
+
+int iteration_count;
+
+void PrintIterationCount(void)
+{
+    UnityPrintFormatted("At iteration #%d: ", iteration_count);
+}
+```
 
 ##### `UNITY_EXCLUDE_DETAILS`
 
@@ -441,12 +459,12 @@ will allow you to specify how Unity will treat these assertions.
 
 #### `UNITY_SUPPORT_VARIADIC_MACROS`
 
-This will force Unity to support variadic macros when using its own built-in 
+This will force Unity to support variadic macros when using its own built-in
 RUN_TEST macro. This will rarely be necessary. Most often, Unity will automatically
 detect if the compiler supports variadic macros by checking to see if it's C99+
 compatible. In the event that the compiler supports variadic macros, but is primarily
-C89 (ANSI), defining this option will allow you to use them. This option is also not 
-necessary when using Ceedling or the test runner generator script. 
+C89 (ANSI), defining this option will allow you to use them. This option is also not
+necessary when using Ceedling or the test runner generator script.
 
 ## Getting Into The Guts
 

--- a/src/unity.c
+++ b/src/unity.c
@@ -600,6 +600,27 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
 #endif /* ! UNITY_EXCLUDE_FLOAT_PRINT */
 
 /*-----------------------------------------------*/
+static void UnityPrintContext(void)
+{
+#ifdef UNITY_PRINT_TEST_CONTEXT
+    UNITY_PRINT_TEST_CONTEXT();
+#endif
+#ifndef UNITY_EXCLUDE_DETAILS
+    if (Unity.CurrentDetail1)
+    {
+        UnityPrint(UnityStrDetail1Name);
+        UnityPrint(Unity.CurrentDetail1);
+        if (Unity.CurrentDetail2)
+        {
+            UnityPrint(UnityStrDetail2Name);
+            UnityPrint(Unity.CurrentDetail2);
+        }
+        UnityPrint(UnityStrSpacer);
+    }
+#endif
+}
+
+/*-----------------------------------------------*/
 static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
 {
 #ifdef UNITY_OUTPUT_FOR_ECLIPSE
@@ -680,19 +701,7 @@ static void UnityAddMsgIfSpecified(const char* msg)
     if (msg)
     {
         UnityPrint(UnityStrSpacer);
-#ifndef UNITY_EXCLUDE_DETAILS
-        if (Unity.CurrentDetail1)
-        {
-            UnityPrint(UnityStrDetail1Name);
-            UnityPrint(Unity.CurrentDetail1);
-            if (Unity.CurrentDetail2)
-            {
-                UnityPrint(UnityStrDetail2Name);
-                UnityPrint(Unity.CurrentDetail2);
-            }
-            UnityPrint(UnityStrSpacer);
-        }
-#endif
+        UnityPrintContext();
         UnityPrint(msg);
     }
 }
@@ -1745,20 +1754,7 @@ void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
     if (msg != NULL)
     {
         UNITY_OUTPUT_CHAR(':');
-
-#ifndef UNITY_EXCLUDE_DETAILS
-        if (Unity.CurrentDetail1)
-        {
-            UnityPrint(UnityStrDetail1Name);
-            UnityPrint(Unity.CurrentDetail1);
-            if (Unity.CurrentDetail2)
-            {
-                UnityPrint(UnityStrDetail2Name);
-                UnityPrint(Unity.CurrentDetail2);
-            }
-            UnityPrint(UnityStrSpacer);
-        }
-#endif
+        UnityPrintContext();
         if (msg[0] != ' ')
         {
             UNITY_OUTPUT_CHAR(' ');

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -485,6 +485,10 @@ void UnityConcludeTest(void);
 void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum);
 #endif
 
+#ifdef UNITY_PRINT_TEST_CONTEXT
+void UNITY_PRINT_TEST_CONTEXT(void);
+#endif
+
 /*-------------------------------------------------------
  * Details Support
  *-------------------------------------------------------*/


### PR DESCRIPTION
This option allows you to specify your own function to print additional context
as part of the error message when a test has failed.  It can be useful if you
want to output some specific information about the state of the test at the
point of failure, and UNITY_SET_DETAILS isn't flexible enough for your needs.