### PR TITLE
set lower bound for delta in float/double equal comparison

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -912,6 +912,7 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
     UNITY_UINT32 elements = num_elements;
     UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_expected = expected;
     UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_actual = actual;
+    UNITY_FLOAT delta;
 
     RETURN_IF_FAIL_OR_IGNORE;
 
@@ -932,7 +933,12 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
 
     while (elements--)
     {
-        if (!UnityFloatsWithin(*ptr_expected * UNITY_FLOAT_PRECISION, *ptr_expected, *ptr_actual))
+        delta = *ptr_expected * UNITY_FLOAT_PRECISION;
+        if (delta < UNITY_FLOAT_PRECISION && delta > -UNITY_FLOAT_PRECISION)
+        {
+            delta = UNITY_FLOAT_PRECISION;
+        }
+        if (!UnityFloatsWithin(delta, *ptr_expected, *ptr_actual))
         {
             UnityTestResultsFailBegin(lineNumber);
             UnityPrint(UnityStrElement);
@@ -1054,6 +1060,7 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
     UNITY_UINT32 elements = num_elements;
     UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_expected = expected;
     UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_actual = actual;
+    UNITY_DOUBLE delta;
 
     RETURN_IF_FAIL_OR_IGNORE;
 
@@ -1074,7 +1081,12 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
 
     while (elements--)
     {
-        if (!UnityDoublesWithin(*ptr_expected * UNITY_DOUBLE_PRECISION, *ptr_expected, *ptr_actual))
+        delta = *ptr_expected * UNITY_DOUBLE_PRECISION;
+        if (delta < UNITY_DOUBLE_PRECISION && delta > -UNITY_DOUBLE_PRECISION)
+        {
+            delta = UNITY_DOUBLE_PRECISION;
+        }
+        if (!UnityDoublesWithin(delta, *ptr_expected, *ptr_actual))
         {
             UnityTestResultsFailBegin(lineNumber);
             UnityPrint(UnityStrElement);

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -255,6 +255,9 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
 
 #endif
 
+#define UNITY_FMAX(a,b) ((a) > (b) ? (a) : (b))
+#define UNITY_FABS(a) ((a) < 0 ? - (a) : (a))
+
 /*-------------------------------------------------------
  * Output Method: stdout (DEFAULT)
  *-------------------------------------------------------*/
@@ -988,7 +991,7 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
 #else
 #define UNITY_TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual, line, message)                   UnityAssertFloatsWithin((UNITY_FLOAT)(delta), (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line))
-#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_ASSERT_FLOAT_WITHIN((UNITY_FLOAT)(expected) * (UNITY_FLOAT)UNITY_FLOAT_PRECISION, (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_ASSERT_FLOAT_WITHIN((UNITY_FLOAT)UNITY_FMAX(UNITY_FABS((UNITY_FLOAT)(expected) * (UNITY_FLOAT)UNITY_FLOAT_PRECISION), UNITY_FABS(UNITY_FLOAT_PRECISION)), (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (UNITY_LINE_TYPE)(line), (message))
 #define UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualFloatArray((UNITY_FLOAT*)(expected), (UNITY_FLOAT*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
 #define UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT(expected, actual, num_elements, line, message)        UnityAssertEqualFloatArray(UnityFloatToPtr(expected), (UNITY_FLOAT*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
 #define UNITY_TEST_ASSERT_FLOAT_IS_INF(actual, line, message)                                    UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
@@ -1016,7 +1019,7 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
 #else
 #define UNITY_TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual, line, message)                  UnityAssertDoublesWithin((UNITY_DOUBLE)(delta), (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line))
-#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_ASSERT_DOUBLE_WITHIN((UNITY_DOUBLE)(expected) * (UNITY_DOUBLE)UNITY_DOUBLE_PRECISION, (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_ASSERT_DOUBLE_WITHIN((UNITY_DOUBLE)UNITY_FMAX(UNITY_FABS((UNITY_DOUBLE)(expected) * (UNITY_DOUBLE)UNITY_DOUBLE_PRECISION), UNITY_FABS((UNITY_DOUBLE)UNITY_DOUBLE_PRECISION)), (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (UNITY_LINE_TYPE)(line), (message))
 #define UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualDoubleArray((UNITY_DOUBLE*)(expected), (UNITY_DOUBLE*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
 #define UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE(expected, actual, num_elements, line, message)       UnityAssertEqualDoubleArray(UnityDoubleToPtr(expected), (UNITY_DOUBLE*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
 #define UNITY_TEST_ASSERT_DOUBLE_IS_INF(actual, line, message)                                   UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)


### PR DESCRIPTION
In equality check of float/double, "_UNITY\_<FLOAT/DOUBLE>\_PRECISION * expected_" is used as "_delta_" of _TEST\_ASSERT\_<FLOAT/DOUBLE>\_WITHIN\_MESSAGE(delta, expected, actual, message)_.

That can cause too exact comparison when "_expexted_" is equal to or near zero.

Therefore, I think it is better to set a lower bound for "_delta_" when it will be smaller than precision. I made a pull request that set "_UNITY\_<FLOAT/DOUBLE>\_PRECISION_" as the lower bound in such case.

For example, the following tests all fail in current master branch. My pull request can modify these tests to act in the way it's _supposed_ (at least I suppose) to be.

<details>
<summary>test code</summary>
<pre>
<code>
#include "unity.h"

void setUp(void)
{
}

void tearDown(void)
{
}

void test_FloatNearZero_SupposedToPass(void)
{
  TEST_ASSERT_EQUAL_FLOAT(0.0, 0.0000000000000000000000001f);
}

void test_FloatNearZero_SupposedToFail(void)
{
  TEST_ASSERT_EQUAL_FLOAT(0.0, 0.0001f);
}

void test_DoubleNearZero_SupposedToPass(void)
{
  TEST_ASSERT_EQUAL_DOUBLE(0.0, 1e-300);
}

void test_DoubleNearZero_SupposedToFail(void)
{
  TEST_ASSERT_EQUAL_DOUBLE(0.0, 1e-11);
}

void test_FloatArrayNearZero_SupposedToPass(void)
{
  float exact[2] = {0.0, 0.0};
  float input[2] = {0.000000000001f, -0.000000000001f};
  TEST_ASSERT_EQUAL_FLOAT_ARRAY(exact, input, 2);
}

void test_FloatArrayNearZero_SupposedToFail(void)
{
  float exact[2] = {0.0, 0.0};
  float input[2] = {0.0001f, -0.0001f};
  TEST_ASSERT_EQUAL_FLOAT_ARRAY(exact, input, 2);
}

void test_DoubleArrayNearZero_SupposedToPass(void)
{
  double exact[2] = {0.0, 0.0};
  double input[2] = {1e-100, -1e-100};
  TEST_ASSERT_EQUAL_DOUBLE_ARRAY(exact, input, 2);
}

void test_DoubleArrayNearZero_SupposedToFail(void)
{
  double exact[2] = {0.0, 0.0};
  double input[2] = {1e-10, -1e-10};
  TEST_ASSERT_EQUAL_DOUBLE_ARRAY(exact, input, 2);
}


int main(void)
{
  UNITY_BEGIN();
  RUN_TEST(test_FloatNearZero_SupposedToPass);
  RUN_TEST(test_FloatNearZero_SupposedToFail);
  RUN_TEST(test_DoubleNearZero_SupposedToPass);
  RUN_TEST(test_DoubleNearZero_SupposedToFail);
  RUN_TEST(test_FloatArrayNearZero_SupposedToPass);
  RUN_TEST(test_FloatArrayNearZero_SupposedToFail);
  RUN_TEST(test_DoubleArrayNearZero_SupposedToPass);
  RUN_TEST(test_DoubleArrayNearZero_SupposedToFail);
  return (UNITY_END());
}
</code>
</pre>
</details>