### PR TITLE
Fix warning for issue #507

### DIFF
--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -617,8 +617,14 @@ void UnityAssertNumbersArrayWithin(const UNITY_UINT delta,
                                    const UNITY_DISPLAY_STYLE_T style,
                                    const UNITY_FLAGS_T flags);
 
+#ifndef UNITY_EXCLUDE_SETJMP_H
 void UnityFail(const char* message, const UNITY_LINE_TYPE line) UNITY_FUNCTION_ATTR(noreturn);
 void UnityIgnore(const char* message, const UNITY_LINE_TYPE line) UNITY_FUNCTION_ATTR(noreturn);
+#else
+void UnityFail(const char* message, const UNITY_LINE_TYPE line);
+void UnityIgnore(const char* message, const UNITY_LINE_TYPE line);
+#endif
+
 void UnityMessage(const char* message, const UNITY_LINE_TYPE line);
 
 #ifndef UNITY_EXCLUDE_FLOAT


### PR DESCRIPTION
UnityFail() and UnityIgnore had the 'noreturn' attribute set with long jumps disabled