### PR TITLE
Make TEST_RANGE handle a single range

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -149,8 +149,8 @@ class UnityTestRunnerGenerator
             end
           end.map do |arg_values|
             (arg_values[0]..arg_values[1]).step(arg_values[2]).to_a
-          end.reduce do |result, arg_range_expanded|
-            result.product(arg_range_expanded)
+          end.reduce(nil) do |result, arg_range_expanded|
+            result.nil? ? arg_range_expanded.map { |a| [a] } : result.product(arg_range_expanded)
           end.map do |arg_combinations|
             arg_combinations.flatten.join(', ')
           end


### PR DESCRIPTION
Before this change a single range such as TEST_RANGE([5, 100, 5]) would
generate the following error:

undefined method `flatten' for 5:Integer (NoMethodError)

The problem is that reduce called on an array with a single element
returns that element which isn't an array of arrays as expected by the
following block.