### PR TITLE
Improve regex for test parameterization to support function pointers

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -131,6 +131,7 @@ class UnityTestRunnerGenerator
     lines.each_with_index do |line, _index|
       # find tests
       next unless line =~ /^((?:\s*(?:TEST_CASE|TEST_RANGE)\s*\(.*?\)\s*)*)\s*void\s+((?:#{@options[:test_prefix]}).*)\s*\(\s*(.*)\s*\)/m
+      next unless line =~ /^((?:\s*(?:TEST_CASE|TEST_RANGE)\s*\(.*?\)\s*)*)\s*void\s+((?:#{@options[:test_prefix]})\w*)\s*\(\s*(.*)\s*\)/m
 
       arguments = Regexp.last_match(1)
       name = Regexp.last_match(2)

--- a/test/testdata/Defs.h
+++ b/test/testdata/Defs.h
@@ -4,5 +4,6 @@
 #define EXTERN_DECL
 
 extern int CounterSuiteSetup;
+extern int isArgumentOne(int i);
 
 #endif

--- a/test/testdata/testRunnerGenerator.c
+++ b/test/testdata/testRunnerGenerator.c
@@ -167,6 +167,17 @@ void paratest_ShouldHandleParameterizedTestsThatFail(int Num)
     TEST_ASSERT_EQUAL_MESSAGE(3, Num, "This call should fail");
 }
 
+int isArgumentOne(int i)
+{
+    return i == 1;
+}
+
+TEST_CASE(isArgumentOne)
+void paratest_WorksWithFunctionPointers(int function(int))
+{
+    TEST_ASSERT_TRUE_MESSAGE(function(1), "Function should return True");
+}
+
 #ifdef USE_CEXCEPTION
 void extest_ShouldHandleCExceptionInTest(void)
 {

--- a/test/tests/test_generate_test_runner.rb
+++ b/test/tests/test_generate_test_runner.rb
@@ -151,6 +151,7 @@ RUNNER_TESTS = [
                     'paratest_ShouldHandleParameterizedTests\(5\)',
                     'paratest_ShouldHandleParameterizedTests2\(7\)',
                     'paratest_ShouldHandleNonParameterizedTestsWhenParameterizationValid',
+                    'paratest_WorksWithFunctionPointers\(isArgumentOne\)',
                   ],
       :to_fail => [ 'paratest_ShouldHandleParameterizedTestsThatFail\(17\)' ],
       :to_ignore => [ ],
@@ -168,6 +169,7 @@ RUNNER_TESTS = [
                     'paratest_ShouldHandleParameterizedTests\(5\)',
                     'paratest_ShouldHandleParameterizedTests2\(7\)',
                     'paratest_ShouldHandleNonParameterizedTestsWhenParameterizationValid',
+                    'paratest_WorksWithFunctionPointers\(isArgumentOne\)',
                   ],
       :to_fail => [ 'paratest_ShouldHandleParameterizedTestsThatFail\(17\)' ],
       :to_ignore => [ ],
@@ -188,6 +190,7 @@ RUNNER_TESTS = [
                     'paratest_ShouldHandleParameterizedTests\(5\)',
                     'paratest_ShouldHandleParameterizedTests2\(7\)',
                     'paratest_ShouldHandleNonParameterizedTestsWhenParameterizationValid',
+                    'paratest_WorksWithFunctionPointers\(isArgumentOne\)',
                   ],
       :to_fail => [ 'paratest_ShouldHandleParameterizedTestsThatFail\(17\)' ],
       :to_ignore => [ ],
@@ -1108,7 +1111,8 @@ RUNNER_TESTS = [
                   'paratest_ShouldHandleParameterizedTests\(5\)',
                   'paratest_ShouldHandleParameterizedTests2\(7\)',
                   'paratest_ShouldHandleNonParameterizedTestsWhenParameterizationValid',
-                  'paratest_ShouldHandleParameterizedTestsThatFail\(17\)'
+                  'paratest_ShouldHandleParameterizedTestsThatFail\(17\)',
+                  'paratest_WorksWithFunctionPointers\(isArgumentOne\)',
                ],
     }
   },


### PR DESCRIPTION
The regex to match function names for the test parameterization used the
wildcard '.*'. This lead to an error when you try to add a function
pointer as arguement.

The regex will now only match the word characters a-z A-Z 0-9 and
underscore (which are all characers that are accepted by the C standard)