### PR TITLE
Enhance meson support so that it can automatically generate a test runner

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/ruby
+
 # ==========================================
 #   Unity Project - A Test Framework for C
 #   Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams

--- a/docs/MesonGeneratorRunner.md
+++ b/docs/MesonGeneratorRunner.md
@@ -1,0 +1,18 @@
+# Meson Generator - Test Runner
+
+One of the really nice things about using Unity with Ceedling is that Ceedling takes care of generating all of the test runners automatically. If you're not using Ceedling though, you'll need to do this yourself.
+
+The way this is done in Unity is via a Ruby script called `generate_test_runner.rb`. When given a test file such as `test_example.c`, the script will generate `test_example_Runner.c`, which provides the `main` method and some other useful plumbing.
+
+So that you don't have to run this by hand, a Meson generator is provided to generate the runner automatically for you. Generally with Meson, you would use Unity as a subproject and you'd want to access the generator from the parent.
+
+For example, to get the generator you can use:
+
+    unity_proj = subproject('unity')
+    runner_gen = unity_proj.get_variable('gen_test_runner')
+
+Once you have the generator you need to pass it the absolute path of your test file. This seems to be a bug in how the paths work with subprojects in Meson. You can get the full path with `meson.source_root()`, so you could do:
+
+    test_runner = meson.source_root() / 'test/test_example.c'
+
+You can then include `test_runner` as a normal dependency to your builds. Meson will create the test runner in a private directory for each build target. It's only meant to be used as part of the build, so if you need to refer to the runner after the build, you won't be able to use the generator.

--- a/meson.build
+++ b/meson.build
@@ -12,3 +12,15 @@ project('unity', 'c',
 
 subdir('src')
 unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)
+
+
+# Get the generate_test_runner script relative to itself or the parent project if it is being used as a subproject
+# NOTE: This could be (and probably is) a complete hack - but I haven't yet been able to find a better way....
+if meson.is_subproject()
+gen_test_runner_path = find_program(meson.source_root() / 'subprojects/unity/auto/generate_test_runner.rb')
+else
+gen_test_runner_path = find_program('subprojects/unity/auto/generate_test_runner.rb')
+endif
+
+# Create a generator that we can access from the parent project
+gen_test_runner = generator(gen_test_runner_path, output: '@BASENAME@_Runner.c', arguments: ['@INPUT@', '@OUTPUT@'] )


### PR DESCRIPTION
The current `meson.build` file is all that's needed to link Unity into a parent project. However, this doesn't expose any of the helper scripts, with `generate_test_runner.rb` being one of the most important for "it just works" testing.

The added generator makes it easy to call `generate_test_runner.rb` with given input and output files, allowing Meson to automatically integrate the runner into its build environment. This did require making `generate_test_runner.rb` executable and adding a `#!` though.

The approach used is the best I can find from scouring the docs. From a brief discussion with a Meson dev, the path should magically do the right thing. Alas it doesn't and likely I'll need to file a bug. This works in the meantime however.

I've added some documentation in `docs/` - happy to refine as needed :)