### PR TITLE
Wrap UNITY_TEST_ASSERT in a do ... while(0) block

### DIFF
--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -763,7 +763,7 @@ int UnityTestMatches(void);
  * Test Asserts
  *-------------------------------------------------------*/
 
-#define UNITY_TEST_ASSERT(condition, line, message)                                              if (condition) {} else {UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), (message));}
+#define UNITY_TEST_ASSERT(condition, line, message)                                              do {if (condition) {} else {UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), (message));}} while(0)
 #define UNITY_TEST_ASSERT_NULL(pointer, line, message)                                           UNITY_TEST_ASSERT(((pointer) == NULL),  (UNITY_LINE_TYPE)(line), (message))
 #define UNITY_TEST_ASSERT_NOT_NULL(pointer, line, message)                                       UNITY_TEST_ASSERT(((pointer) != NULL),  (UNITY_LINE_TYPE)(line), (message))
 #define UNITY_TEST_ASSERT_EMPTY(pointer, line, message)                                          UNITY_TEST_ASSERT(((pointer[0]) == 0),  (UNITY_LINE_TYPE)(line), (message))

--- a/test/tests/test_unity_core.c
+++ b/test/tests/test_unity_core.c
@@ -133,6 +133,19 @@ void testFalse(void)
     TEST_ASSERT_UNLESS(0);
 }
 
+void testSingleStatement(void)
+{
+    for(int i = 0; i < 2; i++)
+    {
+        /* TEST_ASSERT_TRUE should expand to a single C statement, minus
+         * the semicolon. This if-else will fail to compile otherwise. */
+        if(i > 0)
+            TEST_ASSERT_TRUE(i);
+        else
+            TEST_ASSERT_FALSE(i);
+    }
+}
+
 void testPreviousPass(void)
 {
     TEST_ASSERT_EQUAL_INT(0U, Unity.TestFailures);


### PR DESCRIPTION
This ensures that constructions like the following work correctly:

  if(condition)
    TEST_ASSERT(a);
  else
    TEST_ASSERT(b);