### PR TITLE
Adding Meson scripts to expos code from extras.

### DIFF
--- a/examples/example_4/meson.build
+++ b/examples/example_4/meson.build
@@ -1,14 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 project('example-4', 'c')
 
 unity_dep = dependency('unity', fallback : ['unity', 'unity_dep'])

--- a/examples/example_4/src/meson.build
+++ b/examples/example_4/src/meson.build
@@ -1,14 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 inc_dir = include_directories('.')
 lib_list = {'a': ['ProductionCode.c' ], 'b': ['ProductionCode2.c']}
 

--- a/examples/example_4/test/meson.build
+++ b/examples/example_4/test/meson.build
@@ -1,12 +1,7 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 subdir('test_runners')

--- a/examples/example_4/test/test_runners/meson.build
+++ b/examples/example_4/test/test_runners/meson.build
@@ -1,16 +1,13 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
-cases = [['TestProductionCode_Runner.c',  join_paths('..' ,'TestProductionCode.c')], 
-        ['TestProductionCode2_Runner.c', join_paths('..' ,'TestProductionCode2.c')]]
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
+cases = [
+          ['TestProductionCode_Runner.c',  join_paths('..' ,'TestProductionCode.c' )], 
+          ['TestProductionCode2_Runner.c', join_paths('..' ,'TestProductionCode2.c')]
+        ]
 
 test('Running: 01-test-case', executable('01-test-case', cases[0], dependencies: [ a_dep, unity_dep ]))
 test('Running: 02-test-case', executable('02-test-case', cases[1], dependencies: [ b_dep, unity_dep ]))

--- a/extras/fixture/meson.build
+++ b/extras/fixture/meson.build
@@ -1,0 +1,11 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
+# WRITTEN BY: Michael Brockus.                                                    #
+#                                                                                 #
+# License: MIT                                                                    #
+#                                                                                 #
+###################################################################################
+subdir('src')

--- a/extras/fixture/meson.build
+++ b/extras/fixture/meson.build
@@ -1,11 +1,7 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 subdir('src')

