### PR TITLE
Fixed CMake install when compiled with extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,8 @@ project(unity
 option(UNITY_EXTENSION_FIXTURE "Compiles Unity with the \"fixture\" extension." OFF)
 option(UNITY_EXTENSION_MEMORY "Compiles Unity with the \"memory\" extension." OFF)
 
-# Fixture is a dependant of memory
-set(UNITY_EXTENSION_FIXTURE_ENABLED ${UNITY_EXTENSION_FIXTURE})
-set(UNITY_EXTENSION_MEMORY_ENABLED $<OR:$<BOOL:${UNITY_EXTENSION_MEMORY}>,$<BOOL:${UNITY_EXTENSION_FIXTURE}>>)
+set(UNITY_EXTENSION_FIXTURE_ENABLED $<BOOL:${UNITY_EXTENSION_FIXTURE}>)
+set(UNITY_EXTENSION_MEMORY_ENABLED $<OR:${UNITY_EXTENSION_FIXTURE_ENABLED},$<BOOL:${UNITY_EXTENSION_MEMORY}>>)
 
 if(${UNITY_EXTENSION_FIXTURE})
     message(STATUS "Unity: Bulding with the fixture extension.")
@@ -84,10 +83,9 @@ target_include_directories(${PROJECT_NAME}
 set(${PROJECT_NAME}_PUBLIC_HEADERS
         src/unity.h
         src/unity_internals.h
-        $<$<BOOL:${UNITY_EXTENSION_FIXTURE_ENABLED}>:extras/fixture/src/unity_fixture.h
-                                             extras/fixture/src/unity_fixture_internals.h>
-        $<$<BOOL:${UNITY_EXTENSION_MEMORY_ENABLED}>:extras/memory/src/unity_memory.h
-                                            extras/memory/src/unity_memory_internals.h>
+        $<$<BOOL:${UNITY_EXTENSION_FIXTURE_ENABLED}>:${CMAKE_CURRENT_SOURCE_DIR}/extras/fixture/src/unity_fixture.h>
+        $<$<BOOL:${UNITY_EXTENSION_FIXTURE_ENABLED}>:${CMAKE_CURRENT_SOURCE_DIR}/extras/fixture/src/unity_fixture_internals.h>
+        $<$<BOOL:${UNITY_EXTENSION_MEMORY_ENABLED}>:${CMAKE_CURRENT_SOURCE_DIR}/extras/memory/src/unity_memory.h>
 )
 
 set_target_properties(${PROJECT_NAME}


### PR DESCRIPTION
This is a fix from the change I made in
`commit 418c1635f2f1bcd353b6fce23a16594c914047b8`
where I added options to compile unity with the `fixture` and `memory`
extensions:

In that version, Unity had been able to build, but there were some issues when
trying to install it. Namely, the CMake generator expressions were not
evaluated correctly, and it would try to install with a path that had
un-expanded generator commands in it, which would obviously fail and throw an
error. I've got a feeling that this is a bug with CMake, but for now the
workaround that worked in [this stackoverflow
post](https://stackoverflow.com/questions/51541678/nested-cmake-generator-expressions-are-only-partially-evaluated)
seemed to work here, as well.

Another issue with that commit was that it tried to include a
`unity_memory_internals.h` file, which did not exist. This has also been
resolved.