### PR TITLE
add support for header files with extensions other than only .h

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -170,9 +170,9 @@ class UnityTestRunnerGenerator
 
     # parse out includes
     includes = {
-      local: source.scan(/^\s*#include\s+\"\s*(.+)\.[hH]\s*\"/).flatten,
+      local: source.scan(/^\s*#include\s+\"\s*(.+)\s*\"/).flatten,
       system: source.scan(/^\s*#include\s+<\s*(.+)\s*>/).flatten.map { |inc| "<#{inc}>" },
-      linkonly: source.scan(/^TEST_FILE\(\s*\"\s*(.+)\.[cC]\w*\s*\"/).flatten
+      linkonly: source.scan(/^TEST_FILE\(\s*\"\s*(.+)\s*\"/).flatten
     }
     includes
   end
@@ -205,14 +205,14 @@ class UnityTestRunnerGenerator
       output.puts("#include \"#{File.basename(@options[:header_file])}\"")
     else
       @options[:includes].flatten.uniq.compact.each do |inc|
-        output.puts("#include #{inc.include?('<') ? inc : "\"#{inc.gsub('.h', '')}.h\""}")
+        output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
       end
       testfile_includes.each do |inc|
-        output.puts("#include #{inc.include?('<') ? inc : "\"#{inc.gsub('.h', '')}.h\""}")
+        output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
       end
     end
     mocks.each do |mock|
-      output.puts("#include \"#{mock.gsub('.h', '')}.h\"")
+      output.puts("#include \"#{mock}\"")
     end
     output.puts('#include "CException.h"') if @options[:plugins].include?(:cexception)
 
@@ -247,7 +247,7 @@ class UnityTestRunnerGenerator
       output.puts('  GlobalOrderError = NULL;')
     end
 
-    mocks = mock_headers.map { |mock| File.basename(mock) }
+    mocks = mock_headers.map { |mock| File.basename(mock, '.*') }
     mocks.each do |mock|
       mock_clean = TypeSanitizer.sanitize_c_identifier(mock)
       output.puts("  #{mock_clean}_Init();")
@@ -423,10 +423,10 @@ class UnityTestRunnerGenerator
     output.puts("#include \"#{@options[:framework]}.h\"")
     output.puts('#include "cmock.h"') unless used_mocks.empty?
     @options[:includes].flatten.uniq.compact.each do |inc|
-      output.puts("#include #{inc.include?('<') ? inc : "\"#{inc.gsub('.h', '')}.h\""}")
+      output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
     end
     testfile_includes.each do |inc|
-      output.puts("#include #{inc.include?('<') ? inc : "\"#{inc.gsub('.h', '')}.h\""}")
+      output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
     end
     output.puts "\n"
     tests.each do |test|


### PR DESCRIPTION
This is an initial step for adding support to CMock to support files with extensions other than only .h and .c. For example this permits easier use with C++ projects that use file extensions like .hh, .hpp, .cc, .cpp, .cxx, etc.