### PR TITLE
Fix typo in UnityHelperScriptsGuide.md

### DIFF
--- a/docs/UnityHelperScriptsGuide.md
+++ b/docs/UnityHelperScriptsGuide.md
@@ -74,7 +74,7 @@ to love the next section of this document.
     - stdio.h
     - microdefs.h
   :cexception: 1
-  :suit_setup: "blah = malloc(1024);"
+  :suite_setup: "blah = malloc(1024);"
   :suite_teardown: "free(blah);"
 ```
 


### PR DESCRIPTION
An `e` is missing in`suit_setup` in the `my_config.yml`.