### PR TITLE
Fix for MSVC compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,9 @@ target_compile_options(${PROJECT_NAME}
                                  -Wno-missing-braces
                                  -Wold-style-cast
                                  -Wshadow
-                                 -Wweak-vtables>
+                                 -Wweak-vtables
+                                 -Werror
+                                 -Wall>
         $<$<C_COMPILER_ID:GNU>:-Waddress
                                -Waggregate-return
                                -Wformat-nonliteral
@@ -101,9 +103,10 @@ target_compile_options(${PROJECT_NAME}
                                -Wno-unused-parameter
                                -Wunreachable-code
                                -Wwrite-strings
-                               -Wpointer-arith>
-        -Wall
-        -Werror
+                               -Wpointer-arith
+                               -Werror
+                               -Wall>
+       $<$<C_COMPILER_ID:MSVC>:/Wall>
 )
 
 write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake


### PR DESCRIPTION
This is a patch to solve the problem that the test framework is not compiling in MSVC. I can't think of any reasons that this would have side effects, and I tried the fix with MSVC, GCC, and Clang, and they are all still working as they were before the fix.

I hope that this fix works for everyone else, as it certainly worked for me.