### PR TITLE
Enlarge the TEST_RANGE() regex to accept more spaces

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -143,7 +143,7 @@ class UnityTestRunnerGenerator
         arguments.scan(/\s*TEST_CASE\s*\((.*)\)\s*$/) { |a| args << a[0] }
 
         arguments.scan(/\s*TEST_RANGE\s*\((.*)\)\s*$/).flatten.each do |range_str|
-          args += range_str.scan(/\[(-?\d+.?\d*), *(-?\d+.?\d*), *(-?\d+.?\d*)\]/).map do |arg_values_str|
+          args += range_str.scan(/\[\s*(-?\d+.?\d*),\s*(-?\d+.?\d*),\s*(-?\d+.?\d*)\s*\]/).map do |arg_values_str|
             arg_values_str.map do |arg_value_str|
               arg_value_str.include?('.') ? arg_value_str.to_f : arg_value_str.to_i
             end


### PR DESCRIPTION
This commit change the regex to accept more spaces inside the brackets
of the TEST_RANGE().

I use clang-format through vscode "editor.formatOnSave": true feature and it produce
padding spaces inside the array brackets by default.

```c
int a[] = [1, 2];
```

is changed into

```c
int a[] = [ 1, 2 ];
```

Also, every time I save a file containing a TEST_RANGE() with ctrl + s
it breaks it.