### PR TITLE
 allow compilation with stricter warnings

### DIFF
--- a/auto/run_test.erb
+++ b/auto/run_test.erb
@@ -1,5 +1,5 @@
 /*=======Test Runner Used To Run Each Test=====*/
-static void run_test(UnityTestFunction func, const char* name, int line_num)
+static void run_test(UnityTestFunction func, const char* name, UNITY_LINE_TYPE line_num)
 {
     Unity.CurrentTestName = name;
     Unity.CurrentTestLineNumber = line_num;

--- a/src/unity.c
+++ b/src/unity.c
@@ -1001,6 +1001,7 @@ void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
             is_trait = !isinf(actual) && !isnan(actual);
             break;
 
+        case UNITY_FLOAT_INVALID_TRAIT:
         default:
             trait_index = 0;
             trait_names[0] = UnityStrInvalidFloatTrait;
@@ -1141,6 +1142,7 @@ void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
             is_trait = !isinf(actual) && !isnan(actual);
             break;
 
+        case UNITY_FLOAT_INVALID_TRAIT:
         default:
             trait_index = 0;
             trait_names[0] = UnityStrInvalidFloatTrait;


### PR DESCRIPTION
These two patches allow a source base to be compiled with more strict warnings -Wsign-compare and -Wswitch-enum enabled.