### PR TITLE
Add guard TEST on test module template

### DIFF
--- a/auto/generate_module.rb
+++ b/auto/generate_module.rb
@@ -13,7 +13,9 @@ require 'fileutils'
 require 'pathname'
 
 # TEMPLATE_TST
-TEMPLATE_TST ||= '#include "unity.h"
+TEMPLATE_TST ||= '#ifdef TEST
+
+#include "unity.h"
 
 %2$s#include "%1$s.h"
 
@@ -29,6 +31,8 @@ void test_%4$s_NeedToImplement(void)
 {
     TEST_IGNORE_MESSAGE("Need to Implement %1$s");
 }
+
+#endif // TEST
 '.freeze
 
 # TEMPLATE_SRC


### PR DESCRIPTION
With a test file guarded we can include this file on IDE project (MPLAB X in my case) and compile without excluding test files.
Excluding test files on MPLAB X disable autocompletion and function navigation.

Please note that I am not sure everyone define TEST on their projects and if this should be an option instead of the default template.