### PR TITLE
Add support for TEST_RANGE with exclusive end

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -148,12 +148,13 @@ class UnityTestRunnerGenerator
           end
 
           # RANGE
-          args += type_and_args[i + 1].scan(/\[\s*(-?\d+.?\d*)\s*,\s*(-?\d+.?\d*)\s*,\s*(-?\d+.?\d*)\s*\]/m).map do |arg_values_str|
-            arg_values_str.map do |arg_value_str|
+          args += type_and_args[i + 1].scan(/(\[|<)\s*(-?\d+.?\d*)\s*,\s*(-?\d+.?\d*)\s*,\s*(-?\d+.?\d*)\s*(\]|>)/m).map do |arg_values_str|
+            exclude_end = arg_values_str[0] == '<' && arg_values_str[-1] == '>'
+            arg_values_str[1...-1].map do |arg_value_str|
               arg_value_str.include?('.') ? arg_value_str.to_f : arg_value_str.to_i
-            end
+            end.push(exclude_end)
           end.map do |arg_values|
-            (arg_values[0]..arg_values[1]).step(arg_values[2]).to_a
+            Range.new(arg_values[0], arg_values[1], arg_values[3]).step(arg_values[2]).to_a
           end.reduce(nil) do |result, arg_range_expanded|
             result.nil? ? arg_range_expanded.map { |a| [a] } : result.product(arg_range_expanded)
           end.map do |arg_combinations|

--- a/src/unity.h
+++ b/src/unity.h
@@ -89,7 +89,7 @@ void verifyTest(void);
  *     - define UNITY_SUPPORT_TEST_CASES to include the TEST_CASE macro, though really it's mostly about the runner generator script
 
  * Parameterized Tests
- *     - you'll want to create a define of TEST_CASE(...) which basically evaluates to nothing
+ *     - you'll want to create a define of TEST_CASE(...) and/or TEST_RANGE(...) which basically evaluates to nothing
 
  * Tests with Arguments
  *     - you'll want to define UNITY_USE_COMMAND_LINE_ARGS if you have the test runner passing arguments to Unity

--- a/test/tests/test_unity_parameterized.c
+++ b/test/tests/test_unity_parameterized.c
@@ -173,6 +173,32 @@ void test_CharsArePreserved(unsigned index, char c)
     NextExpectedCharIndex++;
 }
 
+TEST_RANGE([0, 10, 2])
+void test_SingleRange(unsigned value)
+{
+  TEST_ASSERT_EQUAL(0, value % 2);
+  TEST_ASSERT_LESS_OR_EQUAL(10, value);
+}
+
+TEST_RANGE([1, 2, 1], [2, 1, -1])
+void test_TwoRanges(unsigned first, unsigned second)
+{
+  TEST_ASSERT_LESS_OR_EQUAL(4, first * second);
+}
+
+TEST_RANGE(<0, 10, 2>)
+void test_SingleExclusiveRange(unsigned value)
+{
+  TEST_ASSERT_EQUAL(0, value % 2);
+  TEST_ASSERT_LESS_THAN(10, value);
+}
+
+TEST_RANGE([2, 4, 1], <1, 2, 1>)
+void test_BothInclusiveAndExclusiveRange(unsigned first, unsigned second)
+{
+  TEST_ASSERT_LESS_THAN(first, second);
+}
+
 TEST_CASE(0,
 
           1)


### PR DESCRIPTION
If the range is <start, end, step> instead of [start, end, step], the
end value will not be included in the range.

This can be useful if you have a define that defines e.g. the size of
something and you want to use this define as the end value. As the
pre-processor doesn't evalutate expressions (unless you do some macro
magic) you can't specify the range as [0, MY_SIZE - 1, 1]. With this
change you can then instead give the range <0, MY_SIZE, 1>.