### PR TITLE
Meson updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 builddir/
 test/sandbox
 .DS_Store
+examples/example_1/subprojects/unity
 examples/example_1/test1.exe
 examples/example_1/test2.exe
 examples/example_2/all_tests.exe

--- a/auto/extract_version.py
+++ b/auto/extract_version.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import re
+import sys
+
+ver_re = re.compile(r"^#define\s+UNITY_VERSION_(?:MAJOR|MINOR|BUILD)\s+(\d+)$")
+version = []
+
+with open(sys.argv[1], "r") as f:
+    for line in f:
+        m = ver_re.match(line)
+        if m:
+            version.append(m.group(1))
+
+print(".".join(version))

--- a/examples/example_1/meson.build
+++ b/examples/example_1/meson.build
@@ -1,0 +1,42 @@
+project('Unity Example', 'c',
+  license: 'MIT',
+  default_options: [
+    'c_std=c89',
+    'warning_level=3',
+  ])
+
+unity_root = 'subprojects' / 'unity'
+
+unity = subproject('unity')
+unity_dep = unity.get_variable('unity_dep')
+
+src1 = files('src/ProductionCode.c', 'test/TestProductionCode.c')
+src2 = files('src/ProductionCode2.c', 'test/TestProductionCode2.c')
+
+inc = include_directories('src')
+
+ruby = find_program('ruby')
+runner_gen = generator(ruby,
+  arguments: [
+    '@SOURCE_DIR@' / unity_root / 'auto' / 'generate_test_runner.rb',
+    '@INPUT@', '@OUTPUT@',
+  ],
+  output: '@BASENAME@_Runner.c')
+
+
+test1 = executable('test1', [
+    src1,
+    runner_gen.process('test/TestProductionCode.c'),
+  ],
+  include_directories: inc,
+  dependencies: unity_dep)
+test('test1', test1,
+  should_fail: true)
+
+test2 = executable('test2', [
+    src2,
+    runner_gen.process('test/TestProductionCode2.c'),
+  ],
+  include_directories: inc,
+  dependencies: unity_dep)
+test('test2', test2)

--- a/examples/example_1/readme.txt
+++ b/examples/example_1/readme.txt
@@ -2,4 +2,11 @@ Example 1
 =========
 
 Close to the simplest possible example of Unity, using only basic features.
-Run make to build & run the example tests.
+
+Build and run with Make
+---
+Just run `make`.
+
+Build and run with Meson
+---
+Run `meson setup build` to create the build directory, and then `meson test -C build` to build and run the tests.

--- a/examples/example_1/subprojects/unity.wrap
+++ b/examples/example_1/subprojects/unity.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/ThrowTheSwitch/Unity.git
+revision = head

--- a/extras/fixture/src/meson.build
+++ b/extras/fixture/src/meson.build
@@ -1,0 +1,8 @@
+unity_inc += include_directories('.')
+unity_src += files('unity_fixture.c')
+
+install_headers(
+  'unity_fixture.h',
+  'unity_fixture_internals.h',
+  subdir: meson.project_name(),
+)

--- a/extras/memory/src/meson.build
+++ b/extras/memory/src/meson.build
@@ -1,0 +1,7 @@
+unity_inc += include_directories('.')
+unity_src += files('unity_memory.c')
+
+install_headers(
+  'unity_memory.h',
+  subdir: meson.project_name(),
+)

--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,44 @@
-#
-# build script written by : Michael Brockus.
-# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
-#
-# license: MIT
-#
 project('unity', 'c',
-    license: 'MIT',
-    meson_version: '>=0.53.0',
-    default_options: ['werror=true', 'c_std=c11']
+  version: run_command(
+    find_program('python'), 'auto' / 'extract_version.py', 'src/unity.h',
+    check: true).stdout(),
+  license: 'MIT',
+  meson_version: '>=0.53.0',
+  default_options: ['werror=true', 'c_std=c11']
 )
 
+build_fixture = get_option('extension_fixture').enabled()
+build_memory = get_option('extension_memory').enabled()
+
+unity_inc = []
+unity_src = []
+
 subdir('src')
-unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)
+
+if build_fixture
+  build_memory = true
+  subdir('extras/fixture/src')
+endif
+
+if build_memory
+  subdir('extras/memory/src')
+endif
+
+unity_lib = static_library(meson.project_name(), unity_src,
+  include_directories: unity_inc,
+  install: true)
+
+unity_dep = declare_dependency(
+  link_with: unity_lib,
+  include_directories: unity_inc)
+
+pkg = import('pkgconfig')
+pkg.generate(unity_lib,
+  description: 'C Unit testing framework.')
+
+summary({
+    'Fixture extension': build_fixture,
+    'Memory extension': build_memory,
+  },
+  section: 'Extensions',
+  bool_yn: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('extension_fixture', type: 'feature', value: 'disabled')
+option('extension_memory', type: 'feature', value: 'disabled')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,11 +1,8 @@
-#
-# build script written by : Michael Brockus.
-# github repo author: Mike Karlesky, Mark VanderVoord, Greg Williams.
-#
-# license: MIT
-#
-unity_dir = include_directories('.')
+unity_inc += include_directories('.')
+unity_src += files('unity.c')
 
-unity_lib = static_library(meson.project_name(), 
-    files('unity.c'),
-    include_directories: unity_dir)
+install_headers(
+    'unity.h',
+    'unity_internals.h',
+    subdir: meson.project_name(),
+)


### PR DESCRIPTION
This updates the meson build scripts to bring them more-or-less up to parity with the CMake script and adds a meson build script to one of the project examples.

Build script additions:
 * Library version is now retrieved from `unity.h` instead of being left as undefined.
 * Extensions (`fixture` and `memory`) are now supported.
 * The library, headers, and package configuration files (using `pkg-config` instead of CMake's config format) are now installed with `ninja install` / `meson compile install`.