### PR TITLE
Cleaning Meson build support implementation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
     - os: linux
       dist: trusty
       compiler: gcc
+    - os: linux
+      dist: trusty
+      compiler: clang
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then rvm install 2.3 && rvm use 2.3 && ruby -v; fi

--- a/examples/example_4/meson.build
+++ b/examples/example_4/meson.build
@@ -1,14 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 project('example-4', 'c')
 
 unity_dep = dependency('unity', fallback : ['unity', 'unity_dep'])

--- a/examples/example_4/src/meson.build
+++ b/examples/example_4/src/meson.build
@@ -1,14 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 inc_dir = include_directories('.')
 lib_list = {'a': ['ProductionCode.c' ], 'b': ['ProductionCode2.c']}
 

--- a/examples/example_4/test/meson.build
+++ b/examples/example_4/test/meson.build
@@ -1,12 +1,7 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 subdir('test_runners')

--- a/examples/example_4/test/test_runners/meson.build
+++ b/examples/example_4/test/test_runners/meson.build
@@ -1,16 +1,13 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
-cases = [['TestProductionCode_Runner.c',  join_paths('..' ,'TestProductionCode.c')], 
-        ['TestProductionCode2_Runner.c', join_paths('..' ,'TestProductionCode2.c')]]
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
+cases = [
+          ['TestProductionCode_Runner.c',  join_paths('..' ,'TestProductionCode.c' )], 
+          ['TestProductionCode2_Runner.c', join_paths('..' ,'TestProductionCode2.c')]
+        ]
 
 test('Running: 01-test-case', executable('01-test-case', cases[0], dependencies: [ a_dep, unity_dep ]))
 test('Running: 02-test-case', executable('02-test-case', cases[1], dependencies: [ b_dep, unity_dep ]))

--- a/meson.build
+++ b/meson.build
@@ -1,37 +1,29 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
-
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 project('unity', 'c',
-    license         : 'MIT',
-    meson_version   : '>=0.50.0',
-    default_options: ['warning_level=3', 'werror=true', 'c_std=c11']
+    license: 'MIT',
+    meson_version: '>=0.53.0',
+    default_options: ['layout=flat', 'warning_level=3', 'werror=true', 'c_std=c11']
 )
 lang = 'c'
 cc = meson.get_compiler(lang)
 
-
-##
 #
 # Meson: Add compiler flags
-#
-##
 if cc.get_id() == 'clang'
     add_project_arguments(cc.get_supported_arguments(
             [
-                '-Wcast-qual', '-Wshadow', '-Wcast-align', '-Wweak-vtables',
-                '-Wold-style-cast', '-Wpointer-arith', '-Wconversion',
-                '-Wexit-time-destructors', '-Wglobal-constructors',
-                '-Wmissing-noreturn', '-Wmissing-prototypes', '-Wno-missing-braces'
+                '-Wexit-time-destructors',
+                '-Wglobal-constructors',
+                '-Wmissing-prototypes',
+                '-Wmissing-noreturn',
+                '-Wno-missing-braces',
+                '-Wold-style-cast', '-Wpointer-arith', '-Wweak-vtables',
+                '-Wcast-align', '-Wconversion', '-Wcast-qual', '-Wshadow'
             ]
         ), language: lang)
 endif
@@ -44,23 +36,13 @@ if cc.get_argument_syntax() == 'gcc'
                 '-Wno-parentheses'      , '-Wno-type-limits'             ,
                 '-Wformat-security'     , '-Wunreachable-code'           ,
                 '-Waggregate-return'    , '-Wformat-nonliteral'          ,
-                '-Wmissing-prototypes'  , '-Wold-style-definition'       ,
                 '-Wmissing-declarations', '-Wmissing-include-dirs'       ,
-                '-Wno-unused-parameter' , '-Wdeclaration-after-statement'
+                '-Wno-unused-parameter'
             ]
         ), language: lang)
 endif
 
-if cc.get_id() == 'msvc'
-    add_project_arguments(cc.get_supported_arguments(
-            [
-                '/w44265', '/w44061', '/w44062',
-                '/wd4018', '/wd4146', '/wd4244',
-                '/wd4305', '/D _CRT_SECURE_NO_WARNINGS'
-            ]
-        ), language: lang)
-endif
-
+#
+# Sub directory to project source code
 subdir('src')
-
 unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,14 +1,9 @@
-###################################################################################
-#                                                                                 #
-# NAME: meson.build                                                               #
-#                                                                                 #
-# AUTHOR: Mike Karlesky, Mark VanderVoord, Greg Williams.                         #
-# WRITTEN BY: Michael Brockus.                                                    #
-#                                                                                 #
-# License: MIT                                                                    #
-#                                                                                 #
-###################################################################################
-
+#
+# build script written by : Michael Brockus.
+# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
+#
+# license: MIT
+#
 unity_dir = include_directories('.')
 
 unity_lib = static_library(meson.project_name(), 


### PR DESCRIPTION
Cleaning up Unity's Meson build scripts and keeping them updated, removed flags that may choke either C++ or MSVC compilers, and bump build system minimum version required number to 0.53.0 since Meson will have better support for bare-metal targets.

I also added Clang to the CI file.