### PR TITLE
parse mock files correctly

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -197,7 +197,7 @@ class UnityTestRunnerGenerator
     mock_headers = []
     includes.each do |include_path|
       include_file = File.basename(include_path)
-      mock_headers << include_path if include_file =~ /^#{@options[:mock_prefix]}.*#{@options[:mock_suffix]}$/i
+      mock_headers << include_path if include_file =~ /^#{@options[:mock_prefix]}.*#{@options[:mock_suffix]}\.h$/i
     end
     mock_headers
   end


### PR DESCRIPTION
Fixes ThrowTheSwitch/Unity#519
Allows for usage of mock suffixes without 2 distinct configurations for Unity and Cmock.