### PR TITLE
More elegant RUN_TEST macro

### DIFF
--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -701,11 +701,8 @@ extern const char UnityStrErrShorthand[];
 #endif
 #endif
 #ifdef UNITY_SUPPORT_VARIADIC_MACROS
-#define RUN_TEST(...) UnityDefaultTestRun(RUN_TEST_FIRST(__VA_ARGS__), RUN_TEST_SECOND(__VA_ARGS__))
-#define RUN_TEST_FIRST(...) RUN_TEST_FIRST_HELPER(__VA_ARGS__, throwaway)
-#define RUN_TEST_FIRST_HELPER(first, ...) (first), #first
-#define RUN_TEST_SECOND(...) RUN_TEST_SECOND_HELPER(__VA_ARGS__, __LINE__, throwaway)
-#define RUN_TEST_SECOND_HELPER(first, second, ...) (second)
+#define RUN_TEST(...) RUN_TEST_AT_LINE(__VA_ARGS__, __LINE__)
+#define RUN_TEST_AT_LINE(func, line, ...) UnityDefaultTestRun(func, #func, line)
 #endif
 #endif
 


### PR DESCRIPTION
Here is a RUN_TEST macro that is equivalent in functionality to the old one but is much more easy to read and understand (in my opinon of course)

The RUN_TEST_AT_LINE macro could be changed to
`#define RUN_TEST_AT_LINE(func, line, ...) UnityDefaultTestRun((func), #func, (line))`
to have an identical output to the old one but that's a few extra parenthesis too many for my taste.