### PR TITLE
Enable __attribute__ when __clang__ is definedgit

### DIFF
--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -40,10 +40,10 @@
 #include <limits.h>
 #endif
 
-#if defined __GNUC__
-#    define UNITY_FUNCTION_ATTR(a) __attribute__((a))
+#if defined(__GNUC__) || defined(__clang__)
+  #define UNITY_FUNCTION_ATTR(a)    __attribute__((a))
 #else
-#    define UNITY_FUNCTION_ATTR(a) /* ignore */
+  #define UNITY_FUNCTION_ATTR(a)    /* ignore */
 #endif
 
 /*-------------------------------------------------------


### PR DESCRIPTION
Add __clang__ to the list of compilers that support the __attribute__ syntax in order to make "noreturn" work for all clang compilers.

This PR fixes: #531 