### PR TITLE
Support `UNITY_INCLUDE_EXEC_TIME` under Apples OSX

### DIFF
--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -333,7 +333,7 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
         UnityPrintNumberUnsigned(execTimeMs); \
         UnityPrint(" ms)"); \
         }
-    #elif defined(__unix__)
+    #elif defined(__unix__) || defined(__APPLE__)
       #include <time.h>
       #define UNITY_TIME_TYPE struct timespec
       #define UNITY_GET_TIME(t) clock_gettime(CLOCK_MONOTONIC, &t)


### PR DESCRIPTION
The unix way of getting the time works under OSX as well and can be used.