--- a/extras/fixture/src/meson.build
+++ b/extras/fixture/src/meson.build
@@ -1,13 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 unity_fixture_dir = include_directories('.')
 
 unity_fixture_lib = static_library('unity_fixture', 

--- a/extras/fixture/src/meson.build
+++ b/extras/fixture/src/meson.build
@@ -1,0 +1,17 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
+# WRITTEN BY: Michael Brockus.                                                    #
+#                                                                                 #
+# License: MIT                                                                    #
+#                                                                                 #
+###################################################################################
+unity_fixture_dir = include_directories('.')
+
+unity_fixture_lib = static_library('unity_fixture', 
+    sources: ['unity_fixture.c'],
+    link_with: unity_memory_lib,
+    dependencies: unity_dep,
+    include_directories: [unity_fixture_dir, unity_memory_dir])

--- a/extras/memory/meson.build
+++ b/extras/memory/meson.build
@@ -1,0 +1,11 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
+# WRITTEN BY: Michael Brockus.                                                    #
+#                                                                                 #
+# License: MIT                                                                    #
+#                                                                                 #
+###################################################################################
+subdir('src')

--- a/extras/memory/meson.build
+++ b/extras/memory/meson.build
@@ -1,11 +1,7 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 subdir('src')

--- a/extras/memory/src/meson.build
+++ b/extras/memory/src/meson.build
@@ -1,13 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 unity_memory_dir = include_directories('.')
 
 unity_memory_lib = static_library('unity_memory', 

--- a/extras/memory/src/meson.build
+++ b/extras/memory/src/meson.build
@@ -1,0 +1,16 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
+# WRITTEN BY: Michael Brockus.                                                    #
+#                                                                                 #
+# License: MIT                                                                    #
+#                                                                                 #
+###################################################################################
+unity_memory_dir = include_directories('.')
+
+unity_memory_lib = static_library('unity_memory', 
+    sources: ['unity_memory.c'],
+    dependencies: unity_dep,
+    include_directories: unity_memory_dir)

--- a/extras/meson.build
+++ b/extras/meson.build
@@ -1,12 +1,8 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 subdir('memory')
 subdir('fixture')

--- a/extras/meson.build
+++ b/extras/meson.build
@@ -1,0 +1,12 @@
+###################################################################################
+#                                                                                 #
+# NAME: meson.build                                                               #
+#                                                                                 #
+# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
+# WRITTEN BY: Michael Brockus.                                                    #
+#                                                                                 #
+# License: MIT                                                                    #
+#                                                                                 #
+###################################################################################
+subdir('memory')
+subdir('fixture')

--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 project('unity', 'c',
     license: 'MIT',
     meson_version: '>=0.53.0',

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@
 ###################################################################################
 project('unity', 'c',
     license: 'MIT',
-    meson_version: '>=0.50.0',
+    meson_version: '>=0.53.0',
     default_options: ['layout=flat', 'warning_level=3', 'werror=true', 'c_std=c11']
 )
 

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,38 @@ project('unity', 'c',
     meson_version: '>=0.53.0',
     default_options: ['layout=flat', 'warning_level=3', 'werror=true', 'c_std=c11']
 )
+lang = 'c'
+cc = meson.get_compiler(lang)
+
+#
+# Meson: Add compiler flags
+if cc.get_id() == 'clang'
+    add_project_arguments(cc.get_supported_arguments(
+            [
+                '-Wexit-time-destructors',
+                '-Wglobal-constructors',
+                '-Wmissing-prototypes',
+                '-Wmissing-noreturn',
+                '-Wno-missing-braces',
+                '-Wold-style-cast', '-Wpointer-arith', '-Wweak-vtables',
+                '-Wcast-align', '-Wconversion', '-Wcast-qual', '-Wshadow'
+            ]
+        ), language: lang)
+endif
+
+if cc.get_argument_syntax() == 'gcc'
+    add_project_arguments(cc.get_supported_arguments(
+            [
+                '-Wformat', '-Waddress', '-Winit-self', '-Wno-multichar',
+                '-Wpointer-arith'       , '-Wwrite-strings'              ,
+                '-Wno-parentheses'      , '-Wno-type-limits'             ,
+                '-Wformat-security'     , '-Wunreachable-code'           ,
+                '-Waggregate-return'    , '-Wformat-nonliteral'          ,
+                '-Wmissing-declarations', '-Wmissing-include-dirs'       ,
+                '-Wno-unused-parameter'
+            ]
+        ), language: lang)
+endif
 
 #
 # Sub directory to project source code

--- a/meson.build
+++ b/meson.build
@@ -8,13 +8,10 @@
 # License: MIT                                                                    #
 #                                                                                 #
 ###################################################################################
-
-
-
 project('unity', 'c',
-    license         : 'MIT',
-    meson_version   : '>=0.50.0',
-    default_options: ['warning_level=3', 'werror=true', 'c_std=c11']
+    license: 'MIT',
+    meson_version: '>=0.50.0',
+    default_options: ['layout=flat', 'werror=true', 'c_std=c11']
 )
 lang = 'c'
 cc = meson.get_compiler(lang)
@@ -62,5 +59,8 @@ if cc.get_id() == 'msvc'
 endif
 
 subdir('src')
-
 unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)
+
+subdir('extras')
+unity_fixture_dep = declare_dependency(link_with: unity_fixture_lib, include_directories: unity_fixture_dir)
+unity_memory_dep  = declare_dependency(link_with: unity_memory_lib,  include_directories: unity_memory_dir)

--- a/meson.build
+++ b/meson.build
@@ -11,56 +11,16 @@
 project('unity', 'c',
     license: 'MIT',
     meson_version: '>=0.50.0',
-    default_options: ['layout=flat', 'werror=true', 'c_std=c11']
+    default_options: ['layout=flat', 'warning_level=3', 'werror=true', 'c_std=c11']
 )
-lang = 'c'
-cc = meson.get_compiler(lang)
 
-
-##
 #
-# Meson: Add compiler flags
-#
-##
-if cc.get_id() == 'clang'
-    add_project_arguments(cc.get_supported_arguments(
-            [
-                '-Wcast-qual', '-Wshadow', '-Wcast-align', '-Wweak-vtables',
-                '-Wold-style-cast', '-Wpointer-arith', '-Wconversion',
-                '-Wexit-time-destructors', '-Wglobal-constructors',
-                '-Wmissing-noreturn', '-Wmissing-prototypes', '-Wno-missing-braces'
-            ]
-        ), language: lang)
-endif
-
-if cc.get_argument_syntax() == 'gcc'
-    add_project_arguments(cc.get_supported_arguments(
-            [
-                '-Wformat', '-Waddress', '-Winit-self', '-Wno-multichar',
-                '-Wpointer-arith'       , '-Wwrite-strings'              ,
-                '-Wno-parentheses'      , '-Wno-type-limits'             ,
-                '-Wformat-security'     , '-Wunreachable-code'           ,
-                '-Waggregate-return'    , '-Wformat-nonliteral'          ,
-                '-Wmissing-prototypes'  , '-Wold-style-definition'       ,
-                '-Wmissing-declarations', '-Wmissing-include-dirs'       ,
-                '-Wno-unused-parameter' , '-Wdeclaration-after-statement'
-            ]
-        ), language: lang)
-endif
-
-if cc.get_id() == 'msvc'
-    add_project_arguments(cc.get_supported_arguments(
-            [
-                '/w44265', '/w44061', '/w44062',
-                '/wd4018', '/wd4146', '/wd4244',
-                '/wd4305', '/D _CRT_SECURE_NO_WARNINGS'
-            ]
-        ), language: lang)
-endif
-
+# Sub directory to project source code
 subdir('src')
 unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)
 
+#
+# Exposing extra add-ons from the extras directory
 subdir('extras')
 unity_fixture_dep = declare_dependency(link_with: unity_fixture_lib, include_directories: unity_fixture_dir)
 unity_memory_dep  = declare_dependency(link_with: unity_memory_lib,  include_directories: unity_memory_dir)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,14 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 unity_dir = include_directories('.')
 
 unity_lib = static_library(meson.project_name(), 


### PR DESCRIPTION
I have added more build scripts to expose the extra code from the extras directory.

Also removed any flags that clould chock the C++ compiler and all Windows MSVC compiler, bump support version to 0.53.0 do to senescent fixes in compiler support for embedded platforms, and to keep the improved static linking from Meson 0.52.0.