### PR TITLE
Fix unity_test_summary ruby script with parameterized tests

### DIFF
--- a/auto/unity_test_summary.rb
+++ b/auto/unity_test_summary.rb
@@ -86,7 +86,11 @@ class UnityTestSummary
   def get_details(_result_file, lines)
     results = { failures: [], ignores: [], successes: [] }
     lines.each do |line|
-      _src_file, _src_line, _test_name, status, _msg = line.split(/:/)
+      status_match = line.match(/^[^:]+:[^:]+:\w+(?:\([^\)]*\)):([^:]+):?/)
+      if not status_match
+        next
+      end
+      status = status_match.captures[0]
       line_out = (@root && (@root != 0) ? "#{@root}#{line}" : line).gsub(/\//, '\\')
       case status
       when 'IGNORE' then results[:ignores]   << line_out

--- a/auto/unity_test_summary.rb
+++ b/auto/unity_test_summary.rb
@@ -86,7 +86,7 @@ class UnityTestSummary
   def get_details(_result_file, lines)
     results = { failures: [], ignores: [], successes: [] }
     lines.each do |line|
-      status_match = line.match(/^[^:]+:[^:]+:\w+(?:\([^\)]*\)):([^:]+):?/)
+      status_match = line.match(/^[^:]+:[^:]+:\w+(?:\([^\)]*\))?:([^:]+):?/)
       if not status_match
         next
       end


### PR DESCRIPTION
When you passed a string with a colon (":") to a test via test
parameterization, the unity_test_summary.rb script was no longer
able to handle its output.

EXAMPLE:
```
TEST_CASE("::1")
void test_some_parameterized_ipv6_address(const char *address)
{
	TEST_FAIL();
}
```

The reason for this is, that a simple split at colon command was used.
Changed this to a more complex regex.

PLEASE NOTE: I have no clue, how to write clean ruby code. I bet this
can be written much prettier. Feel free to change it, but at least the
concept is working.