### PR TITLE
unity: annotate noreturn APIs (fix Wsuggest-attribute=noreturn warnings)

### DIFF
--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -40,6 +40,12 @@
 #include <limits.h>
 #endif
 
+#if defined __GNUC__
+#    define UNITY_FUNCTION_ATTR(a) __attribute__((a))
+#else
+#    define UNITY_FUNCTION_ATTR(a) /* ignore */
+#endif
+
 /*-------------------------------------------------------
  * Guess Widths If Not Specified
  *-------------------------------------------------------*/
@@ -611,8 +617,8 @@ void UnityAssertNumbersArrayWithin(const UNITY_UINT delta,
                                    const UNITY_DISPLAY_STYLE_T style,
                                    const UNITY_FLAGS_T flags);
 
-void UnityFail(const char* message, const UNITY_LINE_TYPE line);
-void UnityIgnore(const char* message, const UNITY_LINE_TYPE line);
+void UnityFail(const char* message, const UNITY_LINE_TYPE line) UNITY_FUNCTION_ATTR(noreturn);
+void UnityIgnore(const char* message, const UNITY_LINE_TYPE line) UNITY_FUNCTION_ATTR(noreturn);
 void UnityMessage(const char* message, const UNITY_LINE_TYPE line);
 
 #ifndef UNITY_EXCLUDE_FLOAT


### PR DESCRIPTION
GCC (& Clang) have the notion of pure and const functions [1],
where those attributes are intended to help the optimiser.

Annotate a few APIs here with the appropriate key words, which
also fixes Wsuggest-attribute=noreturn warning, which a
source base might have enabled:
Compiling unity.c...
.../src/unity.c: In function ‘UnityFail’:
.../src/unity.c:1759:6: warning: function might be candidate for attribute ‘noreturn’ [-Wsuggest-attribute=noreturn]
 1759 | void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
      |      ^~~~~~~~~
.../src/unity.c: In function ‘UnityIgnore’:
.../src/unity.c:1796:6: warning: function might be candidate for attribute ‘noreturn’ [-Wsuggest-attribute=noreturn]
 1796 | void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
      |      ^~~~~~~~~~~

[1] https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html

Signed-off-by: André Draszik <git@andred.net>