### PR TITLE
Lint markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
-Unity Test ![CI](https://github.com/ThrowTheSwitch/Unity/workflows/CI/badge.svg)
-==========
+# Unity Test ![CI](https://github.com/ThrowTheSwitch/Unity/workflows/CI/badge.svg)
+
 __Copyright (c) 2007 - 2021 Unity Project by Mike Karlesky, Mark VanderVoord, and Greg Williams__
 
-Welcome to the Unity Test Project, one of the main projects of ThrowTheSwitch.org. Unity Test is a 
-unit testing framework built for C, with a focus on working with embedded toolchains. 
+Welcome to the Unity Test Project, one of the main projects of ThrowTheSwitch.org. Unity Test is a
+unit testing framework built for C, with a focus on working with embedded toolchains.
 
-This project is made to test code targetting microcontrollers big and small. The core project is a 
-single C file and a pair of headers, allowing it to the added to your existing build setup without 
+This project is made to test code targetting microcontrollers big and small. The core project is a
+single C file and a pair of headers, allowing it to the added to your existing build setup without
 too much headache. You may use any compiler you wish, and may use most existing build systems
-including make, cmake, etc. If you'd like to leave the hard work to us, you might be interested
-in Ceedling, a build tool also by ThrowTheSwitch.org. 
+including Make, CMake, etc. If you'd like to leave the hard work to us, you might be interested
+in Ceedling, a build tool also by ThrowTheSwitch.org.
 
 If you're new to Unity, we encourage you to tour the [getting started guide](docs/UnityGettingStartedGuide.md)
 
-Getting Started
-===============
-The [docs](docs/) folder contains a [getting started guide](docs/UnityGettingStartedGuide.md)
-and much more tips about using Unity. 
+## Getting Started
 
-Unity Assertion Summary
-=======================
+The [docs](docs/) folder contains a [getting started guide](docs/UnityGettingStartedGuide.md)
+and much more tips about using Unity.
+
+## Unity Assertion Summary
+
 For the full list, see [UnityAssertionsReference.md](docs/UnityAssertionsReference.md).
 
-Basic Validity Tests
---------------------
+### Basic Validity Tests
 
     TEST_ASSERT_TRUE(condition)
 
@@ -46,8 +45,7 @@ Another way of calling `TEST_ASSERT_FALSE`
 
 This test is automatically marked as a failure. The message is output stating why.
 
-Numerical Assertions: Integers
-------------------------------
+### Numerical Assertions: Integers
 
     TEST_ASSERT_EQUAL_INT(expected, actual)
     TEST_ASSERT_EQUAL_INT8(expected, actual)
@@ -87,19 +85,15 @@ Another way of calling TEST_ASSERT_EQUAL_INT
 Asserts that the actual value is within plus or minus delta of the expected value. This also comes in
 size specific variants.
 
-
     TEST_ASSERT_GREATER_THAN(threshold, actual)
 
 Asserts that the actual value is greater than the threshold. This also comes in size specific variants.
-
 
     TEST_ASSERT_LESS_THAN(threshold, actual)
 
 Asserts that the actual value is less than the threshold. This also comes in size specific variants.
 
-
-Arrays
-------
+### Arrays
 
     _ARRAY
 
@@ -116,8 +110,7 @@ value. You do this by specifying the EACH_EQUAL macro. For example:
 
     TEST_ASSERT_EACH_EQUAL_INT32(expected, actual, elements)
 
-Numerical Assertions: Bitwise
------------------------------
+### Numerical Assertions: Bitwise
 
     TEST_ASSERT_BITS(mask, expected, actual)
 
@@ -139,8 +132,7 @@ Test a single bit and verify that it is high.  The bit is specified 0-31 for a 3
 
 Test a single bit and verify that it is low.  The bit is specified 0-31 for a 32-bit integer.
 
-Numerical Assertions: Floats
-----------------------------
+### Numerical Assertions: Floats
 
     TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual)
 
@@ -151,8 +143,7 @@ Asserts that the actual value is within plus or minus delta of the expected valu
 
 Asserts that two floating point values are "equal" within a small % delta of the expected value.
 
-String Assertions
------------------
+### String Assertions
 
     TEST_ASSERT_EQUAL_STRING(expected, actual)
 
@@ -170,8 +161,7 @@ Compare two null-terminate strings.  Fail if any character is different or if th
 
 Compare two strings. Fail if any character is different, stop comparing after len characters. Output a custom message on failure.
 
-Pointer Assertions
-------------------
+### Pointer Assertions
 
 Most pointer operations can be performed by simply using the integer comparisons above. However, a couple of special cases are added for clarity.
 
@@ -183,18 +173,15 @@ Fails if the pointer is not equal to NULL
 
 Fails if the pointer is equal to NULL
 
-Memory Assertions
------------------
+### Memory Assertions
 
     TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)
 
 Compare two blocks of memory.  This is a good generic assertion for types that can't be coerced into acting like
 standard types... but since it's a memory compare, you have to be careful that your data types are packed.
 
-\_MESSAGE
----------
+### \_MESSAGE
 
-you can append \_MESSAGE to any of the macros to make them take an additional argument.  This argument
+you can append `\_MESSAGE` to any of the macros to make them take an additional argument.  This argument
 is a string that will be printed at the end of the failure strings.  This is useful for specifying more
 information about the problem.
-

--- a/README.md
+++ b/README.md
@@ -2,21 +2,19 @@
 
 __Copyright (c) 2007 - 2021 Unity Project by Mike Karlesky, Mark VanderVoord, and Greg Williams__
 
-Welcome to the Unity Test Project, one of the main projects of ThrowTheSwitch.org. Unity Test is a
-unit testing framework built for C, with a focus on working with embedded toolchains.
+Welcome to the Unity Test Project, one of the main projects of ThrowTheSwitch.org.
+Unity Test is a unit testing framework built for C, with a focus on working with embedded toolchains.
 
-This project is made to test code targetting microcontrollers big and small. The core project is a
-single C file and a pair of headers, allowing it to the added to your existing build setup without
-too much headache. You may use any compiler you wish, and may use most existing build systems
-including Make, CMake, etc. If you'd like to leave the hard work to us, you might be interested
-in Ceedling, a build tool also by ThrowTheSwitch.org.
+This project is made to test code targetting microcontrollers big and small.
+The core project is a single C file and a pair of headers, allowing it to the added to your existing build setup without too much headache.
+You may use any compiler you wish, and may use most existing build systems including Make, CMake, etc.
+If you'd like to leave the hard work to us, you might be interested in Ceedling, a build tool also by ThrowTheSwitch.org.
 
 If you're new to Unity, we encourage you to tour the [getting started guide][].
 
 ## Getting Started
 
-The [docs][] folder contains a [getting started guide][]
-and much more tips about using Unity.
+The [docs][] folder contains a [getting started guide][] and much more tips about using Unity.
 
 ## Unity Assertion Summary
 
@@ -43,7 +41,8 @@ Another way of calling `TEST_ASSERT_FALSE`
     TEST_FAIL()
     TEST_FAIL_MESSAGE(message)
 
-This test is automatically marked as a failure. The message is output stating why.
+This test is automatically marked as a failure.
+The message is output stating why.
 
 ### Numerical Assertions: Integers
 
@@ -53,9 +52,9 @@ This test is automatically marked as a failure. The message is output stating wh
     TEST_ASSERT_EQUAL_INT32(expected, actual)
     TEST_ASSERT_EQUAL_INT64(expected, actual)
 
-Compare two integers for equality and display errors as signed integers. A cast will be performed
-to your natural integer size so often this can just be used. When you need to specify the exact size,
-like when comparing arrays, you can use a specific version:
+Compare two integers for equality and display errors as signed integers.
+A cast will be performed to your natural integer size so often this can just be used.
+When you need to specify the exact size, like when comparing arrays, you can use a specific version:
 
     TEST_ASSERT_EQUAL_UINT(expected, actual)
     TEST_ASSERT_EQUAL_UINT8(expected, actual)
@@ -63,8 +62,8 @@ like when comparing arrays, you can use a specific version:
     TEST_ASSERT_EQUAL_UINT32(expected, actual)
     TEST_ASSERT_EQUAL_UINT64(expected, actual)
 
-Compare two integers for equality and display errors as unsigned integers. Like INT, there are
-variants for different sizes also.
+Compare two integers for equality and display errors as unsigned integers.
+Like INT, there are variants for different sizes also.
 
     TEST_ASSERT_EQUAL_HEX(expected, actual)
     TEST_ASSERT_EQUAL_HEX8(expected, actual)
@@ -72,9 +71,8 @@ variants for different sizes also.
     TEST_ASSERT_EQUAL_HEX32(expected, actual)
     TEST_ASSERT_EQUAL_HEX64(expected, actual)
 
-Compares two integers for equality and display errors as hexadecimal. Like the other integer comparisons,
-you can specify the size... here the size will also effect how many nibbles are shown (for example, `HEX16`
-will show 4 nibbles).
+Compares two integers for equality and display errors as hexadecimal.
+Like the other integer comparisons, you can specify the size... here the size will also effect how many nibbles are shown (for example, `HEX16` will show 4 nibbles).
 
     TEST_ASSERT_EQUAL(expected, actual)
 
@@ -82,31 +80,35 @@ Another way of calling TEST_ASSERT_EQUAL_INT
 
     TEST_ASSERT_INT_WITHIN(delta, expected, actual)
 
-Asserts that the actual value is within plus or minus delta of the expected value. This also comes in
-size specific variants.
+Asserts that the actual value is within plus or minus delta of the expected value.
+This also comes in size specific variants.
 
     TEST_ASSERT_GREATER_THAN(threshold, actual)
 
-Asserts that the actual value is greater than the threshold. This also comes in size specific variants.
+Asserts that the actual value is greater than the threshold.
+This also comes in size specific variants.
 
     TEST_ASSERT_LESS_THAN(threshold, actual)
 
-Asserts that the actual value is less than the threshold. This also comes in size specific variants.
+Asserts that the actual value is less than the threshold.
+This also comes in size specific variants.
 
 ### Arrays
 
     _ARRAY
 
-You can append `_ARRAY` to any of these macros to make an array comparison of that type.  Here you will
-need to care a bit more about the actual size of the value being checked.  You will also specify an
-additional argument which is the number of elements to compare.  For example:
+You can append `_ARRAY` to any of these macros to make an array comparison of that type.
+Here you will need to care a bit more about the actual size of the value being checked.
+You will also specify an additional argument which is the number of elements to compare.
+For example:
 
     TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, elements)
 
     _EACH_EQUAL
 
-Another array comparison option is to check that EVERY element of an array is equal to a single expected
-value. You do this by specifying the EACH_EQUAL macro. For example:
+Another array comparison option is to check that EVERY element of an array is equal to a single expected value.
+You do this by specifying the EACH_EQUAL macro.
+For example:
 
     TEST_ASSERT_EACH_EQUAL_INT32(expected, actual, elements)
 
@@ -114,23 +116,28 @@ value. You do this by specifying the EACH_EQUAL macro. For example:
 
     TEST_ASSERT_BITS(mask, expected, actual)
 
-Use an integer mask to specify which bits should be compared between two other integers.  High bits in the mask are compared, low bits ignored.
+Use an integer mask to specify which bits should be compared between two other integers.
+High bits in the mask are compared, low bits ignored.
 
     TEST_ASSERT_BITS_HIGH(mask, actual)
 
-Use an integer mask to specify which bits should be inspected to determine if they are all set high.  High bits in the mask are compared, low bits ignored.
+Use an integer mask to specify which bits should be inspected to determine if they are all set high.
+High bits in the mask are compared, low bits ignored.
 
     TEST_ASSERT_BITS_LOW(mask, actual)
 
-Use an integer mask to specify which bits should be inspected to determine if they are all set low.  High bits in the mask are compared, low bits ignored.
+Use an integer mask to specify which bits should be inspected to determine if they are all set low.
+High bits in the mask are compared, low bits ignored.
 
     TEST_ASSERT_BIT_HIGH(bit, actual)
 
-Test a single bit and verify that it is high.  The bit is specified 0-31 for a 32-bit integer.
+Test a single bit and verify that it is high.
+The bit is specified 0-31 for a 32-bit integer.
 
     TEST_ASSERT_BIT_LOW(bit, actual)
 
-Test a single bit and verify that it is low.  The bit is specified 0-31 for a 32-bit integer.
+Test a single bit and verify that it is low.
+The bit is specified 0-31 for a 32-bit integer.
 
 ### Numerical Assertions: Floats
 
@@ -147,23 +154,30 @@ Asserts that two floating point values are "equal" within a small % delta of the
 
     TEST_ASSERT_EQUAL_STRING(expected, actual)
 
-Compare two null-terminate strings.  Fail if any character is different or if the lengths are different.
+Compare two null-terminate strings.
+Fail if any character is different or if the lengths are different.
 
     TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len)
 
-Compare two strings.  Fail if any character is different, stop comparing after len characters.
+Compare two strings.
+Fail if any character is different, stop comparing after len characters.
 
     TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)
 
-Compare two null-terminate strings.  Fail if any character is different or if the lengths are different. Output a custom message on failure.
+Compare two null-terminate strings.
+Fail if any character is different or if the lengths are different.
+Output a custom message on failure.
 
     TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)
 
-Compare two strings. Fail if any character is different, stop comparing after len characters. Output a custom message on failure.
+Compare two strings.
+Fail if any character is different, stop comparing after len characters.
+Output a custom message on failure.
 
 ### Pointer Assertions
 
-Most pointer operations can be performed by simply using the integer comparisons above. However, a couple of special cases are added for clarity.
+Most pointer operations can be performed by simply using the integer comparisons above.
+However, a couple of special cases are added for clarity.
 
     TEST_ASSERT_NULL(pointer)
 
@@ -177,14 +191,14 @@ Fails if the pointer is equal to NULL
 
     TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)
 
-Compare two blocks of memory.  This is a good generic assertion for types that can't be coerced into acting like
-standard types... but since it's a memory compare, you have to be careful that your data types are packed.
+Compare two blocks of memory.
+This is a good generic assertion for types that can't be coerced into acting like standard types... but since it's a memory compare, you have to be careful that your data types are packed.
 
 ### \_MESSAGE
 
-you can append `\_MESSAGE` to any of the macros to make them take an additional argument.  This argument
-is a string that will be printed at the end of the failure strings.  This is useful for specifying more
-information about the problem.
+You can append `\_MESSAGE` to any of the macros to make them take an additional argument.
+This argument is a string that will be printed at the end of the failure strings.
+This is useful for specifying more information about the problem.
 
 [CI]: https://github.com/ThrowTheSwitch/Unity/workflows/CI/badge.svg
 [getting started guide]: docs/UnityGettingStartedGuide.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unity Test ![CI](https://github.com/ThrowTheSwitch/Unity/workflows/CI/badge.svg)
+# Unity Test ![CI][]
 
 __Copyright (c) 2007 - 2021 Unity Project by Mike Karlesky, Mark VanderVoord, and Greg Williams__
 
@@ -11,16 +11,16 @@ too much headache. You may use any compiler you wish, and may use most existing 
 including Make, CMake, etc. If you'd like to leave the hard work to us, you might be interested
 in Ceedling, a build tool also by ThrowTheSwitch.org.
 
-If you're new to Unity, we encourage you to tour the [getting started guide](docs/UnityGettingStartedGuide.md)
+If you're new to Unity, we encourage you to tour the [getting started guide][].
 
 ## Getting Started
 
-The [docs](docs/) folder contains a [getting started guide](docs/UnityGettingStartedGuide.md)
+The [docs][] folder contains a [getting started guide][]
 and much more tips about using Unity.
 
 ## Unity Assertion Summary
 
-For the full list, see [UnityAssertionsReference.md](docs/UnityAssertionsReference.md).
+For the full list, see [UnityAssertionsReference.md][].
 
 ### Basic Validity Tests
 
@@ -185,3 +185,8 @@ standard types... but since it's a memory compare, you have to be careful that y
 you can append `\_MESSAGE` to any of the macros to make them take an additional argument.  This argument
 is a string that will be printed at the end of the failure strings.  This is useful for specifying more
 information about the problem.
+
+[CI]: https://github.com/ThrowTheSwitch/Unity/workflows/CI/badge.svg
+[getting started guide]: docs/UnityGettingStartedGuide.md
+[docs]: docs/
+[UnityAssertionsReference.md]: docs/UnityAssertionsReference.md

--- a/docs/ThrowTheSwitchCodingStandard.md
+++ b/docs/ThrowTheSwitchCodingStandard.md
@@ -1,58 +1,51 @@
 ﻿# ThrowTheSwitch.org Coding Standard
 
-Hi. Welcome to the coding standard for ThrowTheSwitch.org. For the most part,
-we try to follow these standards to unify our contributors' code into a cohesive
-unit (puns intended). You might find places where these standards aren't
-followed. We're not perfect. Please be polite where you notice these discrepancies
-and we'll try to be polite when we notice yours.
+Hi.
+Welcome to the coding standard for ThrowTheSwitch.org.
+For the most part, we try to follow these standards to unify our contributors' code into a cohesive unit (puns intended).
+You might find places where these standards aren't followed.
+We're not perfect. Please be polite where you notice these discrepancies and we'll try to be polite when we notice yours.
 
 ;)
 
 ## Why Have A Coding Standard?
 
-Being consistent makes code easier to understand. We've tried to keep
-our standard simple because we also believe that we can only expect someone to
-follow something that is understandable. Please do your best.
+Being consistent makes code easier to understand.
+We've tried to keep our standard simple because we also believe that we can only expect someone to follow something that is understandable.
+Please do your best.
 
 ## Our Philosophy
 
-Before we get into details on syntax, let's take a moment to talk about our
-vision for these tools. We're C developers and embedded software developers.
-These tools are great to test any C code, but catering to embedded software has
-made us more tolerant of compiler quirks. There are a LOT of quirky compilers
-out there. By quirky I mean "doesn't follow standards because they feel like
-they have a license to do as they wish."
+Before we get into details on syntax, let's take a moment to talk about our vision for these tools.
+We're C developers and embedded software developers.
+These tools are great to test any C code, but catering to embedded software made us more tolerant of compiler quirks.
+There are a LOT of quirky compilers out there.
+By quirky I mean "doesn't follow standards because they feel like they have a license to do as they wish."
 
-Our philosophy is "support every compiler we can". Most often, this means that
-we aim for writing C code that is standards compliant (often C89... that seems
-to be a sweet spot that is almost always compatible). But it also means these
-tools are tolerant of things that aren't common. Some that aren't even
-compliant. There are configuration options to override the size of standard
-types. There are configuration options to force Unity to not use certain
-standard library functions. A lot of Unity is configurable and we have worked
-hard to make it not TOO ugly in the process.
+Our philosophy is "support every compiler we can".
+Most often, this means that we aim for writing C code that is standards compliant (often C89... that seems to be a sweet spot that is almost always compatible).
+But it also means these tools are tolerant of things that aren't common.
+Some that aren't even compliant.
+There are configuration options to override the size of standard types.
+There are configuration options to force Unity to not use certain standard library functions.
+A lot of Unity is configurable and we have worked hard to make it not TOO ugly in the process.
 
-Similarly, our tools that parse C do their best. They aren't full C parsers
-(yet) and, even if they were, they would still have to accept non-standard
-additions like gcc extensions or specifying `@0x1000` to force a variable to
-compile to a particular location. It's just what we do, because we like
-everything to Just Work™.
+Similarly, our tools that parse C do their best.
+They aren't full C parsers (yet) and, even if they were, they would still have to accept non-standard additions like gcc extensions or specifying `@0x1000` to force a variable to compile to a particular location.
+It's just what we do, because we like everything to Just Work™.
 
-Speaking of having things Just Work™, that's our second philosophy. By that, we
-mean that we do our best to have EVERY configuration option have a logical
-default. We believe that if you're working with a simple compiler and target,
-you shouldn't need to configure very much... we try to make the tools guess as
-much as they can, but give the user the power to override it when it's wrong.
+Speaking of having things Just Work™, that's our second philosophy.
+By that, we mean that we do our best to have EVERY configuration option have a logical default.
+We believe that if you're working with a simple compiler and target, you shouldn't need to configure very much... we try to make the tools guess as much as they can, but give the user the power to override it when it's wrong.
 
 ## Naming Things
 
-Let's talk about naming things. Programming is all about naming things. We name
-files, functions, variables, and so much more. While we're not always going to
-find the best name for something, we actually put a bit of effort into
-finding *What Something WANTS to be Called*™.
+Let's talk about naming things.
+Programming is all about naming things.
+We name files, functions, variables, and so much more.
+While we're not always going to find the best name for something, we actually put a bit of effort into finding *What Something WANTS to be Called*™.
 
-When naming things, we follow this hierarchy, the first being the
-most important to us (but we do all four when possible):
+When naming things, we follow this hierarchy, the first being the most important to us (but we do all four when possible):
 
 1. Readable
 2. Descriptive
@@ -61,68 +54,63 @@ most important to us (but we do all four when possible):
 
 ### Readable
 
-We want to read our code. This means we like names and flow that are more
-naturally read. We try to avoid double negatives. We try to avoid cryptic
-abbreviations (sticking to ones we feel are common).
+We want to read our code.
+This means we like names and flow that are more naturally read.
+We try to avoid double negatives.
+We try to avoid cryptic abbreviations (sticking to ones we feel are common).
 
 ### Descriptive
 
 We like descriptive names for things, especially functions and variables.
-Finding the right name for something is an important endeavor. You might notice
-from poking around our code that this often results in names that are a little
-longer than the average. Guilty. We're okay with a bit more typing if it
-means our code is easier to understand.
+Finding the right name for something is an important endeavour.
+You might notice from poking around our code that this often results in names that are a little longer than the average.
+Guilty.
+We're okay with a bit more typing if it means our code is easier to understand.
 
-There are two exceptions to this rule that we also stick to as religiously as
-possible:
+There are two exceptions to this rule that we also stick to as religiously as possible:
 
-First, while we realize hungarian notation (and similar systems for encoding
-type information into variable names) is providing a more descriptive name, we
-feel that (for the average developer) it takes away from readability and is to be avoided.
+First, while we realize hungarian notation (and similar systems for encoding type information into variable names) is providing a more descriptive name, we feel that (for the average developer) it takes away from readability and is to be avoided.
 
-Second, loop counters and other local throw-away variables often have a purpose
-which is obvious. There's no need, therefore, to get carried away with complex
-naming. We find i, j, and k are better loop counters than loopCounterVar or
-whatnot. We only break this rule when we see that more description could improve
-understanding of an algorithm.
+Second, loop counters and other local throw-away variables often have a purpose which is obvious.
+There's no need, therefore, to get carried away with complex naming.
+We find i, j, and k are better loop counters than loopCounterVar or whatnot.
+We only break this rule when we see that more description could improve understanding of an algorithm.
 
 ### Consistent
 
-We like consistency, but we're not really obsessed with it. We try to name our
-configuration macros in a consistent fashion... you'll notice a repeated use of
-UNITY_EXCLUDE_BLAH or UNITY_USES_BLAH macros. This helps users avoid having to
-remember each macro's details.
+We like consistency, but we're not really obsessed with it.
+We try to name our configuration macros in a consistent fashion... you'll notice a repeated use of UNITY_EXCLUDE_BLAH or UNITY_USES_BLAH macros.
+This helps users avoid having to remember each macro's details.
 
 ### Memorable
 
-Where ever it doesn't violate the above principles, we try to apply memorable
-names. Sometimes this means using something that is simply descriptive, but
-often we strive for descriptive AND unique... we like quirky names that stand
-out in our memory and are easier to search for. Take a look through the file
-names in Ceedling and you'll get a good idea of what we are talking about here.
-Why use preprocess when you can use preprocessinator? Or what better describes a
-module in charge of invoking tasks during releases than release_invoker? Don't
-get carried away. The names are still descriptive and fulfil the above
-requirements, but they don't feel stale.
+Where ever it doesn't violate the above principles, we try to apply memorable names.
+Sometimes this means using something that is simply descriptive, but often we strive for descriptive AND unique... we like quirky names that stand out in our memory and are easier to search for.
+Take a look through the file names in Ceedling and you'll get a good idea of what we are talking about here.
+Why use preprocess when you can use preprocessinator?
+Or what better describes a module in charge of invoking tasks during releases than release_invoker?
+Don't get carried away.
+The names are still descriptive and fulfil the above requirements, but they don't feel stale.
 
 ## C and C++ Details
 
-We don't really want to add to the style battles out there. Tabs or spaces?
-How many spaces? Where do the braces go? These are age-old questions that will
-never be answered... or at least not answered in a way that will make everyone
-happy.
+We don't really want to add to the style battles out there.
+Tabs or spaces?
+How many spaces?
+Where do the braces go?
+These are age-old questions that will never be answered... or at least not answered in a way that will make everyone happy.
 
-We've decided on our own style preferences. If you'd like to contribute to these
-projects (and we hope that you do), then we ask if you do your best to follow
-the same. It will only hurt a little. We promise.
+We've decided on our own style preferences.
+If you'd like to contribute to these projects (and we hope that you do), then we ask if you do your best to follow the same.
+It will only hurt a little. We promise.
 
 ### Whitespace in C/C++
 
-Our C-style is to use spaces and to use 4 of them per indent level. It's a nice
-power-of-2 number that looks decent on a wide-screen. We have no more reason
-than that. We break that rule when we have lines that wrap (macros or function
-arguments or whatnot). When that happens, we like to indent further to line
-things up in nice tidy columns.
+Our C-style is to use spaces and to use 4 of them per indent level.
+It's a nice power-of-2 number that looks decent on a wide-screen.
+We have no more reason than that.
+We break that rule when we have lines that wrap (macros or function arguments or whatnot).
+When that happens, we like to indent further to line things up in nice tidy columns.
 
 ```C
     if (stuff_happened)
@@ -142,9 +130,10 @@ things up in nice tidy columns.
 
 ### Braces in C/C++
 
-The left brace is on the next line after the declaration. The right brace is
-directly below that. Everything in between in indented one level. If you're
-catching an error and you have a one-line, go ahead and to it on the same line.
+The left brace is on the next line after the declaration.
+The right brace is directly below that.
+Everything in between in indented one level.
+If you're catching an error and you have a one-line, go ahead and to it on the same line.
 
 ```C
     while (blah)
@@ -155,24 +144,28 @@ catching an error and you have a one-line, go ahead and to it on the same line.
 
 ### Comments in C/C++
 
-Do you know what we hate? Old-school C block comments. BUT, we're using them
-anyway. As we mentioned, our goal is to support every compiler we can,
-especially embedded compilers. There are STILL C compilers out there that only
-support old-school block comments. So that is what we're using. We apologize. We
-think they are ugly too.
+Do you know what we hate?
+Old-school C block comments.
+BUT, we're using them anyway.
+As we mentioned, our goal is to support every compiler we can, especially embedded compilers.
+There are STILL C compilers out there that only support old-school block comments.
+So that is what we're using.
+We apologize.
+We think they are ugly too.
 
 ## Ruby Details
 
-Is there really such thing as a Ruby coding standard? Ruby is such a free form
-language, it seems almost sacrilegious to suggest that people should comply to
-one method! We'll keep it really brief!
+Is there really such thing as a Ruby coding standard?
+Ruby is such a free form language, it seems almost sacrilegious to suggest that people should comply to one method!
+We'll keep it really brief!
 
 ### Whitespace in Ruby
 
-Our Ruby style is to use spaces and to use 2 of them per indent level. It's a
-nice power-of-2 number that really grooves with Ruby's compact style. We have no
-more reason than that. We break that rule when we have lines that wrap. When
-that happens, we like to indent further to line things up in nice tidy columns.
+Our Ruby style is to use spaces and to use 2 of them per indent level.
+It's a nice power-of-2 number that really grooves with Ruby's compact style.
+We have no more reason than that.
+We break that rule when we have lines that wrap.
+When that happens, we like to indent further to line things up in nice tidy columns.
 
 ### Case in Ruby
 
@@ -184,8 +177,10 @@ that happens, we like to indent further to line things up in nice tidy columns.
 
 ## Documentation
 
-Egad. Really? We use mark down and we like pdf files because they can be made to
-look nice while still being portable. Good enough?
+Egad.
+Really?
+We use markdown and we like PDF files because they can be made to look nice while still being portable.
+Good enough?
 
 *Find The Latest of This And More at [ThrowTheSwitch.org][]*
 

--- a/docs/ThrowTheSwitchCodingStandard.md
+++ b/docs/ThrowTheSwitchCodingStandard.md
@@ -8,13 +8,11 @@ and we'll try to be polite when we notice yours.
 
 ;)
 
-
 ## Why Have A Coding Standard?
 
 Being consistent makes code easier to understand. We've tried to keep
 our standard simple because we also believe that we can only expect someone to
 follow something that is understandable. Please do your best.
-
 
 ## Our Philosophy
 
@@ -46,7 +44,6 @@ default. We believe that if you're working with a simple compiler and target,
 you shouldn't need to configure very much... we try to make the tools guess as
 much as they can, but give the user the power to override it when it's wrong.
 
-
 ## Naming Things
 
 Let's talk about naming things. Programming is all about naming things. We name
@@ -56,20 +53,19 @@ finding *What Something WANTS to be Called*™.
 
 When naming things, we follow this hierarchy, the first being the
 most important to us (but we do all four when possible):
+
 1. Readable
 2. Descriptive
 3. Consistent
 4. Memorable
 
-
-#### Readable
+### Readable
 
 We want to read our code. This means we like names and flow that are more
 naturally read. We try to avoid double negatives. We try to avoid cryptic
 abbreviations (sticking to ones we feel are common).
 
-
-#### Descriptive
+### Descriptive
 
 We like descriptive names for things, especially functions and variables.
 Finding the right name for something is an important endeavor. You might notice
@@ -90,16 +86,14 @@ naming. We find i, j, and k are better loop counters than loopCounterVar or
 whatnot. We only break this rule when we see that more description could improve
 understanding of an algorithm.
 
-
-#### Consistent
+### Consistent
 
 We like consistency, but we're not really obsessed with it. We try to name our
 configuration macros in a consistent fashion... you'll notice a repeated use of
 UNITY_EXCLUDE_BLAH or UNITY_USES_BLAH macros. This helps users avoid having to
 remember each macro's details.
 
-
-#### Memorable
+### Memorable
 
 Where ever it doesn't violate the above principles, we try to apply memorable
 names. Sometimes this means using something that is simply descriptive, but
@@ -108,9 +102,8 @@ out in our memory and are easier to search for. Take a look through the file
 names in Ceedling and you'll get a good idea of what we are talking about here.
 Why use preprocess when you can use preprocessinator? Or what better describes a
 module in charge of invoking tasks during releases than release_invoker? Don't
-get carried away. The names are still descriptive and fulfill the above
+get carried away. The names are still descriptive and fulfil the above
 requirements, but they don't feel stale.
-
 
 ## C and C++ Details
 
@@ -123,8 +116,7 @@ We've decided on our own style preferences. If you'd like to contribute to these
 projects (and we hope that you do), then we ask if you do your best to follow
 the same. It will only hurt a little. We promise.
 
-
-#### Whitespace
+### Whitespace in C/C++
 
 Our C-style is to use spaces and to use 4 of them per indent level. It's a nice
 power-of-2 number that looks decent on a wide-screen. We have no more reason
@@ -139,8 +131,7 @@ things up in nice tidy columns.
     }
 ```
 
-
-#### Case
+### Case in C/C++
 
 - Files - all lower case with underscores.
 - Variables - all lower case with underscores
@@ -149,8 +140,7 @@ things up in nice tidy columns.
 - Functions - camel cased. Usually named ModuleName_FuncName
 - Constants and Globals - camel cased.
 
-
-#### Braces
+### Braces in C/C++
 
 The left brace is on the next line after the declaration. The right brace is
 directly below that. Everything in between in indented one level. If you're
@@ -163,8 +153,7 @@ catching an error and you have a one-line, go ahead and to it on the same line.
     }
 ```
 
-
-#### Comments
+### Comments in C/C++
 
 Do you know what we hate? Old-school C block comments. BUT, we're using them
 anyway. As we mentioned, our goal is to support every compiler we can,
@@ -172,23 +161,20 @@ especially embedded compilers. There are STILL C compilers out there that only
 support old-school block comments. So that is what we're using. We apologize. We
 think they are ugly too.
 
-
 ## Ruby Details
 
 Is there really such thing as a Ruby coding standard? Ruby is such a free form
 language, it seems almost sacrilegious to suggest that people should comply to
 one method! We'll keep it really brief!
 
-
-#### Whitespace
+### Whitespace in Ruby
 
 Our Ruby style is to use spaces and to use 2 of them per indent level. It's a
 nice power-of-2 number that really grooves with Ruby's compact style. We have no
 more reason than that. We break that rule when we have lines that wrap. When
 that happens, we like to indent further to line things up in nice tidy columns.
 
-
-#### Case
+### Case in Ruby
 
 - Files - all lower case with underscores.
 - Variables - all lower case with underscores
@@ -196,11 +182,9 @@ that happens, we like to indent further to line things up in nice tidy columns.
 - Functions - all lower case with underscores
 - Constants - all upper case with underscores
 
-
 ## Documentation
 
 Egad. Really? We use mark down and we like pdf files because they can be made to
 look nice while still being portable. Good enough?
-
 
 *Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*

--- a/docs/ThrowTheSwitchCodingStandard.md
+++ b/docs/ThrowTheSwitchCodingStandard.md
@@ -187,4 +187,6 @@ that happens, we like to indent further to line things up in nice tidy columns.
 Egad. Really? We use mark down and we like pdf files because they can be made to
 look nice while still being portable. Good enough?
 
-*Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*
+*Find The Latest of This And More at [ThrowTheSwitch.org][]*
+
+[ThrowTheSwitch.org]: https://throwtheswitch.org

--- a/docs/UnityAssertionsReference.md
+++ b/docs/UnityAssertionsReference.md
@@ -34,7 +34,7 @@ execution and reports an error through some appropriate I/O channel (e.g.
 stdout, GUI, file, blinky light).
 
 Fundamentally, for dynamic verification all you need is a single assertion
-mechanism. In fact, that's what the [assert() macro in C's standard library](http://en.wikipedia.org/en/wiki/Assert.h)
+mechanism. In fact, that's what the [assert() macro][] in C's standard library
 is for. So why not just use it? Well, we can do far better in the reporting
 department. C's `assert()` is pretty dumb as-is and is particularly poor for
 handling common data types like arrays, structs, etc. And, without some other
@@ -781,4 +781,7 @@ operations, particularly `TEST_ASSERT_INT_WITHIN`.Such assertions might wrap
 your `int` in the wrong place, and you could experience false failures. You can
 always back down to a simple `TEST_ASSERT` and do the operations yourself.
 
-*Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*
+*Find The Latest of This And More at [ThrowTheSwitch.org][]*
+
+[assert() macro]: http://en.wikipedia.org/en/wiki/Assert.h
+[ThrowTheSwitch.org]: https://throwtheswitch.org

--- a/docs/UnityAssertionsReference.md
+++ b/docs/UnityAssertionsReference.md
@@ -16,14 +16,12 @@ source code in, well, test code.
 - Document types, expected values, and basic behavior in your source code for
 free.
 
-
 ### Unity Is Several Things But Mainly It's Assertions
 
 One way to think of Unity is simply as a rich collection of assertions you can
 use to establish whether your source code behaves the way you think it does.
 Unity provides a framework to easily organize and execute those assertions in
 test code separate from your source code.
-
 
 ### What's an Assertion?
 
@@ -44,7 +42,6 @@ support, it's far too tempting to litter source code with C's `assert()`'s. It's
 generally much cleaner, manageable, and more useful to separate test and source
 code in the way Unity facilitates.
 
-
 ### Unity's Assertions: Helpful Messages _and_ Free Source Code Documentation
 
 Asserting a simple truth condition is valuable, but using the context of the
@@ -60,33 +57,31 @@ tests pass, you have a detailed, up-to-date view of the intent and mechanisms in
 your source code. And due to a wondrous mystery, well-tested code usually tends
 to be well designed code.
 
-
 ## Assertion Conventions and Configurations
 
 ### Naming and Parameter Conventions
 
 The convention of assertion parameters generally follows this order:
 
-```
+```c
 TEST_ASSERT_X( {modifiers}, {expected}, actual, {size/count} )
 ```
 
 The very simplest assertion possible uses only a single `actual` parameter (e.g.
 a simple null check).
 
- - `Actual` is the value being tested and unlike the other parameters in an
-    assertion construction is the only parameter present in all assertion variants.
- - `Modifiers` are masks, ranges, bit flag specifiers, floating point deltas.
- - `Expected` is your expected value (duh) to compare to an `actual` value; it's
-    marked as an optional parameter because some assertions only need a single
-    `actual` parameter (e.g. null check).
- - `Size/count` refers to string lengths, number of array elements, etc.
+- `Actual` is the value being tested and unlike the other parameters in an
+  assertion construction is the only parameter present in all assertion variants.
+- `Modifiers` are masks, ranges, bit flag specifiers, floating point deltas.
+- `Expected` is your expected value (duh) to compare to an `actual` value; it's
+  marked as an optional parameter because some assertions only need a single
+  `actual` parameter (e.g. null check).
+- `Size/count` refers to string lengths, number of array elements, etc.
 
 Many of Unity's assertions are clear duplications in that the same data type
 is handled by several assertions. The differences among these are in how failure
 messages are presented. For instance, a `_HEX` variant of an assertion prints
 the expected and actual values of that assertion formatted as hexadecimal.
-
 
 #### TEST_ASSERT_X_MESSAGE Variants
 
@@ -100,17 +95,18 @@ the reference list below and add a string as the final parameter.
 
 _Example:_
 
-```
+```c
 TEST_ASSERT_X( {modifiers}, {expected}, actual, {size/count} )
 ```
 
 becomes messageified like thus...
 
-```
+```c
 TEST_ASSERT_X_MESSAGE( {modifiers}, {expected}, actual, {size/count}, message )
 ```
 
 Notes:
+
 - The `_MESSAGE` variants intentionally do not support `printf` style formatting
   since many embedded projects don't support or avoid `printf` for various reasons.
   It is possible to use `sprintf` before the assertion to assemble a complex fail
@@ -118,7 +114,6 @@ Notes:
 - If you want to output a counter value within an assertion fail message (e.g. from
   a loop) , building up an array of results and then using one of the `_ARRAY`
   assertions (see below) might be a handy alternative to `sprintf`.
-
 
 #### TEST_ASSERT_X_ARRAY Variants
 
@@ -128,22 +123,21 @@ with the `_MESSAGE`variants of Unity's Asserts in that for pretty much any Unity
 type assertion you can tack on `_ARRAY` and run assertions on an entire block of
 memory.
 
-```
+```c
     TEST_ASSERT_EQUAL_TYPEX_ARRAY( expected, actual, {size/count} )
 ```
 
- - `Expected` is an array itself.
- - `Size/count` is one or two parameters necessary to establish the number of array
-    elements and perhaps the length of elements within the array.
+- `Expected` is an array itself.
+- `Size/count` is one or two parameters necessary to establish the number of array
+  elements and perhaps the length of elements within the array.
 
 Notes:
 
- - The `_MESSAGE` variant convention still applies here to array assertions. The
-   `_MESSAGE` variants of the `_ARRAY` assertions have names ending with
-   `_ARRAY_MESSAGE`.
- - Assertions for handling arrays of floating point values are grouped with float
-   and double assertions (see immediately following section).
-
+- The `_MESSAGE` variant convention still applies here to array assertions. The
+  `_MESSAGE` variants of the `_ARRAY` assertions have names ending with
+  `_ARRAY_MESSAGE`.
+- Assertions for handling arrays of floating point values are grouped with float
+  and double assertions (see immediately following section).
 
 ### TEST_ASSERT_EACH_EQUAL_X Variants
 
@@ -153,21 +147,20 @@ the Each Equal section below. these are almost on par with the `_MESSAGE`
 variants of Unity's Asserts in that for pretty much any Unity type assertion you
 can inject `_EACH_EQUAL` and run assertions on an entire block of memory.
 
-```
+```c
 TEST_ASSERT_EACH_EQUAL_TYPEX( expected, actual, {size/count} )
 ```
 
- - `Expected` is a single value to compare to.
- - `Actual` is an array where each element will be compared to the expected value.
- - `Size/count` is one of two parameters necessary to establish the number of array
-    elements and perhaps the length of elements within the array.
+- `Expected` is a single value to compare to.
+- `Actual` is an array where each element will be compared to the expected value.
+- `Size/count` is one of two parameters necessary to establish the number of array
+  elements and perhaps the length of elements within the array.
 
 Notes:
 
- - The `_MESSAGE` variant convention still applies here to Each Equal assertions.
- - Assertions for handling Each Equal of floating point values are grouped with
-   float and double assertions (see immediately following section).
-
+- The `_MESSAGE` variant convention still applies here to Each Equal assertions.
+- Assertions for handling Each Equal of floating point values are grouped with
+  float and double assertions (see immediately following section).
 
 ### Configuration
 
@@ -179,7 +172,6 @@ or disabled in Unity code. This is useful for embedded targets with no floating
 point math support (i.e. Unity compiles free of errors for fixed point only
 platforms). See Unity documentation for specifics.
 
-
 #### Maximum Data Type Width Is Configurable
 
 Not all targets support 64 bit wide types or even 32 bit wide types. Define the
@@ -187,14 +179,13 @@ appropriate preprocessor symbols and Unity will omit all operations from
 compilation that exceed the maximum width of your target. See Unity
 documentation for specifics.
 
-
 ## The Assertions in All Their Blessed Glory
 
 ### Basic Fail, Pass and Ignore
 
-##### `TEST_FAIL()`
+#### `TEST_FAIL()`
 
-##### `TEST_FAIL_MESSAGE("message")`
+#### `TEST_FAIL_MESSAGE("message")`
 
 This fella is most often used in special conditions where your test code is
 performing logic beyond a simple assertion. That is, in practice, `TEST_FAIL()`
@@ -207,25 +198,25 @@ code then verifies as a final step.
 - Triggering an exception and verifying it (as in Try / Catch / Throw - see the
 [CException](https://github.com/ThrowTheSwitch/CException) project).
 
-##### `TEST_PASS()`
+#### `TEST_PASS()`
 
-##### `TEST_PASS_MESSAGE("message")`
+#### `TEST_PASS_MESSAGE("message")`
 
 This will abort the remainder of the test, but count the test as a pass. Under
 normal circumstances, it is not necessary to include this macro in your tests...
 a lack of failure will automatically be counted as a `PASS`. It is occasionally
 useful for tests with `#ifdef`s and such.
 
-##### `TEST_IGNORE()`
+#### `TEST_IGNORE()`
 
-##### `TEST_IGNORE_MESSAGE("message")`
+#### `TEST_IGNORE_MESSAGE("message")`
 
 Marks a test case (i.e. function meant to contain test assertions) as ignored.
 Usually this is employed as a breadcrumb to come back and implement a test case.
 An ignored test case has effects if other assertions are in the enclosing test
 case (see Unity documentation for more).
 
-##### `TEST_MESSAGE(message)`
+#### `TEST_MESSAGE(message)`
 
 This can be useful for outputting `INFO` messages into the Unity output stream
 without actually ending the test. Like pass and fail messages, it will be output
@@ -233,27 +224,27 @@ with the filename and line number.
 
 ### Boolean
 
-##### `TEST_ASSERT (condition)`
+#### `TEST_ASSERT (condition)`
 
-##### `TEST_ASSERT_TRUE (condition)`
+#### `TEST_ASSERT_TRUE (condition)`
 
-##### `TEST_ASSERT_FALSE (condition)`
+#### `TEST_ASSERT_FALSE (condition)`
 
-##### `TEST_ASSERT_UNLESS (condition)`
+#### `TEST_ASSERT_UNLESS (condition)`
 
 A simple wording variation on `TEST_ASSERT_FALSE`.The semantics of
 `TEST_ASSERT_UNLESS` aid readability in certain test constructions or
 conditional statements.
 
-##### `TEST_ASSERT_NULL (pointer)`
+#### `TEST_ASSERT_NULL (pointer)`
 
-##### `TEST_ASSERT_NOT_NULL (pointer)`
+#### `TEST_ASSERT_NOT_NULL (pointer)`
 
 Verify if a pointer is or is not NULL.
 
-##### `TEST_ASSERT_EMPTY (pointer)`
+#### `TEST_ASSERT_EMPTY (pointer)`
 
-##### `TEST_ASSERT_NOT_EMPTY (pointer)`
+#### `TEST_ASSERT_NOT_EMPTY (pointer)`
 
 Verify if the first element dereferenced from a pointer is or is not zero. This
 is particularly useful for checking for empty (or non-empty) null-terminated
@@ -268,26 +259,25 @@ that would break compilation (see Unity documentation for more). Refer to
 Advanced Asserting later in this document for advice on dealing with other word
 sizes.
 
-##### `TEST_ASSERT_EQUAL_INT (expected, actual)`
+#### `TEST_ASSERT_EQUAL_INT (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_INT8 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_INT8 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_INT16 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_INT16 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_INT32 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_INT32 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_INT64 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_INT64 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_UINT (expected, actual)`
+#### `TEST_ASSERT_EQUAL_UINT (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_UINT8 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_UINT8 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_UINT16 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_UINT16 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_UINT32 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_UINT32 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_UINT64 (expected, actual)`
-
+#### `TEST_ASSERT_EQUAL_UINT64 (expected, actual)`
 
 ### Unsigned Integers (of all sizes) in Hexadecimal
 
@@ -295,16 +285,15 @@ All `_HEX` assertions are identical in function to unsigned integer assertions
 but produce failure messages with the `expected` and `actual` values formatted
 in hexadecimal. Unity output is big endian.
 
-##### `TEST_ASSERT_EQUAL_HEX (expected, actual)`
+#### `TEST_ASSERT_EQUAL_HEX (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_HEX8 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_HEX8 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_HEX16 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_HEX16 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_HEX32 (expected, actual)`
+#### `TEST_ASSERT_EQUAL_HEX32 (expected, actual)`
 
-##### `TEST_ASSERT_EQUAL_HEX64 (expected, actual)`
-
+#### `TEST_ASSERT_EQUAL_HEX64 (expected, actual)`
 
 ### Characters
 
@@ -312,36 +301,30 @@ While you can use the 8-bit integer assertions to compare `char`, another option
 to use this specialized assertion which will show printable characters as printables,
 otherwise showing the HEX escape code for the characters.
 
-##### `TEST_ASSERT_EQUAL_CHAR (expected, actual)`
-
+#### `TEST_ASSERT_EQUAL_CHAR (expected, actual)`
 
 ### Masked and Bit-level Assertions
 
 Masked and bit-level assertions produce output formatted in hexadecimal. Unity
 output is big endian.
 
-
-##### `TEST_ASSERT_BITS (mask, expected, actual)`
+#### `TEST_ASSERT_BITS (mask, expected, actual)`
 
 Only compares the masked (i.e. high) bits of `expected` and `actual` parameters.
 
-
-##### `TEST_ASSERT_BITS_HIGH (mask, actual)`
+#### `TEST_ASSERT_BITS_HIGH (mask, actual)`
 
 Asserts the masked bits of the `actual` parameter are high.
 
-
-##### `TEST_ASSERT_BITS_LOW (mask, actual)`
+#### `TEST_ASSERT_BITS_LOW (mask, actual)`
 
 Asserts the masked bits of the `actual` parameter are low.
 
-
-##### `TEST_ASSERT_BIT_HIGH (bit, actual)`
+#### `TEST_ASSERT_BIT_HIGH (bit, actual)`
 
 Asserts the specified bit of the `actual` parameter is high.
 
-
-##### `TEST_ASSERT_BIT_LOW (bit, actual)`
+#### `TEST_ASSERT_BIT_LOW (bit, actual)`
 
 Asserts the specified bit of the `actual` parameter is low.
 
@@ -352,16 +335,15 @@ than `threshold` (exclusive). For example, if the threshold value is 0 for the
 greater than assertion will fail if it is 0 or less. There are assertions for
 all the various sizes of ints, as for the equality assertions. Some examples:
 
-##### `TEST_ASSERT_GREATER_THAN_INT8 (threshold, actual)`
+#### `TEST_ASSERT_GREATER_THAN_INT8 (threshold, actual)`
 
-##### `TEST_ASSERT_GREATER_OR_EQUAL_INT16 (threshold, actual)`
+#### `TEST_ASSERT_GREATER_OR_EQUAL_INT16 (threshold, actual)`
 
-##### `TEST_ASSERT_LESS_THAN_INT32 (threshold, actual)`
+#### `TEST_ASSERT_LESS_THAN_INT32 (threshold, actual)`
 
-##### `TEST_ASSERT_LESS_OR_EQUAL_UINT (threshold, actual)`
+#### `TEST_ASSERT_LESS_OR_EQUAL_UINT (threshold, actual)`
 
-##### `TEST_ASSERT_NOT_EQUAL_UINT8 (threshold, actual)`
-
+#### `TEST_ASSERT_NOT_EQUAL_UINT8 (threshold, actual)`
 
 ### Integer Ranges (of all sizes)
 
@@ -370,59 +352,56 @@ These assertions verify that the `expected` parameter is within +/- `delta`
 and the delta is 3 then the assertion will fail for any value outside the range
 of 7 - 13.
 
-##### `TEST_ASSERT_INT_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_INT_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_INT8_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_INT8_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_INT16_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_INT16_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_INT32_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_INT32_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_INT64_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_INT64_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_UINT_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_UINT_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_UINT8_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_UINT8_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_UINT16_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_UINT16_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_UINT32_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_UINT32_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_UINT64_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_UINT64_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_HEX_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_HEX_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_HEX8_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_HEX8_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_HEX16_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_HEX16_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_HEX32_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_HEX32_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_HEX64_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_HEX64_WITHIN (delta, expected, actual)`
 
-##### `TEST_ASSERT_CHAR_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_CHAR_WITHIN (delta, expected, actual)`
 
 ### Structs and Strings
 
-##### `TEST_ASSERT_EQUAL_PTR (expected, actual)`
+#### `TEST_ASSERT_EQUAL_PTR (expected, actual)`
 
 Asserts that the pointers point to the same memory location.
 
-
-##### `TEST_ASSERT_EQUAL_STRING (expected, actual)`
+#### `TEST_ASSERT_EQUAL_STRING (expected, actual)`
 
 Asserts that the null terminated (`'\0'`)strings are identical. If strings are
 of different lengths or any portion of the strings before their terminators
 differ, the assertion fails. Two NULL strings (i.e. zero length) are considered
 equivalent.
 
-
-##### `TEST_ASSERT_EQUAL_MEMORY (expected, actual, len)`
+#### `TEST_ASSERT_EQUAL_MEMORY (expected, actual, len)`
 
 Asserts that the contents of the memory specified by the `expected` and `actual`
 pointers is identical. The size of the memory blocks in bytes is specified by
 the `len` parameter.
-
 
 ### Arrays
 
@@ -438,43 +417,43 @@ For array of strings comparison behavior, see comments for
 Assertions fail upon the first element in the compared arrays found not to
 match. Failure messages specify the array index of the failed comparison.
 
-##### `TEST_ASSERT_EQUAL_INT_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_INT_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_INT8_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_INT8_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_INT16_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_INT16_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_INT32_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_INT32_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_INT64_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_INT64_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_UINT_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_UINT_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_UINT8_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_UINT8_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_UINT16_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_UINT16_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_UINT32_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_UINT32_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_UINT64_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_UINT64_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_HEX_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_HEX_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_HEX8_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_HEX8_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_HEX16_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_HEX16_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_HEX32_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_HEX32_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_HEX64_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_HEX64_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_CHAR_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_CHAR_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_PTR_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_PTR_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_STRING_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_STRING_ARRAY (expected, actual, num_elements)`
 
-##### `TEST_ASSERT_EQUAL_MEMORY_ARRAY (expected, actual, len, num_elements)`
+#### `TEST_ASSERT_EQUAL_MEMORY_ARRAY (expected, actual, len, num_elements)`
 
 `len` is the memory in bytes to be compared at each array element.
 
@@ -485,37 +464,37 @@ These assertions verify that the `expected` array parameter is within +/- `delta
 \[10, 12\] and the delta is 3 then the assertion will fail for any value
 outside the range of \[7 - 13, 9 - 15\].
 
-##### `TEST_ASSERT_INT_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_INT_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_INT8_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_INT8_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_INT16_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_INT16_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_INT32_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_INT32_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_INT64_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_INT64_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_UINT_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_UINT_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_UINT8_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_UINT8_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_UINT16_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_UINT16_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_UINT32_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_UINT32_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_UINT64_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_UINT64_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_HEX_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_HEX_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_HEX8_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_HEX8_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_HEX16_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_HEX16_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_HEX32_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_HEX32_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_HEX64_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_HEX64_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
-##### `TEST_ASSERT_CHAR_ARRAY_WITHIN (delta, expected, actual, num_elements)`
+#### `TEST_ASSERT_CHAR_ARRAY_WITHIN (delta, expected, actual, num_elements)`
 
 ### Each Equal (Arrays to Single Value)
 
@@ -568,17 +547,15 @@ match. Failure messages specify the array index of the failed comparison.
 
 `len` is the memory in bytes to be compared at each array element.
 
-
 ### Floating Point (If enabled)
 
-##### `TEST_ASSERT_FLOAT_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_FLOAT_WITHIN (delta, expected, actual)`
 
 Asserts that the `actual` value is within +/- `delta` of the `expected` value.
 The nature of floating point representation is such that exact evaluations of
 equality are not guaranteed.
 
-
-##### `TEST_ASSERT_EQUAL_FLOAT (expected, actual)`
+#### `TEST_ASSERT_EQUAL_FLOAT (expected, actual)`
 
 Asserts that the ?actual?value is "close enough to be considered equal" to the
 `expected` value. If you are curious about the details, refer to the Advanced
@@ -586,74 +563,63 @@ Asserting section for more details on this. Omitting a user-specified delta in a
 floating point assertion is both a shorthand convenience and a requirement of
 code generation conventions for CMock.
 
-
-##### `TEST_ASSERT_EQUAL_FLOAT_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_FLOAT_ARRAY (expected, actual, num_elements)`
 
 See Array assertion section for details. Note that individual array element
 float comparisons are executed using T?EST_ASSERT_EQUAL_FLOAT?.That is, user
 specified delta comparison values requires a custom-implemented floating point
 array assertion.
 
-
-##### `TEST_ASSERT_FLOAT_IS_INF (actual)`
+#### `TEST_ASSERT_FLOAT_IS_INF (actual)`
 
 Asserts that `actual` parameter is equivalent to positive infinity floating
 point representation.
 
-
-##### `TEST_ASSERT_FLOAT_IS_NEG_INF (actual)`
+#### `TEST_ASSERT_FLOAT_IS_NEG_INF (actual)`
 
 Asserts that `actual` parameter is equivalent to negative infinity floating
 point representation.
 
-
-##### `TEST_ASSERT_FLOAT_IS_NAN (actual)`
+#### `TEST_ASSERT_FLOAT_IS_NAN (actual)`
 
 Asserts that `actual` parameter is a Not A Number floating point representation.
 
-
-##### `TEST_ASSERT_FLOAT_IS_DETERMINATE (actual)`
+#### `TEST_ASSERT_FLOAT_IS_DETERMINATE (actual)`
 
 Asserts that ?actual?parameter is a floating point representation usable for
 mathematical operations. That is, the `actual` parameter is neither positive
 infinity nor negative infinity nor Not A Number floating point representations.
 
-
-##### `TEST_ASSERT_FLOAT_IS_NOT_INF (actual)`
+#### `TEST_ASSERT_FLOAT_IS_NOT_INF (actual)`
 
 Asserts that `actual` parameter is a value other than positive infinity floating
 point representation.
 
-
-##### `TEST_ASSERT_FLOAT_IS_NOT_NEG_INF (actual)`
+#### `TEST_ASSERT_FLOAT_IS_NOT_NEG_INF (actual)`
 
 Asserts that `actual` parameter is a value other than negative infinity floating
 point representation.
 
-
-##### `TEST_ASSERT_FLOAT_IS_NOT_NAN (actual)`
+#### `TEST_ASSERT_FLOAT_IS_NOT_NAN (actual)`
 
 Asserts that `actual` parameter is a value other than Not A Number floating
 point representation.
 
-
-##### `TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE (actual)`
+#### `TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE (actual)`
 
 Asserts that `actual` parameter is not usable for mathematical operations. That
 is, the `actual` parameter is either positive infinity or negative infinity or
 Not A Number floating point representations.
 
-
 ### Double (If enabled)
 
-##### `TEST_ASSERT_DOUBLE_WITHIN (delta, expected, actual)`
+#### `TEST_ASSERT_DOUBLE_WITHIN (delta, expected, actual)`
 
 Asserts that the `actual` value is within +/- `delta` of the `expected` value.
 The nature of floating point representation is such that exact evaluations of
 equality are not guaranteed.
 
-
-##### `TEST_ASSERT_EQUAL_DOUBLE (expected, actual)`
+#### `TEST_ASSERT_EQUAL_DOUBLE (expected, actual)`
 
 Asserts that the `actual` value is "close enough to be considered equal" to the
 `expected` value. If you are curious about the details, refer to the Advanced
@@ -661,63 +627,53 @@ Asserting section for more details. Omitting a user-specified delta in a
 floating point assertion is both a shorthand convenience and a requirement of
 code generation conventions for CMock.
 
-
-##### `TEST_ASSERT_EQUAL_DOUBLE_ARRAY (expected, actual, num_elements)`
+#### `TEST_ASSERT_EQUAL_DOUBLE_ARRAY (expected, actual, num_elements)`
 
 See Array assertion section for details. Note that individual array element
 double comparisons are executed using `TEST_ASSERT_EQUAL_DOUBLE`.That is, user
 specified delta comparison values requires a custom implemented double array
 assertion.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_INF (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_INF (actual)`
 
 Asserts that `actual` parameter is equivalent to positive infinity floating
 point representation.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_NEG_INF (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_NEG_INF (actual)`
 
 Asserts that `actual` parameter is equivalent to negative infinity floating point
 representation.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_NAN (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_NAN (actual)`
 
 Asserts that `actual` parameter is a Not A Number floating point representation.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_DETERMINATE (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_DETERMINATE (actual)`
 
 Asserts that `actual` parameter is a floating point representation usable for
 mathematical operations. That is, the ?actual?parameter is neither positive
 infinity nor negative infinity nor Not A Number floating point representations.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_NOT_INF (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_NOT_INF (actual)`
 
 Asserts that `actual` parameter is a value other than positive infinity floating
 point representation.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF (actual)`
 
 Asserts that `actual` parameter is a value other than negative infinity floating
 point representation.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_NOT_NAN (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_NOT_NAN (actual)`
 
 Asserts that `actual` parameter is a value other than Not A Number floating
 point representation.
 
-
-##### `TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE (actual)`
+#### `TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE (actual)`
 
 Asserts that `actual` parameter is not usable for mathematical operations. That
 is, the `actual` parameter is either positive infinity or negative infinity or
 Not A Number floating point representations.
-
 
 ## Advanced Asserting: Details On Tricky Assertions
 
@@ -726,7 +682,6 @@ assertion situations you may run into. It will give you a glimpse into some of
 the under-the-hood details of Unity's assertion mechanisms. If you're one of
 those people who likes to know what is going on in the background, read on. If
 not, feel free to ignore the rest of this document until you need it.
-
 
 ### How do the EQUAL assertions work for FLOAT and DOUBLE?
 
@@ -767,7 +722,6 @@ If you don't like these ranges and you want to make your floating point equality
 assertions less strict, you can change these multipliers to whatever you like by
 defining UNITY_FLOAT_PRECISION and UNITY_DOUBLE_PRECISION. See Unity
 documentation for more.
-
 
 ### How do we deal with targets with non-standard int sizes?
 
@@ -826,6 +780,5 @@ with zeros.
 operations, particularly `TEST_ASSERT_INT_WITHIN`.Such assertions might wrap
 your `int` in the wrong place, and you could experience false failures. You can
 always back down to a simple `TEST_ASSERT` and do the operations yourself.
-
 
 *Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*

--- a/docs/UnityConfigurationGuide.md
+++ b/docs/UnityConfigurationGuide.md
@@ -22,7 +22,6 @@ challenging to build. From a more positive perspective, it is also proof that a
 great deal of complexity can be centralized primarily to one place to
 provide a more consistent and simple experience elsewhere.
 
-
 ### Using These Options
 
 It doesn't matter if you're using a target-specific compiler and a simulator or
@@ -58,8 +57,7 @@ certainly not every compiler you are likely to encounter. Therefore, Unity has a
 number of features for helping to adjust itself to match your required integer
 sizes. It starts off by trying to do it automatically.
 
-
-##### `UNITY_EXCLUDE_STDINT_H`
+#### `UNITY_EXCLUDE_STDINT_H`
 
 The first thing that Unity does to guess your types is check `stdint.h`.
 This file includes defines like `UINT_MAX` that Unity can use to
@@ -70,18 +68,19 @@ That way, Unity will know to skip the inclusion of this file and you won't
 be left with a compiler error.
 
 _Example:_
+
 ```C
 #define UNITY_EXCLUDE_STDINT_H
 ```
 
-
-##### `UNITY_EXCLUDE_LIMITS_H`
+#### `UNITY_EXCLUDE_LIMITS_H`
 
 The second attempt to guess your types is to check `limits.h`. Some compilers
 that don't support `stdint.h` could include `limits.h` instead. If you don't
 want Unity to check this file either, define this to make it skip the inclusion.
 
 _Example:_
+
 ```C
 #define UNITY_EXCLUDE_LIMITS_H
 ```
@@ -91,19 +90,18 @@ do the configuration yourself. Don't worry. Even this isn't too bad... there are
 just a handful of defines that you are going to specify if you don't like the
 defaults.
 
-
-##### `UNITY_INT_WIDTH`
+#### `UNITY_INT_WIDTH`
 
 Define this to be the number of bits an `int` takes up on your system. The
 default, if not autodetected, is 32 bits.
 
 _Example:_
+
 ```C
 #define UNITY_INT_WIDTH 16
 ```
 
-
-##### `UNITY_LONG_WIDTH`
+#### `UNITY_LONG_WIDTH`
 
 Define this to be the number of bits a `long` takes up on your system. The
 default, if not autodetected, is 32 bits. This is used to figure out what kind
@@ -112,12 +110,12 @@ of 64-bit support your system can handle. Does it need to specify a `long` or a
 ignored.
 
 _Example:_
+
 ```C
 #define UNITY_LONG_WIDTH 16
 ```
 
-
-##### `UNITY_POINTER_WIDTH`
+#### `UNITY_POINTER_WIDTH`
 
 Define this to be the number of bits a pointer takes up on your system. The
 default, if not autodetected, is 32-bits. If you're getting ugly compiler
@@ -129,6 +127,7 @@ width of 23-bit), choose the next power of two (in this case 32-bit).
 _Supported values:_ 16, 32 and 64
 
 _Example:_
+
 ```C
 // Choose on of these #defines to set your pointer width (if not autodetected)
 //#define UNITY_POINTER_WIDTH 16
@@ -136,8 +135,7 @@ _Example:_
 #define UNITY_POINTER_WIDTH 64 // Set UNITY_POINTER_WIDTH to 64-bit
 ```
 
-
-##### `UNITY_SUPPORT_64`
+#### `UNITY_SUPPORT_64`
 
 Unity will automatically include 64-bit support if it auto-detects it, or if
 your `int`, `long`, or pointer widths are greater than 32-bits. Define this to
@@ -146,10 +144,10 @@ can be a significant size and speed impact to enabling 64-bit support on small
 targets, so don't define it if you don't need it.
 
 _Example:_
+
 ```C
 #define UNITY_SUPPORT_64
 ```
-
 
 ### Floating Point Types
 
@@ -160,14 +158,13 @@ are always available in at least one size. Floating point, on the other hand, is
 sometimes not available at all. Trying to include `float.h` on these platforms
 would result in an error. This leaves manual configuration as the only option.
 
+#### `UNITY_INCLUDE_FLOAT`
 
-##### `UNITY_INCLUDE_FLOAT`
+#### `UNITY_EXCLUDE_FLOAT`
 
-##### `UNITY_EXCLUDE_FLOAT`
+#### `UNITY_INCLUDE_DOUBLE`
 
-##### `UNITY_INCLUDE_DOUBLE`
-
-##### `UNITY_EXCLUDE_DOUBLE`
+#### `UNITY_EXCLUDE_DOUBLE`
 
 By default, Unity guesses that you will want single precision floating point
 support, but not double precision. It's easy to change either of these using the
@@ -176,14 +173,14 @@ suits your needs. For features that are enabled, the following floating point
 options also become available.
 
 _Example:_
+
 ```C
 //what manner of strange processor is this?
 #define UNITY_EXCLUDE_FLOAT
 #define UNITY_INCLUDE_DOUBLE
 ```
 
-
-##### `UNITY_EXCLUDE_FLOAT_PRINT`
+#### `UNITY_EXCLUDE_FLOAT_PRINT`
 
 Unity aims for as small of a footprint as possible and avoids most standard
 library calls (some embedded platforms don’t have a standard library!). Because
@@ -196,24 +193,24 @@ can use this define to instead respond to a failed assertion with a message like
 point assertions, use these options to give more explicit failure messages.
 
 _Example:_
+
 ```C
 #define UNITY_EXCLUDE_FLOAT_PRINT
 ```
 
-
-##### `UNITY_FLOAT_TYPE`
+#### `UNITY_FLOAT_TYPE`
 
 If enabled, Unity assumes you want your `FLOAT` asserts to compare standard C
 floats. If your compiler supports a specialty floating point type, you can
 always override this behavior by using this definition.
 
 _Example:_
+
 ```C
 #define UNITY_FLOAT_TYPE float16_t
 ```
 
-
-##### `UNITY_DOUBLE_TYPE`
+#### `UNITY_DOUBLE_TYPE`
 
 If enabled, Unity assumes you want your `DOUBLE` asserts to compare standard C
 doubles. If you would like to change this, you can specify something else by
@@ -222,14 +219,14 @@ could enable gargantuan floating point types on your 64-bit processor instead of
 the standard `double`.
 
 _Example:_
+
 ```C
 #define UNITY_DOUBLE_TYPE long double
 ```
 
+#### `UNITY_FLOAT_PRECISION`
 
-##### `UNITY_FLOAT_PRECISION`
-
-##### `UNITY_DOUBLE_PRECISION`
+#### `UNITY_DOUBLE_PRECISION`
 
 If you look up `UNITY_ASSERT_EQUAL_FLOAT` and `UNITY_ASSERT_EQUAL_DOUBLE` as
 documented in the big daddy Unity Assertion Guide, you will learn that they are
@@ -243,14 +240,14 @@ For further details on how this works, see the appendix of the Unity Assertion
 Guide.
 
 _Example:_
+
 ```C
 #define UNITY_FLOAT_PRECISION 0.001f
 ```
 
-
 ### Miscellaneous
 
-##### `UNITY_EXCLUDE_STDDEF_H`
+#### `UNITY_EXCLUDE_STDDEF_H`
 
 Unity uses the `NULL` macro, which defines the value of a null pointer constant,
 defined in `stddef.h` by default. If you want to provide
@@ -258,10 +255,10 @@ your own macro for this, you should exclude the `stddef.h` header file by adding
 define to your configuration.
 
 _Example:_
+
 ```C
 #define UNITY_EXCLUDE_STDDEF_H
 ```
-
 
 #### `UNITY_INCLUDE_PRINT_FORMATTED`
 
@@ -282,6 +279,7 @@ which is able to print a string modified by the following format string modifier
 - __%%__ - The "%" symbol (escaped)
 
 _Example:_
+
 ```C
 #define UNITY_INCLUDE_PRINT_FORMATTED
 
@@ -300,7 +298,6 @@ TEST_PRINTF("\n");
 TEST_PRINTF("Multiple (%d) (%i) (%u) (%x)\n", -100, 0, 200, 0x12345);
 ```
 
-
 ### Toolset Customization
 
 In addition to the options listed above, there are a number of other options
@@ -310,14 +307,13 @@ certain platforms, particularly those running in simulators, may need to jump
 through extra hoops to run properly. These macros will help in those
 situations.
 
+#### `UNITY_OUTPUT_CHAR(a)`
 
-##### `UNITY_OUTPUT_CHAR(a)`
+#### `UNITY_OUTPUT_FLUSH()`
 
-##### `UNITY_OUTPUT_FLUSH()`
+#### `UNITY_OUTPUT_START()`
 
-##### `UNITY_OUTPUT_START()`
-
-##### `UNITY_OUTPUT_COMPLETE()`
+#### `UNITY_OUTPUT_COMPLETE()`
 
 By default, Unity prints its results to `stdout` as it runs. This works
 perfectly fine in most situations where you are using a native compiler for
@@ -333,6 +329,7 @@ _Example:_
 Say you are forced to run your test suite on an embedded processor with no
 `stdout` option. You decide to route your test result output to a custom serial
 `RS232_putc()` function you wrote like thus:
+
 ```C
 #include "RS232_header.h"
 ...
@@ -346,44 +343,43 @@ _Note:_
 `UNITY_OUTPUT_FLUSH()` can be set to the standard out flush function simply by
 specifying `UNITY_USE_FLUSH_STDOUT`. No other defines are required.
 
+#### `UNITY_OUTPUT_FOR_ECLIPSE`
 
-##### `UNITY_OUTPUT_FOR_ECLIPSE`
+#### `UNITY_OUTPUT_FOR_IAR_WORKBENCH`
 
-##### `UNITY_OUTPUT_FOR_IAR_WORKBENCH`
-
-##### `UNITY_OUTPUT_FOR_QT_CREATOR`
+#### `UNITY_OUTPUT_FOR_QT_CREATOR`
 
 When managing your own builds, it is often handy to have messages output in a format which is
 recognized by your IDE. These are some standard formats which can be supported. If you're using
 Ceedling to manage your builds, it is better to stick with the standard format (leaving these
 all undefined) and allow Ceedling to use its own decorators.
 
-
-##### `UNITY_PTR_ATTRIBUTE`
+#### `UNITY_PTR_ATTRIBUTE`
 
 Some compilers require a custom attribute to be assigned to pointers, like
 `near` or `far`. In these cases, you can give Unity a safe default for these by
 defining this option with the attribute you would like.
 
 _Example:_
+
 ```C
 #define UNITY_PTR_ATTRIBUTE __attribute__((far))
 #define UNITY_PTR_ATTRIBUTE near
 ```
 
-##### `UNITY_PRINT_EOL`
+#### `UNITY_PRINT_EOL`
 
 By default, Unity outputs \n at the end of each line of output. This is easy
 to parse by the scripts, by Ceedling, etc, but it might not be ideal for YOUR
 system. Feel free to override this and to make it whatever you wish.
 
 _Example:_
+
 ```C
 #define UNITY_PRINT_EOL { UNITY_OUTPUT_CHAR('\r'); UNITY_OUTPUT_CHAR('\n'); }
 ```
 
-
-##### `UNITY_EXCLUDE_DETAILS`
+#### `UNITY_EXCLUDE_DETAILS`
 
 This is an option for if you absolutely must squeeze every byte of memory out of
 your system. Unity stores a set of internal scratchpads which are used to pass
@@ -392,11 +388,12 @@ report which function or argument flagged an error. If you're not using CMock an
 you're not using these details for other things, then you can exclude them.
 
 _Example:_
+
 ```C
 #define UNITY_EXCLUDE_DETAILS
 ```
 
-##### `UNITY_PRINT_TEST_CONTEXT`
+#### `UNITY_PRINT_TEST_CONTEXT`
 
 This option allows you to specify your own function to print additional context
 as part of the error message when a test has failed. It can be useful if you
@@ -404,6 +401,7 @@ want to output some specific information about the state of the test at the poin
 of failure, and `UNITY_SET_DETAILS` isn't flexible enough for your needs.
 
 _Example:_
+
 ```C
 #define UNITY_PRINT_TEST_CONTEXT PrintIterationCount
 
@@ -415,7 +413,7 @@ void PrintIterationCount(void)
 }
 ```
 
-##### `UNITY_EXCLUDE_SETJMP`
+#### `UNITY_EXCLUDE_SETJMP`
 
 If your embedded system doesn't support the standard library setjmp, you can
 exclude Unity's reliance on this by using this define. This dropped dependence
@@ -425,23 +423,28 @@ compiler doesn't support setjmp, you wouldn't have had the memory space for thos
 things anyway, though... so this option exists for those situations.
 
 _Example:_
+
 ```C
 #define UNITY_EXCLUDE_SETJMP
 ```
 
-##### `UNITY_OUTPUT_COLOR`
+#### `UNITY_OUTPUT_COLOR`
 
 If you want to add color using ANSI escape codes you can use this define.
 
 _Example:_
+
 ```C
 #define UNITY_OUTPUT_COLOR
 ```
 
-##### `UNITY_SHORTHAND_AS_INT`
-##### `UNITY_SHORTHAND_AS_MEM`
-##### `UNITY_SHORTHAND_AS_RAW`
-##### `UNITY_SHORTHAND_AS_NONE`
+#### `UNITY_SHORTHAND_AS_INT`
+
+#### `UNITY_SHORTHAND_AS_MEM`
+
+#### `UNITY_SHORTHAND_AS_RAW`
+
+#### `UNITY_SHORTHAND_AS_NONE`
 
 These options  give you control of the `TEST_ASSERT_EQUAL` and the
 `TEST_ASSERT_NOT_EQUAL` shorthand assertions. Historically, Unity treated the
@@ -450,15 +453,15 @@ comparison using `!=`. This assymetry was confusing, but there was much
 disagreement as to how best to treat this pair of assertions. These four options
 will allow you to specify how Unity will treat these assertions.
 
-  - AS INT - the values will be cast to integers and directly compared. Arguments
-             that don't cast easily to integers will cause compiler errors.
-  - AS MEM - the address of both values will be taken and the entire object's
-             memory footprint will be compared byte by byte. Directly placing
-             constant numbers like `456` as expected values will cause errors.
-  - AS_RAW - Unity assumes that you can compare the two values using `==` and `!=`
-             and will do so. No details are given about mismatches, because it
-             doesn't really know what type it's dealing with.
-  - AS_NONE - Unity will disallow the use of these shorthand macros altogether,
+- AS INT - the values will be cast to integers and directly compared. Arguments
+            that don't cast easily to integers will cause compiler errors.
+- AS MEM - the address of both values will be taken and the entire object's
+            memory footprint will be compared byte by byte. Directly placing
+            constant numbers like `456` as expected values will cause errors.
+- AS_RAW - Unity assumes that you can compare the two values using `==` and `!=`
+            and will do so. No details are given about mismatches, because it
+            doesn't really know what type it's dealing with.
+- AS_NONE - Unity will disallow the use of these shorthand macros altogether,
              insisting that developers choose a more descriptive option.
 
 #### `UNITY_SUPPORT_VARIADIC_MACROS`
@@ -482,8 +485,7 @@ require special help. This special help will usually reside in one of two
 places: the `main()` function or the `RUN_TEST` macro. Let's look at how these
 work.
 
-
-##### `main()`
+### `main()`
 
 Each test module is compiled and run on its own, separate from the other test
 files in your project. Each test file, therefore, has a `main` function. This
@@ -515,8 +517,7 @@ after all the test cases have completed. This allows you to do any needed
 system-wide setup or teardown that might be required for your special
 circumstances.
 
-
-##### `RUN_TEST`
+#### `RUN_TEST`
 
 The `RUN_TEST` macro is called with each test case function. Its job is to
 perform whatever setup and teardown is necessary for executing a single test
@@ -552,12 +553,10 @@ each result set. Again, you could do this by adding lines to this macro. Updates
 to this macro are for the occasions when you need an action before or after
 every single test case throughout your entire suite of tests.
 
-
 ## Happy Porting
 
 The defines and macros in this guide should help you port Unity to just about
 any C target we can imagine. If you run into a snag or two, don't be afraid of
 asking for help on the forums. We love a good challenge!
-
 
 *Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*

--- a/docs/UnityConfigurationGuide.md
+++ b/docs/UnityConfigurationGuide.md
@@ -2,70 +2,58 @@
 
 ## C Standards, Compilers and Microcontrollers
 
-The embedded software world contains its challenges. Compilers support different
-revisions of the C Standard. They ignore requirements in places, sometimes to
-make the language more usable in some special regard. Sometimes it's to simplify
-their support. Sometimes it's due to specific quirks of the microcontroller they
-are targeting. Simulators add another dimension to this menagerie.
+The embedded software world contains its challenges.
+Compilers support different revisions of the C Standard.
+They ignore requirements in places, sometimes to make the language more usable in some special regard.
+Sometimes it's to simplify their support.
+Sometimes it's due to specific quirks of the microcontroller they are targeting.
+Simulators add another dimension to this menagerie.
 
-Unity is designed to run on almost anything that is targeted by a C compiler. It
-would be awesome if this could be done with zero configuration. While there are
-some targets that come close to this dream, it is sadly not universal. It is
-likely that you are going to need at least a couple of the configuration options
-described in this document.
+Unity is designed to run on almost anything that is targeted by a C compiler.
+It would be awesome if this could be done with zero configuration.
+While there are some targets that come close to this dream, it is sadly not universal.
+It is likely that you are going to need at least a couple of the configuration options described in this document.
 
-All of Unity's configuration options are `#defines`. Most of these are simple
-definitions. A couple are macros with arguments. They live inside the
-unity_internals.h header file. We don't necessarily recommend opening that file
-unless you really need to. That file is proof that a cross-platform library is
-challenging to build. From a more positive perspective, it is also proof that a
-great deal of complexity can be centralized primarily to one place to
-provide a more consistent and simple experience elsewhere.
+All of Unity's configuration options are `#defines`.
+Most of these are simple definitions.
+A couple are macros with arguments.
+They live inside the unity_internals.h header file.
+We don't necessarily recommend opening that file unless you really need to.
+That file is proof that a cross-platform library is challenging to build.
+From a more positive perspective, it is also proof that a great deal of complexity can be centralized primarily to one place to provide a more consistent and simple experience elsewhere.
 
 ### Using These Options
 
-It doesn't matter if you're using a target-specific compiler and a simulator or
-a native compiler. In either case, you've got a couple choices for configuring
-these options:
+It doesn't matter if you're using a target-specific compiler and a simulator or a native compiler.
+In either case, you've got a couple choices for configuring these options:
 
-1. Because these options are specified via C defines, you can pass most of these
-options to your compiler through command line compiler flags. Even if you're
-using an embedded target that forces you to use their overbearing IDE for all
-configuration, there will be a place somewhere in your project to configure
-defines for your compiler.
-2. You can create a custom `unity_config.h` configuration file (present in your
-toolchain's search paths). In this file, you will list definitions and macros
-specific to your target. All you must do is define `UNITY_INCLUDE_CONFIG_H` and
-Unity will rely on `unity_config.h` for any further definitions it may need.
+1. Because these options are specified via C defines, you can pass most of these options to your compiler through command line compiler flags. Even if you're using an embedded target that forces you to use their overbearing IDE for all configuration, there will be a place somewhere in your project to configure defines for your compiler.
+2. You can create a custom `unity_config.h` configuration file (present in your toolchain's search paths).
+  In this file, you will list definitions and macros specific to your target. All you must do is define `UNITY_INCLUDE_CONFIG_H` and Unity will rely on `unity_config.h` for any further definitions it may need.
 
-Unfortunately, it doesn't usually work well to just #define these things in the
-test itself. These defines need to take effect where ever unity.h is included.
-This would be test test, the test runner (if you're generating one), and from
-unity.c when it's compiled.
+Unfortunately, it doesn't usually work well to just #define these things in the test itself.
+These defines need to take effect where ever unity.h is included.
+This would be test test, the test runner (if you're generating one), and from unity.c when it's compiled.
 
 ## The Options
 
 ### Integer Types
 
-If you've been a C developer for long, you probably already know that C's
-concept of an integer varies from target to target. The C Standard has rules
-about the `int` matching the register size of the target microprocessor. It has
-rules about the `int` and how its size relates to other integer types. An `int`
-on one target might be 16 bits while on another target it might be 64. There are
-more specific types in compilers compliant with C99 or later, but that's
-certainly not every compiler you are likely to encounter. Therefore, Unity has a
-number of features for helping to adjust itself to match your required integer
-sizes. It starts off by trying to do it automatically.
+If you've been a C developer for long, you probably already know that C's concept of an integer varies from target to target.
+The C Standard has rules about the `int` matching the register size of the target microprocessor.
+It has rules about the `int` and how its size relates to other integer types.
+An `int` on one target might be 16 bits while on another target it might be 64.
+There are more specific types in compilers compliant with C99 or later, but that's certainly not every compiler you are likely to encounter.
+Therefore, Unity has a number of features for helping to adjust itself to match your required integer sizes.
+It starts off by trying to do it automatically.
 
 #### `UNITY_EXCLUDE_STDINT_H`
 
 The first thing that Unity does to guess your types is check `stdint.h`.
-This file includes defines like `UINT_MAX` that Unity can use to
-learn a lot about your system. It's possible you don't want it to do this
-(um. why not?) or (more likely) it's possible that your system doesn't
-support `stdint.h`. If that's the case, you're going to want to define this.
-That way, Unity will know to skip the inclusion of this file and you won't
-be left with a compiler error.
+This file includes defines like `UINT_MAX` that Unity can use to learn a lot about your system.
+It's possible you don't want it to do this (um. why not?) or (more likely) it's possible that your system doesn't support `stdint.h`.
+If that's the case, you're going to want to define this.
+That way, Unity will know to skip the inclusion of this file and you won't be left with a compiler error.
 
 _Example:_
 
@@ -75,9 +63,9 @@ _Example:_
 
 #### `UNITY_EXCLUDE_LIMITS_H`
 
-The second attempt to guess your types is to check `limits.h`. Some compilers
-that don't support `stdint.h` could include `limits.h` instead. If you don't
-want Unity to check this file either, define this to make it skip the inclusion.
+The second attempt to guess your types is to check `limits.h`.
+Some compilers that don't support `stdint.h` could include `limits.h` instead.
+If you don't want Unity to check this file either, define this to make it skip the inclusion.
 
 _Example:_
 
@@ -85,15 +73,14 @@ _Example:_
 #define UNITY_EXCLUDE_LIMITS_H
 ```
 
-If you've disabled both of the automatic options above, you're going to have to
-do the configuration yourself. Don't worry. Even this isn't too bad... there are
-just a handful of defines that you are going to specify if you don't like the
-defaults.
+If you've disabled both of the automatic options above, you're going to have to do the configuration yourself.
+Don't worry.
+Even this isn't too bad... there are just a handful of defines that you are going to specify if you don't like the defaults.
 
 #### `UNITY_INT_WIDTH`
 
-Define this to be the number of bits an `int` takes up on your system. The
-default, if not autodetected, is 32 bits.
+Define this to be the number of bits an `int` takes up on your system.
+The default, if not autodetected, is 32 bits.
 
 _Example:_
 
@@ -103,11 +90,11 @@ _Example:_
 
 #### `UNITY_LONG_WIDTH`
 
-Define this to be the number of bits a `long` takes up on your system. The
-default, if not autodetected, is 32 bits. This is used to figure out what kind
-of 64-bit support your system can handle. Does it need to specify a `long` or a
-`long long` to get a 64-bit value. On 16-bit systems, this option is going to be
-ignored.
+Define this to be the number of bits a `long` takes up on your system.
+The default, if not autodetected, is 32 bits.
+This is used to figure out what kind of 64-bit support your system can handle.
+Does it need to specify a `long` or a `long long` to get a 64-bit value.
+On 16-bit systems, this option is going to be ignored.
 
 _Example:_
 
@@ -117,12 +104,11 @@ _Example:_
 
 #### `UNITY_POINTER_WIDTH`
 
-Define this to be the number of bits a pointer takes up on your system. The
-default, if not autodetected, is 32-bits. If you're getting ugly compiler
-warnings about casting from pointers, this is the one to look at.
+Define this to be the number of bits a pointer takes up on your system.
+The default, if not autodetected, is 32-bits.
+If you're getting ugly compiler warnings about casting from pointers, this is the one to look at.
 
-_Hint:_ In order to support exotic processors (for example TI C55x with a pointer
-width of 23-bit), choose the next power of two (in this case 32-bit).
+_Hint:_ In order to support exotic processors (for example TI C55x with a pointer width of 23-bit), choose the next power of two (in this case 32-bit).
 
 _Supported values:_ 16, 32 and 64
 
@@ -137,11 +123,9 @@ _Example:_
 
 #### `UNITY_SUPPORT_64`
 
-Unity will automatically include 64-bit support if it auto-detects it, or if
-your `int`, `long`, or pointer widths are greater than 32-bits. Define this to
-enable 64-bit support if none of the other options already did it for you. There
-can be a significant size and speed impact to enabling 64-bit support on small
-targets, so don't define it if you don't need it.
+Unity will automatically include 64-bit support if it auto-detects it, or if your `int`, `long`, or pointer widths are greater than 32-bits.
+Define this to enable 64-bit support if none of the other options already did it for you.
+There can be a significant size and speed impact to enabling 64-bit support on small targets, so don't define it if you don't need it.
 
 _Example:_
 
@@ -151,12 +135,10 @@ _Example:_
 
 ### Floating Point Types
 
-In the embedded world, it's not uncommon for targets to have no support for
-floating point operations at all or to have support that is limited to only
-single precision. We are able to guess integer sizes on the fly because integers
-are always available in at least one size. Floating point, on the other hand, is
-sometimes not available at all. Trying to include `float.h` on these platforms
-would result in an error. This leaves manual configuration as the only option.
+In the embedded world, it's not uncommon for targets to have no support for floating point operations at all or to have support that is limited to only single precision.
+We are able to guess integer sizes on the fly because integers are always available in at least one size.
+Floating point, on the other hand, is sometimes not available at all.
+Trying to include `float.h` on these platforms would result in an error. This leaves manual configuration as the only option.
 
 #### `UNITY_INCLUDE_FLOAT`
 
@@ -166,11 +148,10 @@ would result in an error. This leaves manual configuration as the only option.
 
 #### `UNITY_EXCLUDE_DOUBLE`
 
-By default, Unity guesses that you will want single precision floating point
-support, but not double precision. It's easy to change either of these using the
-include and exclude options here. You may include neither, either, or both, as
-suits your needs. For features that are enabled, the following floating point
-options also become available.
+By default, Unity guesses that you will want single precision floating point support, but not double precision.
+It's easy to change either of these using the include and exclude options here.
+You may include neither, either, or both, as suits your needs.
+For features that are enabled, the following floating point options also become available.
 
 _Example:_
 
@@ -182,15 +163,12 @@ _Example:_
 
 #### `UNITY_EXCLUDE_FLOAT_PRINT`
 
-Unity aims for as small of a footprint as possible and avoids most standard
-library calls (some embedded platforms don’t have a standard library!). Because
-of this, its routines for printing integer values are minimalist and hand-coded.
+Unity aims for as small of a footprint as possible and avoids most standard library calls (some embedded platforms don’t have a standard library!).
+Because of this, its routines for printing integer values are minimalist and hand-coded.
 Therefore, the display of floating point values during a failure are optional.
-By default, Unity will print the actual results of floating point assertion
-failure (e.g. ”Expected 4.56 Was 4.68”). To not include this extra support, you
-can use this define to instead respond to a failed assertion with a message like
-”Values Not Within Delta”. If you would like verbose failure messages for floating
-point assertions, use these options to give more explicit failure messages.
+By default, Unity will print the actual results of floating point assertion failure (e.g. ”Expected 4.56 Was 4.68”).
+To not include this extra support, you can use this define to instead respond to a failed assertion with a message like ”Values Not Within Delta”.
+If you would like verbose failure messages for floating point assertions, use these options to give more explicit failure messages.
 
 _Example:_
 
@@ -200,9 +178,8 @@ _Example:_
 
 #### `UNITY_FLOAT_TYPE`
 
-If enabled, Unity assumes you want your `FLOAT` asserts to compare standard C
-floats. If your compiler supports a specialty floating point type, you can
-always override this behavior by using this definition.
+If enabled, Unity assumes you want your `FLOAT` asserts to compare standard C floats.
+If your compiler supports a specialty floating point type, you can always override this behavior by using this definition.
 
 _Example:_
 
@@ -212,11 +189,9 @@ _Example:_
 
 #### `UNITY_DOUBLE_TYPE`
 
-If enabled, Unity assumes you want your `DOUBLE` asserts to compare standard C
-doubles. If you would like to change this, you can specify something else by
-using this option. For example, defining `UNITY_DOUBLE_TYPE` to `long double`
-could enable gargantuan floating point types on your 64-bit processor instead of
-the standard `double`.
+If enabled, Unity assumes you want your `DOUBLE` asserts to compare standard C doubles.
+If you would like to change this, you can specify something else by using this option.
+For example, defining `UNITY_DOUBLE_TYPE` to `long double` could enable gargantuan floating point types on your 64-bit processor instead of the standard `double`.
 
 _Example:_
 
@@ -228,16 +203,12 @@ _Example:_
 
 #### `UNITY_DOUBLE_PRECISION`
 
-If you look up `UNITY_ASSERT_EQUAL_FLOAT` and `UNITY_ASSERT_EQUAL_DOUBLE` as
-documented in the big daddy Unity Assertion Guide, you will learn that they are
-not really asserting that two values are equal but rather that two values are
-"close enough" to equal. "Close enough" is controlled by these precision
-configuration options. If you are working with 32-bit floats and/or 64-bit
-doubles (the normal on most processors), you should have no need to change these
-options. They are both set to give you approximately 1 significant bit in either
-direction. The float precision is 0.00001 while the double is 10-12.
-For further details on how this works, see the appendix of the Unity Assertion
-Guide.
+If you look up `UNITY_ASSERT_EQUAL_FLOAT` and `UNITY_ASSERT_EQUAL_DOUBLE` as documented in the big daddy Unity Assertion Guide, you will learn that they are not really asserting that two values are equal but rather that two values are "close enough" to equal.
+"Close enough" is controlled by these precision configuration options.
+If you are working with 32-bit floats and/or 64-bit doubles (the normal on most processors), you should have no need to change these options.
+They are both set to give you approximately 1 significant bit in either direction.
+The float precision is 0.00001 while the double is 10-12.
+For further details on how this works, see the appendix of the Unity Assertion Guide.
 
 _Example:_
 
@@ -249,10 +220,8 @@ _Example:_
 
 #### `UNITY_EXCLUDE_STDDEF_H`
 
-Unity uses the `NULL` macro, which defines the value of a null pointer constant,
-defined in `stddef.h` by default. If you want to provide
-your own macro for this, you should exclude the `stddef.h` header file by adding this
-define to your configuration.
+Unity uses the `NULL` macro, which defines the value of a null pointer constant, defined in `stddef.h` by default.
+If you want to provide your own macro for this, you should exclude the `stddef.h` header file by adding this define to your configuration.
 
 _Example:_
 
@@ -262,8 +231,7 @@ _Example:_
 
 #### `UNITY_INCLUDE_PRINT_FORMATTED`
 
-Unity provides a simple (and very basic) printf-like string output implementation,
-which is able to print a string modified by the following format string modifiers:
+Unity provides a simple (and very basic) printf-like string output implementation, which is able to print a string modified by the following format string modifiers:
 
 - __%d__ - signed value (decimal)
 - __%i__ - same as __%i__
@@ -300,12 +268,9 @@ TEST_PRINTF("Multiple (%d) (%i) (%u) (%x)\n", -100, 0, 200, 0x12345);
 
 ### Toolset Customization
 
-In addition to the options listed above, there are a number of other options
-which will come in handy to customize Unity's behavior for your specific
-toolchain. It is possible that you may not need to touch any of these... but
-certain platforms, particularly those running in simulators, may need to jump
-through extra hoops to run properly. These macros will help in those
-situations.
+In addition to the options listed above, there are a number of other options which will come in handy to customize Unity's behavior for your specific toolchain.
+It is possible that you may not need to touch any of these... but certain platforms, particularly those running in simulators, may need to jump through extra hoops to run properly.
+These macros will help in those situations.
 
 #### `UNITY_OUTPUT_CHAR(a)`
 
@@ -315,20 +280,17 @@ situations.
 
 #### `UNITY_OUTPUT_COMPLETE()`
 
-By default, Unity prints its results to `stdout` as it runs. This works
-perfectly fine in most situations where you are using a native compiler for
-testing. It works on some simulators as well so long as they have `stdout`
-routed back to the command line. There are times, however, where the simulator
-will lack support for dumping results or you will want to route results
-elsewhere for other reasons. In these cases, you should define the
-`UNITY_OUTPUT_CHAR` macro. This macro accepts a single character at a time (as
-an `int`, since this is the parameter type of the standard C `putchar` function
-most commonly used). You may replace this with whatever function call you like.
+By default, Unity prints its results to `stdout` as it runs.
+This works perfectly fine in most situations where you are using a native compiler for testing.
+It works on some simulators as well so long as they have `stdout` routed back to the command line.
+There are times, however, where the simulator will lack support for dumping results or you will want to route results elsewhere for other reasons.
+In these cases, you should define the `UNITY_OUTPUT_CHAR` macro.
+This macro accepts a single character at a time (as an `int`, since this is the parameter type of the standard C `putchar` function most commonly used).
+You may replace this with whatever function call you like.
 
 _Example:_
-Say you are forced to run your test suite on an embedded processor with no
-`stdout` option. You decide to route your test result output to a custom serial
-`RS232_putc()` function you wrote like thus:
+Say you are forced to run your test suite on an embedded processor with no `stdout` option.
+You decide to route your test result output to a custom serial `RS232_putc()` function you wrote like thus:
 
 ```C
 #include "RS232_header.h"
@@ -340,8 +302,8 @@ Say you are forced to run your test suite on an embedded processor with no
 ```
 
 _Note:_
-`UNITY_OUTPUT_FLUSH()` can be set to the standard out flush function simply by
-specifying `UNITY_USE_FLUSH_STDOUT`. No other defines are required.
+`UNITY_OUTPUT_FLUSH()` can be set to the standard out flush function simply by specifying `UNITY_USE_FLUSH_STDOUT`.
+No other defines are required.
 
 #### `UNITY_OUTPUT_FOR_ECLIPSE`
 
@@ -349,16 +311,14 @@ specifying `UNITY_USE_FLUSH_STDOUT`. No other defines are required.
 
 #### `UNITY_OUTPUT_FOR_QT_CREATOR`
 
-When managing your own builds, it is often handy to have messages output in a format which is
-recognized by your IDE. These are some standard formats which can be supported. If you're using
-Ceedling to manage your builds, it is better to stick with the standard format (leaving these
-all undefined) and allow Ceedling to use its own decorators.
+When managing your own builds, it is often handy to have messages output in a format which is recognized by your IDE.
+These are some standard formats which can be supported.
+If you're using Ceedling to manage your builds, it is better to stick with the standard format (leaving these all undefined) and allow Ceedling to use its own decorators.
 
 #### `UNITY_PTR_ATTRIBUTE`
 
-Some compilers require a custom attribute to be assigned to pointers, like
-`near` or `far`. In these cases, you can give Unity a safe default for these by
-defining this option with the attribute you would like.
+Some compilers require a custom attribute to be assigned to pointers, like `near` or `far`.
+In these cases, you can give Unity a safe default for these by defining this option with the attribute you would like.
 
 _Example:_
 
@@ -369,9 +329,9 @@ _Example:_
 
 #### `UNITY_PRINT_EOL`
 
-By default, Unity outputs \n at the end of each line of output. This is easy
-to parse by the scripts, by Ceedling, etc, but it might not be ideal for YOUR
-system. Feel free to override this and to make it whatever you wish.
+By default, Unity outputs \n at the end of each line of output.
+This is easy to parse by the scripts, by Ceedling, etc, but it might not be ideal for YOUR system.
+Feel free to override this and to make it whatever you wish.
 
 _Example:_
 
@@ -381,11 +341,10 @@ _Example:_
 
 #### `UNITY_EXCLUDE_DETAILS`
 
-This is an option for if you absolutely must squeeze every byte of memory out of
-your system. Unity stores a set of internal scratchpads which are used to pass
-extra detail information around. It's used by systems like CMock in order to
-report which function or argument flagged an error. If you're not using CMock and
-you're not using these details for other things, then you can exclude them.
+This is an option for if you absolutely must squeeze every byte of memory out of your system.
+Unity stores a set of internal scratchpads which are used to pass extra detail information around.
+It's used by systems like CMock in order to report which function or argument flagged an error.
+If you're not using CMock and you're not using these details for other things, then you can exclude them.
 
 _Example:_
 
@@ -395,10 +354,8 @@ _Example:_
 
 #### `UNITY_PRINT_TEST_CONTEXT`
 
-This option allows you to specify your own function to print additional context
-as part of the error message when a test has failed. It can be useful if you
-want to output some specific information about the state of the test at the point
-of failure, and `UNITY_SET_DETAILS` isn't flexible enough for your needs.
+This option allows you to specify your own function to print additional context as part of the error message when a test has failed.
+It can be useful if you want to output some specific information about the state of the test at the point of failure, and `UNITY_SET_DETAILS` isn't flexible enough for your needs.
 
 _Example:_
 
@@ -415,12 +372,10 @@ void PrintIterationCount(void)
 
 #### `UNITY_EXCLUDE_SETJMP`
 
-If your embedded system doesn't support the standard library setjmp, you can
-exclude Unity's reliance on this by using this define. This dropped dependence
-comes at a price, though. You will be unable to use custom helper functions for
-your tests, and you will be unable to use tools like CMock. Very likely, if your
-compiler doesn't support setjmp, you wouldn't have had the memory space for those
-things anyway, though... so this option exists for those situations.
+If your embedded system doesn't support the standard library setjmp, you can exclude Unity's reliance on this by using this define.
+This dropped dependence comes at a price, though.
+You will be unable to use custom helper functions for your tests, and you will be unable to use tools like CMock.
+Very likely, if your compiler doesn't support setjmp, you wouldn't have had the memory space for those things anyway, though... so this option exists for those situations.
 
 _Example:_
 
@@ -446,53 +401,43 @@ _Example:_
 
 #### `UNITY_SHORTHAND_AS_NONE`
 
-These options  give you control of the `TEST_ASSERT_EQUAL` and the
-`TEST_ASSERT_NOT_EQUAL` shorthand assertions. Historically, Unity treated the
-former as an alias for an integer comparison. It treated the latter as a direct
-comparison using `!=`. This assymetry was confusing, but there was much
-disagreement as to how best to treat this pair of assertions. These four options
-will allow you to specify how Unity will treat these assertions.
+These options give you control of the `TEST_ASSERT_EQUAL` and the `TEST_ASSERT_NOT_EQUAL` shorthand assertions.
+Historically, Unity treated the former as an alias for an integer comparison.
+It treated the latter as a direct comparison using `!=`.
+This asymmetry was confusing, but there was much disagreement as to how best to treat this pair of assertions.
+These four options will allow you to specify how Unity will treat these assertions.
 
-- AS INT - the values will be cast to integers and directly compared. Arguments
-            that don't cast easily to integers will cause compiler errors.
-- AS MEM - the address of both values will be taken and the entire object's
-            memory footprint will be compared byte by byte. Directly placing
-            constant numbers like `456` as expected values will cause errors.
-- AS_RAW - Unity assumes that you can compare the two values using `==` and `!=`
-            and will do so. No details are given about mismatches, because it
-            doesn't really know what type it's dealing with.
-- AS_NONE - Unity will disallow the use of these shorthand macros altogether,
-             insisting that developers choose a more descriptive option.
+- AS INT - the values will be cast to integers and directly compared.
+  Arguments that don't cast easily to integers will cause compiler errors.
+- AS MEM - the address of both values will be taken and the entire object's memory footprint will be compared byte by byte.
+  Directly placing constant numbers like `456` as expected values will cause errors.
+- AS_RAW - Unity assumes that you can compare the two values using `==` and `!=` and will do so.
+  No details are given about mismatches, because it doesn't really know what type it's dealing with.
+- AS_NONE - Unity will disallow the use of these shorthand macros altogether, insisting that developers choose a more descriptive option.
 
 #### `UNITY_SUPPORT_VARIADIC_MACROS`
 
-This will force Unity to support variadic macros when using its own built-in
-RUN_TEST macro. This will rarely be necessary. Most often, Unity will automatically
-detect if the compiler supports variadic macros by checking to see if it's C99+
-compatible. In the event that the compiler supports variadic macros, but is primarily
-C89 (ANSI), defining this option will allow you to use them. This option is also not
-necessary when using Ceedling or the test runner generator script.
+This will force Unity to support variadic macros when using its own built-in RUN_TEST macro.
+This will rarely be necessary. Most often, Unity will automatically detect if the compiler supports variadic macros by checking to see if it's C99+ compatible.
+In the event that the compiler supports variadic macros, but is primarily C89 (ANSI), defining this option will allow you to use them.
+This option is also not necessary when using Ceedling or the test runner generator script.
 
 ## Getting Into The Guts
 
-There will be cases where the options above aren't quite going to get everything
-perfect. They are likely sufficient for any situation where you are compiling
-and executing your tests with a native toolchain (e.g. clang on Mac). These
-options may even get you through the majority of cases encountered in working
-with a target simulator run from your local command line. But especially if you
-must run your test suite on your target hardware, your Unity configuration will
-require special help. This special help will usually reside in one of two
-places: the `main()` function or the `RUN_TEST` macro. Let's look at how these
-work.
+There will be cases where the options above aren't quite going to get everything perfect.
+They are likely sufficient for any situation where you are compiling and executing your tests with a native toolchain (e.g. clang on Mac).
+These options may even get you through the majority of cases encountered in working with a target simulator run from your local command line.
+But especially if you must run your test suite on your target hardware, your Unity configuration will
+require special help.
+This special help will usually reside in one of two places: the `main()` function or the `RUN_TEST` macro.
+Let's look at how these work.
 
 ### `main()`
 
-Each test module is compiled and run on its own, separate from the other test
-files in your project. Each test file, therefore, has a `main` function. This
-`main` function will need to contain whatever code is necessary to initialize
-your system to a workable state. This is particularly true for situations where
-you must set up a memory map or initialize a communication channel for the
-output of your test results.
+Each test module is compiled and run on its own, separate from the other test files in your project.
+Each test file, therefore, has a `main` function.
+This `main` function will need to contain whatever code is necessary to initialize your system to a workable state.
+This is particularly true for situations where you must set up a memory map or initialize a communication channel for the output of your test results.
 
 A simple main function looks something like this:
 
@@ -506,25 +451,22 @@ int main(void) {
 }
 ```
 
-You can see that our main function doesn't bother taking any arguments. For our
-most barebones case, we'll never have arguments because we just run all the
-tests each time. Instead, we start by calling `UNITY_BEGIN`. We run each test
-(in whatever order we wish). Finally, we call `UNITY_END`, returning its return
-value (which is the total number of failures).
+You can see that our main function doesn't bother taking any arguments.
+For our most barebones case, we'll never have arguments because we just run all the tests each time.
+Instead, we start by calling `UNITY_BEGIN`.
+We run each test (in whatever order we wish).
+Finally, we call `UNITY_END`, returning its return value (which is the total number of failures).
 
-It should be easy to see that you can add code before any test cases are run or
-after all the test cases have completed. This allows you to do any needed
-system-wide setup or teardown that might be required for your special
-circumstances.
+It should be easy to see that you can add code before any test cases are run or after all the test cases have completed.
+This allows you to do any needed system-wide setup or teardown that might be required for your special circumstances.
 
 #### `RUN_TEST`
 
-The `RUN_TEST` macro is called with each test case function. Its job is to
-perform whatever setup and teardown is necessary for executing a single test
-case function. This includes catching failures, calling the test module's
-`setUp()` and `tearDown()` functions, and calling `UnityConcludeTest()`. If
-using CMock or test coverage, there will be additional stubs in use here. A
-simple minimalist RUN_TEST macro looks something like this:
+The `RUN_TEST` macro is called with each test case function.
+Its job is to perform whatever setup and teardown is necessary for executing a single test case function.
+This includes catching failures, calling the test module's `setUp()` and `tearDown()` functions, and calling `UnityConcludeTest()`.
+If using CMock or test coverage, there will be additional stubs in use here.
+A simple minimalist RUN_TEST macro looks something like this:
 
 ```C
 #define RUN_TEST(testfunc) \
@@ -538,26 +480,25 @@ simple minimalist RUN_TEST macro looks something like this:
     UnityConcludeTest();
 ```
 
-So that's quite a macro, huh? It gives you a glimpse of what kind of stuff Unity
-has to deal with for every single test case. For each test case, we declare that
-it is a new test. Then we run `setUp` and our test function. These are run
-within a `TEST_PROTECT` block, the function of which is to handle failures that
-occur during the test. Then, assuming our test is still running and hasn't been
-ignored, we run `tearDown`. No matter what, our last step is to conclude this
-test before moving on to the next.
+So that's quite a macro, huh?
+It gives you a glimpse of what kind of stuff Unity has to deal with for every single test case.
+For each test case, we declare that it is a new test.
+Then we run `setUp` and our test function.
+These are run within a `TEST_PROTECT` block, the function of which is to handle failures that occur during the test.
+Then, assuming our test is still running and hasn't been ignored, we run `tearDown`.
+No matter what, our last step is to conclude this test before moving on to the next.
 
-Let's say you need to add a call to `fsync` to force all of your output data to
-flush to a file after each test. You could easily insert this after your
-`UnityConcludeTest` call. Maybe you want to write an xml tag before and after
-each result set. Again, you could do this by adding lines to this macro. Updates
-to this macro are for the occasions when you need an action before or after
-every single test case throughout your entire suite of tests.
+Let's say you need to add a call to `fsync` to force all of your output data to flush to a file after each test.
+You could easily insert this after your `UnityConcludeTest` call.
+Maybe you want to write an xml tag before and after each result set.
+Again, you could do this by adding lines to this macro.
+Updates to this macro are for the occasions when you need an action before or after every single test case throughout your entire suite of tests.
 
 ## Happy Porting
 
-The defines and macros in this guide should help you port Unity to just about
-any C target we can imagine. If you run into a snag or two, don't be afraid of
-asking for help on the forums. We love a good challenge!
+The defines and macros in this guide should help you port Unity to just about any C target we can imagine.
+If you run into a snag or two, don't be afraid of asking for help on the forums.
+We love a good challenge!
 
 *Find The Latest of This And More at [ThrowTheSwitch.org][]*
 

--- a/docs/UnityConfigurationGuide.md
+++ b/docs/UnityConfigurationGuide.md
@@ -559,4 +559,6 @@ The defines and macros in this guide should help you port Unity to just about
 any C target we can imagine. If you run into a snag or two, don't be afraid of
 asking for help on the forums. We love a good challenge!
 
-*Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*
+*Find The Latest of This And More at [ThrowTheSwitch.org][]*
+
+[ThrowTheSwitch.org]: https://throwtheswitch.org

--- a/docs/UnityGettingStartedGuide.md
+++ b/docs/UnityGettingStartedGuide.md
@@ -17,7 +17,6 @@ rules. Unity has been used with many compilers, including GCC, IAR, Clang,
 Green Hills, Microchip, and MS Visual Studio. It's not much work to get it to
 work with a new target.
 
-
 ### Overview of the Documents
 
 #### Unity Assertions reference
@@ -26,20 +25,17 @@ This document will guide you through all the assertion options provided by
 Unity. This is going to be your unit testing bread and butter. You'll spend more
 time with assertions than any other part of Unity.
 
-
 #### Unity Assertions Cheat Sheet
 
 This document contains an abridged summary of the assertions described in the
 previous document. It's perfect for printing and referencing while you
 familiarize yourself with Unity's options.
 
-
 #### Unity Configuration Guide
 
 This document is the one to reference when you are going to use Unity with a new
 target or compiler. It'll guide you through the configuration options and will
 help you customize your testing experience to meet your needs.
-
 
 #### Unity Helper Scripts
 
@@ -49,14 +45,12 @@ included in the auto directory of your Unity installation. Neither Ruby nor
 these scripts are necessary for using Unity. They are provided as a convenience
 for those who wish to use them.
 
-
 #### Unity License
 
 What's an open source project without a license file? This brief document
 describes the terms you're agreeing to when you use this software. Basically, we
 want it to be useful to you in whatever context you want to use it, but please
 don't blame us if you run into problems.
-
 
 ### Overview of the Folders
 
@@ -81,7 +75,6 @@ who gets to port Unity to a new toolchain, this is a good place to verify
 everything is configured properly.
 - `auto` - Here you will find helpful Ruby scripts for simplifying your test
 workflow. They are purely optional and are not required to make use of Unity.
-
 
 ## How to Create A Test File
 
@@ -156,21 +149,27 @@ For that sort of thing, you're going to want to look at the configuration guide.
 This should be enough to get you going, though.
 
 ### Running Test Functions
+
 When writing your own `main()` functions, for a test-runner. There are two ways
 to execute the test.
 
 The classic variant
+
 ``` c
 RUN_TEST(func, linenum)
 ```
+
 or its simpler replacement that starts at the beginning of the function.
+
 ``` c
 RUN_TEST(func)
 ```
+
 These macros perform the necessary setup before the test is called and
-handles cleanup and result tabulation afterwards.
+handles clean-up and result tabulation afterwards.
 
 ### Ignoring Test Functions
+
 There are times when a test is incomplete or not valid for some reason.
 At these times, TEST_IGNORE can be called. Control will immediately be
 returned to the caller of the test, and no failures will be returned.
@@ -182,25 +181,31 @@ TEST_IGNORE()
 
 Ignore this test and return immediately
 
-``` c
+```c
 TEST_IGNORE_MESSAGE (message)
 ```
 
 Ignore this test and return immediately. Output a message stating why the test was ignored.
 
 ### Aborting Tests
+
 There are times when a test will contain an infinite loop on error conditions, or there may be reason to escape from the test early without executing the rest of the test.  A pair of macros support this functionality in Unity.  The first `TEST_PROTECT` sets up the feature, and handles emergency abort cases. `TEST_ABORT` can then be used at any time within the tests to return to the last `TEST_PROTECT` call.
 
+```c
     TEST_PROTECT()
+```
 
 Setup and Catch macro
 
+```c
     TEST_ABORT()
+```
 
 Abort Test macro
 
 Example:
 
+```c
     main()
     {
         if (TEST_PROTECT())
@@ -208,10 +213,9 @@ Example:
             MyTest();
         }
     }
+```
 
 If MyTest calls `TEST_ABORT`, program control will immediately return to `TEST_PROTECT` with a return value of zero.
-
-
 
 ## How to Build and Run A Test File
 
@@ -225,6 +229,7 @@ You have two really good options for toolchains. Depending on where you're
 coming from, it might surprise you that neither of these options is running the
 unit tests on your hardware.
 There are many reasons for this, but here's a short version:
+
 - On hardware, you have too many constraints (processing power, memory, etc),
 - On hardware, you don't have complete control over all registers,
 - On hardware, unit testing is more challenging,
@@ -246,6 +251,5 @@ test set for that module. Then, this process is repeated for the next test file.
 This flexibility of separating tests into individual executables allows us to
 much more thoroughly unit test our system and it keeps all the test code out of
 our final release!
-
 
 *Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*

--- a/docs/UnityGettingStartedGuide.md
+++ b/docs/UnityGettingStartedGuide.md
@@ -108,7 +108,7 @@ call.
 
 Remembering to add each test to the main function can get to be tedious. If you
 enjoy using helper scripts in your build process, you might consider making use
-of our handy [generate_test_runner.rb](../auto/generate_test_runner.rb) script.
+of our handy [generate_test_runner.rb][] script.
 This will create the main function and all the calls for you, assuming that you
 have followed the suggested naming conventions. In this case, there is no need
 for you to include the main function in your test file at all.
@@ -252,4 +252,7 @@ This flexibility of separating tests into individual executables allows us to
 much more thoroughly unit test our system and it keeps all the test code out of
 our final release!
 
-*Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*
+*Find The Latest of This And More at [ThrowTheSwitch.org][]*
+
+[generate_test_runner.rb]: ../auto/generate_test_runner.rb
+[ThrowTheSwitch.org]: https://throwtheswitch.org

--- a/docs/UnityGettingStartedGuide.md
+++ b/docs/UnityGettingStartedGuide.md
@@ -2,116 +2,104 @@
 
 ## Welcome
 
-Congratulations. You're now the proud owner of your very own pile of bits! What
-are you going to do with all these ones and zeros? This document should be able
-to help you decide just that.
+Congratulations.
+You're now the proud owner of your very own pile of bits!
+What are you going to do with all these ones and zeros?
+This document should be able to help you decide just that.
 
-Unity is a unit test framework. The goal has been to keep it small and
-functional. The core Unity test framework is three files: a single C file and a
-couple header files. These team up to provide functions and macros to make
-testing easier.
+Unity is a unit test framework.
+The goal has been to keep it small and functional.
+The core Unity test framework is three files: a single C file and a couple header files.
+These team up to provide functions and macros to make testing easier.
 
-Unity was designed to be cross-platform. It works hard to stick with C standards
-while still providing support for the many embedded C compilers that bend the
-rules. Unity has been used with many compilers, including GCC, IAR, Clang,
-Green Hills, Microchip, and MS Visual Studio. It's not much work to get it to
-work with a new target.
+Unity was designed to be cross-platform.
+It works hard to stick with C standards while still providing support for the many embedded C compilers that bend the rules.
+Unity has been used with many compilers, including GCC, IAR, Clang, Green Hills, Microchip, and MS Visual Studio.
+It's not much work to get it to work with a new target.
 
 ### Overview of the Documents
 
 #### Unity Assertions reference
 
-This document will guide you through all the assertion options provided by
-Unity. This is going to be your unit testing bread and butter. You'll spend more
-time with assertions than any other part of Unity.
+This document will guide you through all the assertion options provided by Unity.
+This is going to be your unit testing bread and butter.
+You'll spend more time with assertions than any other part of Unity.
 
 #### Unity Assertions Cheat Sheet
 
-This document contains an abridged summary of the assertions described in the
-previous document. It's perfect for printing and referencing while you
-familiarize yourself with Unity's options.
+This document contains an abridged summary of the assertions described in the previous document.
+It's perfect for printing and referencing while you familiarize yourself with Unity's options.
 
 #### Unity Configuration Guide
 
-This document is the one to reference when you are going to use Unity with a new
-target or compiler. It'll guide you through the configuration options and will
-help you customize your testing experience to meet your needs.
+This document is the one to reference when you are going to use Unity with a new target or compiler.
+It'll guide you through the configuration options and will help you customize your testing experience to meet your needs.
 
 #### Unity Helper Scripts
 
-This document describes the helper scripts that are available for simplifying
-your testing workflow. It describes the collection of optional Ruby scripts
-included in the auto directory of your Unity installation. Neither Ruby nor
-these scripts are necessary for using Unity. They are provided as a convenience
-for those who wish to use them.
+This document describes the helper scripts that are available for simplifying your testing workflow.
+It describes the collection of optional Ruby scripts included in the auto directory of your Unity installation.
+Neither Ruby nor these scripts are necessary for using Unity.
+They are provided as a convenience for those who wish to use them.
 
 #### Unity License
 
-What's an open source project without a license file? This brief document
-describes the terms you're agreeing to when you use this software. Basically, we
-want it to be useful to you in whatever context you want to use it, but please
-don't blame us if you run into problems.
+What's an open source project without a license file?
+This brief document describes the terms you're agreeing to when you use this software.
+Basically, we want it to be useful to you in whatever context you want to use it, but please don't blame us if you run into problems.
 
 ### Overview of the Folders
 
-If you have obtained Unity through Github or something similar, you might be
-surprised by just how much stuff you suddenly have staring you in the face.
-Don't worry, Unity itself is very small. The rest of it is just there to make
-your life easier. You can ignore it or use it at your convenience. Here's an
-overview of everything in the project.
+If you have obtained Unity through Github or something similar, you might be surprised by just how much stuff you suddenly have staring you in the face.
+Don't worry, Unity itself is very small.
+The rest of it is just there to make your life easier.
+You can ignore it or use it at your convenience.
+Here's an overview of everything in the project.
 
-- `src` - This is the code you care about! This folder contains a C file and two
-header files. These three files _are_ Unity.
-- `docs` - You're reading this document, so it's possible you have found your way
-into this folder already. This is where all the handy documentation can be
-found.
+- `src` - This is the code you care about! This folder contains a C file and two header files.
+  These three files _are_ Unity.
+- `docs` - You're reading this document, so it's possible you have found your way into this folder already.
+  This is where all the handy documentation can be found.
 - `examples` - This contains a few examples of using Unity.
-- `extras` - These are optional add ons to Unity that are not part of the core
-project. If you've reached us through James Grenning's book, you're going to
-want to look here.
-- `test` - This is how Unity and its scripts are all tested. If you're just using
-Unity, you'll likely never need to go in here. If you are the lucky team member
-who gets to port Unity to a new toolchain, this is a good place to verify
-everything is configured properly.
-- `auto` - Here you will find helpful Ruby scripts for simplifying your test
-workflow. They are purely optional and are not required to make use of Unity.
+- `extras` - These are optional add ons to Unity that are not part of the core project.
+  If you've reached us through James Grenning's book, you're going to want to look here.
+- `test` - This is how Unity and its scripts are all tested.
+  If you're just using Unity, you'll likely never need to go in here.
+  If you are the lucky team member who gets to port Unity to a new toolchain, this is a good place to verify everything is configured properly.
+- `auto` - Here you will find helpful Ruby scripts for simplifying your test workflow.
+  They are purely optional and are not required to make use of Unity.
 
 ## How to Create A Test File
 
-Test files are C files. Most often you will create a single test file for each C
-module that you want to test. The test file should include unity.h and the
-header for your C module to be tested.
+Test files are C files.
+Most often you will create a single test file for each C module that you want to test.
+The test file should include unity.h and the header for your C module to be tested.
 
-Next, a test file will include a `setUp()` and `tearDown()` function. The setUp
-function can contain anything you would like to run before each test. The
-tearDown function can contain anything you would like to run after each test.
-Both functions accept no arguments and return nothing. You may leave either or
-both of these blank if you have no need for them.
+Next, a test file will include a `setUp()` and `tearDown()` function.
+The setUp function can contain anything you would like to run before each test.
+The tearDown function can contain anything you would like to run after each test.
+Both functions accept no arguments and return nothing.
+You may leave either or both of these blank if you have no need for them.
 
-If you're using Ceedling or the test runner generator script, you may leave these off
-completely. Not sure? Give it a try. If your compiler complains that it can't
-find setUp or tearDown when it links, you'll know you need to at least include
-an empty function for these.
+If you're using Ceedling or the test runner generator script, you may leave these off completely.
+Not sure?
+Give it a try.
+If your compiler complains that it can't find setUp or tearDown when it links, you'll know you need to at least include an empty function for these.
 
-The majority of the file will be a series of test functions. Test functions
-follow the convention of starting with the word "test_" or "spec_". You don't HAVE
-to name them this way, but it makes it clear what functions are tests for other
-developers.  Also, the automated scripts that come with Unity or Ceedling will default
-to looking for test functions to be prefixed this way. Test functions take no arguments
-and return nothing. All test accounting is handled internally in Unity.
+The majority of the file will be a series of test functions.
+Test functions follow the convention of starting with the word "test_" or "spec_".
+You don't HAVE to name them this way, but it makes it clear what functions are tests for other developers.
+Also, the automated scripts that come with Unity or Ceedling will default to looking for test functions to be prefixed this way.
+Test functions take no arguments and return nothing. All test accounting is handled internally in Unity.
 
 Finally, at the bottom of your test file, you will write a `main()` function.
-This function will call `UNITY_BEGIN()`, then `RUN_TEST` for each test, and
-finally `UNITY_END()`.This is what will actually trigger each of those test
-functions to run, so it is important that each function gets its own `RUN_TEST`
-call.
+This function will call `UNITY_BEGIN()`, then `RUN_TEST` for each test, and finally `UNITY_END()`.
+This is what will actually trigger each of those test functions to run, so it is important that each function gets its own `RUN_TEST` call.
 
-Remembering to add each test to the main function can get to be tedious. If you
-enjoy using helper scripts in your build process, you might consider making use
-of our handy [generate_test_runner.rb][] script.
-This will create the main function and all the calls for you, assuming that you
-have followed the suggested naming conventions. In this case, there is no need
-for you to include the main function in your test file at all.
+Remembering to add each test to the main function can get to be tedious.
+If you enjoy using helper scripts in your build process, you might consider making use of our handy [generate_test_runner.rb][] script.
+This will create the main function and all the calls for you, assuming that you have followed the suggested naming conventions.
+In this case, there is no need for you to include the main function in your test file at all.
 
 When you're done, your test file will look something like this:
 
@@ -150,8 +138,8 @@ This should be enough to get you going, though.
 
 ### Running Test Functions
 
-When writing your own `main()` functions, for a test-runner. There are two ways
-to execute the test.
+When writing your own `main()` functions, for a test-runner.
+There are two ways to execute the test.
 
 The classic variant
 
@@ -159,20 +147,19 @@ The classic variant
 RUN_TEST(func, linenum)
 ```
 
-or its simpler replacement that starts at the beginning of the function.
+Or its simpler replacement that starts at the beginning of the function.
 
 ``` c
 RUN_TEST(func)
 ```
 
-These macros perform the necessary setup before the test is called and
-handles clean-up and result tabulation afterwards.
+These macros perform the necessary setup before the test is called and handles clean-up and result tabulation afterwards.
 
 ### Ignoring Test Functions
 
 There are times when a test is incomplete or not valid for some reason.
-At these times, TEST_IGNORE can be called. Control will immediately be
-returned to the caller of the test, and no failures will be returned.
+At these times, TEST_IGNORE can be called.
+Control will immediately be returned to the caller of the test, and no failures will be returned.
 This is useful when your test runners are automatically generated.
 
 ``` c
@@ -185,11 +172,15 @@ Ignore this test and return immediately
 TEST_IGNORE_MESSAGE (message)
 ```
 
-Ignore this test and return immediately. Output a message stating why the test was ignored.
+Ignore this test and return immediately.
+Output a message stating why the test was ignored.
 
 ### Aborting Tests
 
-There are times when a test will contain an infinite loop on error conditions, or there may be reason to escape from the test early without executing the rest of the test.  A pair of macros support this functionality in Unity.  The first `TEST_PROTECT` sets up the feature, and handles emergency abort cases. `TEST_ABORT` can then be used at any time within the tests to return to the last `TEST_PROTECT` call.
+There are times when a test will contain an infinite loop on error conditions, or there may be reason to escape from the test early without executing the rest of the test.
+A pair of macros support this functionality in Unity.
+The first `TEST_PROTECT` sets up the feature, and handles emergency abort cases.
+`TEST_ABORT` can then be used at any time within the tests to return to the last `TEST_PROTECT` call.
 
 ```c
     TEST_PROTECT()
@@ -219,15 +210,12 @@ If MyTest calls `TEST_ABORT`, program control will immediately return to `TEST_P
 
 ## How to Build and Run A Test File
 
-This is the single biggest challenge to picking up a new unit testing framework,
-at least in a language like C or C++. These languages are REALLY good at getting
-you "close to the metal" (why is the phrase metal? Wouldn't it be more accurate
-to say "close to the silicon"?). While this feature is usually a good thing, it
-can make testing more challenging.
+This is the single biggest challenge to picking up a new unit testing framework, at least in a language like C or C++.
+These languages are REALLY good at getting you "close to the metal" (why is the phrase metal? Wouldn't it be more accurate to say "close to the silicon"?).
+While this feature is usually a good thing, it can make testing more challenging.
 
-You have two really good options for toolchains. Depending on where you're
-coming from, it might surprise you that neither of these options is running the
-unit tests on your hardware.
+You have two really good options for toolchains.
+Depending on where you're coming from, it might surprise you that neither of these options is running the unit tests on your hardware.
 There are many reasons for this, but here's a short version:
 
 - On hardware, you have too many constraints (processing power, memory, etc),
@@ -235,22 +223,18 @@ There are many reasons for this, but here's a short version:
 - On hardware, unit testing is more challenging,
 - Unit testing isn't System testing. Keep them separate.
 
-Instead of running your tests on your actual hardware, most developers choose to
-develop them as native applications (using gcc or MSVC for example) or as
-applications running on a simulator. Either is a good option. Native apps have
-the advantages of being faster and easier to set up. Simulator apps have the
-advantage of working with the same compiler as your target application. The
-options for configuring these are discussed in the configuration guide.
+Instead of running your tests on your actual hardware, most developers choose to develop them as native applications (using gcc or MSVC for example) or as applications running on a simulator.
+Either is a good option.
+Native apps have the advantages of being faster and easier to set up.
+Simulator apps have the advantage of working with the same compiler as your target application.
+The options for configuring these are discussed in the configuration guide.
 
-To get either to work, you might need to make a few changes to the file
-containing your register set (discussed later).
+To get either to work, you might need to make a few changes to the file containing your register set (discussed later).
 
-In either case, a test is built by linking unity, the test file, and the C
-file(s) being tested. These files create an executable which can be run as the
-test set for that module. Then, this process is repeated for the next test file.
-This flexibility of separating tests into individual executables allows us to
-much more thoroughly unit test our system and it keeps all the test code out of
-our final release!
+In either case, a test is built by linking unity, the test file, and the C file(s) being tested.
+These files create an executable which can be run as the test set for that module.
+Then, this process is repeated for the next test file.
+This flexibility of separating tests into individual executables allows us to much more thoroughly unit test our system and it keeps all the test code out of our final release!
 
 *Find The Latest of This And More at [ThrowTheSwitch.org][]*
 

--- a/docs/UnityHelperScriptsGuide.md
+++ b/docs/UnityHelperScriptsGuide.md
@@ -6,7 +6,7 @@ Sometimes what it takes to be a really efficient C programmer is a little non-C.
 The Unity project includes a couple of Ruby scripts for making your life just a tad
 easier. They are completely optional. If you choose to use them, you'll need a
 copy of Ruby, of course. Just install whatever the latest version is, and it is
-likely to work. You can find Ruby at [ruby-lang.org](https://ruby-labg.org/).
+likely to work. You can find Ruby at [ruby-lang.org][].
 
 ### `generate_test_runner.rb`
 
@@ -54,7 +54,7 @@ generated file. The example immediately below will create TestFile_Runner.c.
 ruby generate_test_runner.rb TestFile.c
 ```
 
-You can also add a [YAML](http://www.yaml.org/) file to configure extra options.
+You can also add a [YAML][] file to configure extra options.
 Conveniently, this YAML file is of the same format as that used by Unity and
 CMock. So if you are using YAML files already, you can simply pass the very same
 file into the generator script.
@@ -216,8 +216,8 @@ ignored and failing tests in this project generate corresponding entries in the
 summary report.
 
 If you're interested in other (prettier?) output formats, check into the
-Ceedling build tool project (ceedling.sourceforge.net) that works with Unity and
-CMock and supports xunit-style xml as well as other goodies.
+[Ceedling][] build tool project that works with Unity and CMock and supports
+xunit-style xml as well as other goodies.
 
 This script assumes the existence of files ending with the extensions
 `.testpass` and `.testfail`.The contents of these files includes the test
@@ -267,4 +267,9 @@ OVERALL UNITY TEST SUMMARY
 
 How convenient is that?
 
-*Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*
+*Find The Latest of This And More at [ThrowTheSwitch.org][]*
+
+[ruby-lang.org]: https://ruby-labg.org/
+[YAML]: http://www.yaml.org/
+[Ceedling]: http://www.throwtheswitch.org/ceedling
+[ThrowTheSwitch.org]: https://throwtheswitch.org

--- a/docs/UnityHelperScriptsGuide.md
+++ b/docs/UnityHelperScriptsGuide.md
@@ -8,7 +8,6 @@ easier. They are completely optional. If you choose to use them, you'll need a
 copy of Ruby, of course. Just install whatever the latest version is, and it is
 likely to work. You can find Ruby at [ruby-lang.org](https://ruby-labg.org/).
 
-
 ### `generate_test_runner.rb`
 
 Are you tired of creating your own `main` function in your test file? Do you
@@ -114,20 +113,18 @@ test_files.each do |f|
 end
 ```
 
-#### Options accepted by generate_test_runner.rb:
+#### Options accepted by generate_test_runner.rb
 
 The following options are available when executing `generate_test_runner`. You
 may pass these as a Ruby hash directly or specify them in a YAML file, both of
 which are described above. In the `examples` directory, Example 3's Rakefile
 demonstrates using a Ruby hash.
 
-
 ##### `:includes`
 
 This option specifies an array of file names to be `#include`'d at the top of
 your runner C file. You might use it to reference custom types or anything else
 universally needed in your generated runners.
-
 
 ##### `:suite_setup`
 
@@ -137,7 +134,6 @@ Alternatively, if your C compiler supports weak symbols, you can leave this
 option unset and instead provide a `void suiteSetUp(void)` function in your test
 suite.  The linker will look for this symbol and fall back to a Unity-provided
 stub if it is not found.
-
 
 ##### `:suite_teardown`
 
@@ -151,14 +147,12 @@ option unset and instead provide a `int suiteTearDown(int num_failures)`
 function in your test suite.  The linker will look for this symbol and fall
 back to a Unity-provided stub if it is not found.
 
-
 ##### `:enforce_strict_ordering`
 
 This option should be defined if you have the strict order feature enabled in
 CMock (see CMock documentation). This generates extra variables required for
 everything to run smoothly. If you provide the same YAML to the generator as
 used in CMock's configuration, you've already configured the generator properly.
-
 
 ##### `:externc`
 
@@ -205,7 +199,6 @@ of files to search, update this from the default `'(?:hpp|hh|H|h)'`.
 This option specifies the pattern for matching acceptable source file extensions.
 By default it will accept cpp, cc, C, c, and ino files. If you need a different combination
 of files to search, update this from the default `'(?:cpp|cc|ino|C|c)'`.
-
 
 ### `unity_test_summary.rb`
 
@@ -273,6 +266,5 @@ OVERALL UNITY TEST SUMMARY
 ```
 
 How convenient is that?
-
 
 *Find The Latest of This And More at [ThrowTheSwitch.org](https://throwtheswitch.org)*

--- a/docs/UnityHelperScriptsGuide.md
+++ b/docs/UnityHelperScriptsGuide.md
@@ -3,29 +3,25 @@
 ## With a Little Help From Our Friends
 
 Sometimes what it takes to be a really efficient C programmer is a little non-C.
-The Unity project includes a couple of Ruby scripts for making your life just a tad
-easier. They are completely optional. If you choose to use them, you'll need a
-copy of Ruby, of course. Just install whatever the latest version is, and it is
-likely to work. You can find Ruby at [ruby-lang.org][].
+The Unity project includes a couple of Ruby scripts for making your life just a tad easier.
+They are completely optional.
+If you choose to use them, you'll need a copy of Ruby, of course.
+Just install whatever the latest version is, and it is likely to work. You can find Ruby at [ruby-lang.org][].
 
 ### `generate_test_runner.rb`
 
-Are you tired of creating your own `main` function in your test file? Do you
-keep forgetting to add a `RUN_TEST` call when you add a new test case to your
-suite? Do you want to use CMock or other fancy add-ons but don't want to figure
-out how to create your own `RUN_TEST` macro?
+Are you tired of creating your own `main` function in your test file?
+Do you keep forgetting to add a `RUN_TEST` call when you add a new test case to your suite?
+Do you want to use CMock or other fancy add-ons but don't want to figure out how to create your own `RUN_TEST` macro?
 
 Well then we have the perfect script for you!
 
-The `generate_test_runner` script processes a given test file and automatically
-creates a separate test runner file that includes ?main?to execute the test
-cases within the scanned test file. All you do then is add the generated runner
-to your list of files to be compiled and linked, and presto you're done!
+The `generate_test_runner` script processes a given test file and automatically creates a separate test runner file that includes ?main?to execute the test cases within the scanned test file.
+All you do then is add the generated runner to your list of files to be compiled and linked, and presto you're done!
 
-This script searches your test file for void function signatures having a
-function name beginning with "test" or "spec". It treats each of these
-functions as a test case and builds up a test suite of them. For example, the
-following includes three test cases:
+This script searches your test file for void function signatures having a function name beginning with "test" or "spec".
+It treats each of these functions as a test case and builds up a test suite of them.
+For example, the following includes three test cases:
 
 ```C
 void testVerifyThatUnityIsAwesomeAndWillMakeYourLifeEasier(void)
@@ -40,32 +36,30 @@ void spec_Function_should_DoWhatItIsSupposedToDo(void) {
 }
 ```
 
-You can run this script a couple of ways. The first is from the command line:
+You can run this script a couple of ways.
+The first is from the command line:
 
 ```Shell
 ruby generate_test_runner.rb TestFile.c NameOfRunner.c
 ```
 
-Alternatively, if you include only the test file parameter, the script will copy
-the name of the test file and automatically append `_Runner` to the name of the
-generated file. The example immediately below will create TestFile_Runner.c.
+Alternatively, if you include only the test file parameter, the script will copy the name of the test file and automatically append `_Runner` to the name of the generated file.
+The example immediately below will create TestFile_Runner.c.
 
 ```Shell
 ruby generate_test_runner.rb TestFile.c
 ```
 
 You can also add a [YAML][] file to configure extra options.
-Conveniently, this YAML file is of the same format as that used by Unity and
-CMock. So if you are using YAML files already, you can simply pass the very same
-file into the generator script.
+Conveniently, this YAML file is of the same format as that used by Unity and CMock.
+So if you are using YAML files already, you can simply pass the very same file into the generator script.
 
 ```Shell
 ruby generate_test_runner.rb TestFile.c my_config.yml
 ```
 
-The contents of the YAML file `my_config.yml` could look something like the
-example below. If you're wondering what some of these options do, you're going
-to love the next section of this document.
+The contents of the YAML file `my_config.yml` could look something like the example below.
+If you're wondering what some of these options do, you're going to love the next section of this document.
 
 ```YAML
 :unity:
@@ -77,19 +71,16 @@ to love the next section of this document.
   :suite_teardown: "free(blah);"
 ```
 
-If you would like to force your generated test runner to include one or more
-header files, you can just include those at the command line too. Just make sure
-these are _after_ the YAML file, if you are using one:
+If you would like to force your generated test runner to include one or more header files, you can just include those at the command line too.
+Just make sure these are _after_ the YAML file, if you are using one:
 
 ```Shell
 ruby generate_test_runner.rb TestFile.c my_config.yml extras.h
 ```
 
-Another option, particularly if you are already using Ruby to orchestrate your
-builds - or more likely the Ruby-based build tool Rake - is requiring this
-script directly. Anything that you would have specified in a YAML file can be
-passed to the script as part of a hash. Let's push the exact same requirement
-set as we did above but this time through Ruby code directly:
+Another option, particularly if you are already using Ruby to orchestrate your builds - or more likely the Ruby-based build tool Rake - is requiring this script directly.
+Anything that you would have specified in a YAML file can be passed to the script as part of a hash.
+Let's push the exact same requirement set as we did above but this time through Ruby code directly:
 
 ```Ruby
 require "generate_test_runner.rb"
@@ -102,9 +93,8 @@ options = {
 UnityTestRunnerGenerator.new.run(testfile, runner_name, options)
 ```
 
-If you have multiple files to generate in a build script (such as a Rakefile),
-you might want to instantiate a generator object with your options and call it
-to generate each runner afterwards. Like thus:
+If you have multiple files to generate in a build script (such as a Rakefile), you might want to instantiate a generator object with your options and call it to generate each runner afterwards.
+Like thus:
 
 ```Ruby
 gen = UnityTestRunnerGenerator.new(options)
@@ -115,63 +105,52 @@ end
 
 #### Options accepted by generate_test_runner.rb
 
-The following options are available when executing `generate_test_runner`. You
-may pass these as a Ruby hash directly or specify them in a YAML file, both of
-which are described above. In the `examples` directory, Example 3's Rakefile
-demonstrates using a Ruby hash.
+The following options are available when executing `generate_test_runner`.
+You may pass these as a Ruby hash directly or specify them in a YAML file, both of which are described above.
+In the `examples` directory, Example 3's Rakefile demonstrates using a Ruby hash.
 
 ##### `:includes`
 
-This option specifies an array of file names to be `#include`'d at the top of
-your runner C file. You might use it to reference custom types or anything else
-universally needed in your generated runners.
+This option specifies an array of file names to be `#include`'d at the top of your runner C file.
+You might use it to reference custom types or anything else universally needed in your generated runners.
 
 ##### `:suite_setup`
 
 Define this option with C code to be executed _before any_ test cases are run.
 
-Alternatively, if your C compiler supports weak symbols, you can leave this
-option unset and instead provide a `void suiteSetUp(void)` function in your test
-suite.  The linker will look for this symbol and fall back to a Unity-provided
-stub if it is not found.
+Alternatively, if your C compiler supports weak symbols, you can leave this option unset and instead provide a `void suiteSetUp(void)` function in your test suite.
+The linker will look for this symbol and fall back to a Unity-provided stub if it is not found.
 
 ##### `:suite_teardown`
 
-Define this option with C code to be executed _after all_ test cases have
-finished.  An integer variable `num_failures` is available for diagnostics.
-The code should end with a `return` statement; the value returned will become
-the exit code of `main`.  You can normally just return `num_failures`.
+Define this option with C code to be executed _after all_ test cases have finished.
+An integer variable `num_failures` is available for diagnostics.
+The code should end with a `return` statement; the value returned will become the exit code of `main`.
+You can normally just return `num_failures`.
 
-Alternatively, if your C compiler supports weak symbols, you can leave this
-option unset and instead provide a `int suiteTearDown(int num_failures)`
-function in your test suite.  The linker will look for this symbol and fall
-back to a Unity-provided stub if it is not found.
+Alternatively, if your C compiler supports weak symbols, you can leave this option unset and instead provide a `int suiteTearDown(int num_failures)` function in your test suite.
+The linker will look for this symbol and fall back to a Unity-provided stub if it is not found.
 
 ##### `:enforce_strict_ordering`
 
-This option should be defined if you have the strict order feature enabled in
-CMock (see CMock documentation). This generates extra variables required for
-everything to run smoothly. If you provide the same YAML to the generator as
-used in CMock's configuration, you've already configured the generator properly.
+This option should be defined if you have the strict order feature enabled in CMock (see CMock documentation).
+This generates extra variables required for everything to run smoothly.
+If you provide the same YAML to the generator as used in CMock's configuration, you've already configured the generator properly.
 
 ##### `:externc`
 
-This option should be defined if you are mixing C and CPP and want your test
-runners to automatically include extern "C" support when they are generated.
+This option should be defined if you are mixing C and CPP and want your test runners to automatically include extern "C" support when they are generated.
 
 ##### `:mock_prefix` and `:mock_suffix`
 
-Unity automatically generates calls to Init, Verify and Destroy for every file
-included in the main test file that starts with the given mock prefix and ends
-with the given mock suffix, file extension not included. By default, Unity
-assumes a `Mock` prefix and no suffix.
+Unity automatically generates calls to Init, Verify and Destroy for every file included in the main test file that starts with the given mock prefix and ends with the given mock suffix, file extension not included.
+By default, Unity assumes a `Mock` prefix and no suffix.
 
 ##### `:plugins`
 
-This option specifies an array of plugins to be used (of course, the array can
-contain only a single plugin). This is your opportunity to enable support for
-CException support, which will add a check for unhandled exceptions in each
-test, reporting a failure if one is detected. To enable this feature using Ruby:
+This option specifies an array of plugins to be used (of course, the array can contain only a single plugin).
+This is your opportunity to enable support for CException support, which will add a check for unhandled exceptions in each test, reporting a failure if one is detected.
+To enable this feature using Ruby:
 
 ```Ruby
 :plugins => [ :cexception ]
@@ -184,56 +163,47 @@ Or as a yaml file:
   -:cexception
 ```
 
-If you are using CMock, it is very likely that you are already passing an array
-of plugins to CMock. You can just use the same array here. This script will just
-ignore the plugins that don't require additional support.
+If you are using CMock, it is very likely that you are already passing an array of plugins to CMock.
+You can just use the same array here.
+This script will just ignore the plugins that don't require additional support.
 
 ##### `:include_extensions`
 
 This option specifies the pattern for matching acceptable header file extensions.
-By default it will accept hpp, hh, H, and h files. If you need a different combination
-of files to search, update this from the default `'(?:hpp|hh|H|h)'`.
+By default it will accept hpp, hh, H, and h files.
+If you need a different combination of files to search, update this from the default `'(?:hpp|hh|H|h)'`.
 
 ##### `:source_extensions`
 
 This option specifies the pattern for matching acceptable source file extensions.
-By default it will accept cpp, cc, C, c, and ino files. If you need a different combination
-of files to search, update this from the default `'(?:cpp|cc|ino|C|c)'`.
+By default it will accept cpp, cc, C, c, and ino files.
+If you need a different combination of files to search, update this from the default `'(?:cpp|cc|ino|C|c)'`.
 
 ### `unity_test_summary.rb`
 
-A Unity test file contains one or more test case functions. Each test case can
-pass, fail, or be ignored. Each test file is run individually producing results
-for its collection of test cases. A given project will almost certainly be
-composed of multiple test files. Therefore, the suite of tests is comprised of
-one or more test cases spread across one or more test files. This script
-aggregates individual test file results to generate a summary of all executed
-test cases. The output includes how many tests were run, how many were ignored,
-and how many failed. In addition, the output includes a listing of which
-specific tests were ignored and failed. A good example of the breadth and
-details of these results can be found in the `examples` directory. Intentionally
-ignored and failing tests in this project generate corresponding entries in the
-summary report.
+A Unity test file contains one or more test case functions.
+Each test case can pass, fail, or be ignored.
+Each test file is run individually producing results for its collection of test cases.
+A given project will almost certainly be composed of multiple test files.
+Therefore, the suite of tests is comprised of one or more test cases spread across one or more test files.
+This script aggregates individual test file results to generate a summary of all executed test cases.
+The output includes how many tests were run, how many were ignored, and how many failed. In addition, the output includes a listing of which specific tests were ignored and failed.
+A good example of the breadth and details of these results can be found in the `examples` directory.
+Intentionally ignored and failing tests in this project generate corresponding entries in the summary report.
 
-If you're interested in other (prettier?) output formats, check into the
-[Ceedling][] build tool project that works with Unity and CMock and supports
-xunit-style xml as well as other goodies.
+If you're interested in other (prettier?) output formats, check into the [Ceedling][] build tool project that works with Unity and CMock and supports xunit-style xml as well as other goodies.
 
-This script assumes the existence of files ending with the extensions
-`.testpass` and `.testfail`.The contents of these files includes the test
-results summary corresponding to each test file executed with the extension set
-according to the presence or absence of failures for that test file. The script
-searches a specified path for these files, opens each one it finds, parses the
-results, and aggregates and prints a summary. Calling it from the command line
-looks like this:
+This script assumes the existence of files ending with the extensions `.testpass` and `.testfail`.
+The contents of these files includes the test results summary corresponding to each test file executed with the extension set according to the presence or absence of failures for that test file.
+The script searches a specified path for these files, opens each one it finds, parses the results, and aggregates and prints a summary.
+Calling it from the command line looks like this:
 
 ```Shell
 ruby unity_test_summary.rb build/test/
 ```
 
-You can optionally specify a root path as well. This is really helpful when you
-are using relative paths in your tools' setup, but you want to pull the summary
-into an IDE like Eclipse for clickable shortcuts.
+You can optionally specify a root path as well.
+This is really helpful when you are using relative paths in your tools' setup, but you want to pull the summary into an IDE like Eclipse for clickable shortcuts.
 
 ```Shell
 ruby unity_test_summary.rb build/test/ ~/projects/myproject/

--- a/extras/fixture/readme.md
+++ b/extras/fixture/readme.md
@@ -1,29 +1,26 @@
 # Unity Fixtures
 
-This Framework is an optional add-on to Unity.  By including unity_framework.h in place of unity.h,
-you may now work with Unity in a manner similar to CppUTest.  This framework adds the concepts of
-test groups and gives finer control of your tests over the command line.
+This Framework is an optional add-on to Unity.
+By including unity_framework.h in place of unity.h, you may now work with Unity in a manner similar to CppUTest.
+This framework adds the concepts of test groups and gives finer control of your tests over the command line.
 
-This framework is primarily supplied for those working through James Grenning's book on Embedded
-Test Driven Development, or those coming to Unity from CppUTest. We should note that using this
-framework glosses over some of the features of Unity, and makes it more difficult
-to integrate with other testing tools like Ceedling and CMock.
+This framework is primarily supplied for those working through James Grenning's book on Embedded Test Driven Development, or those coming to Unity from CppUTest.
+We should note that using this framework glosses over some of the features of Unity, and makes it more difficult to integrate with other testing tools like Ceedling and CMock.
 
 ## Dependency Notification
 
-Fixtures, by default, uses the Memory addon as well. This is to make it simple for those trying to
-follow along with James' book. Using them together is completely optional. You may choose to use
-Fixtures without Memory handling by defining `UNITY_FIXTURE_NO_EXTRAS`. It will then stop automatically
-pulling in extras and leave you to do it as desired.
+Fixtures, by default, uses the Memory addon as well.
+This is to make it simple for those trying to follow along with James' book.
+Using them together is completely optional.
+You may choose to use Fixtures without Memory handling by defining `UNITY_FIXTURE_NO_EXTRAS`.
+It will then stop automatically pulling in extras and leave you to do it as desired.
 
 ## Usage information
 
-By default the test executables produced by Unity Fixtures run all tests once, but the behavior can
-be configured with command-line flags. Run the test executable with the `--help` flag for more
-information.
+By default the test executables produced by Unity Fixtures run all tests once, but the behavior can be configured with command-line flags.
+Run the test executable with the `--help` flag for more information.
 
-It's possible to add a custom line at the end of the help message, typically to point to
-project-specific or company-specific unit test documentation. Define `UNITY_CUSTOM_HELP_MSG` to
-provide a custom message, e.g.:
+It's possible to add a custom line at the end of the help message, typically to point to project-specific or company-specific unit test documentation.
+Define `UNITY_CUSTOM_HELP_MSG` to provide a custom message, e.g.:
 
     #define UNITY_CUSTOM_HELP_MSG "If any test fails see https://example.com/troubleshooting"

--- a/extras/fixture/readme.md
+++ b/extras/fixture/readme.md
@@ -1,7 +1,7 @@
 # Unity Fixtures
 
 This Framework is an optional add-on to Unity.  By including unity_framework.h in place of unity.h,
-you may now work with Unity in a manner similar to CppUTest.  This framework adds the concepts of 
+you may now work with Unity in a manner similar to CppUTest.  This framework adds the concepts of
 test groups and gives finer control of your tests over the command line.
 
 This framework is primarily supplied for those working through James Grenning's book on Embedded
@@ -9,14 +9,14 @@ Test Driven Development, or those coming to Unity from CppUTest. We should note 
 framework glosses over some of the features of Unity, and makes it more difficult
 to integrate with other testing tools like Ceedling and CMock.
 
-# Dependency Notification
+## Dependency Notification
 
 Fixtures, by default, uses the Memory addon as well. This is to make it simple for those trying to
-follow along with James' book. Using them together is completely optional. You may choose to use 
+follow along with James' book. Using them together is completely optional. You may choose to use
 Fixtures without Memory handling by defining `UNITY_FIXTURE_NO_EXTRAS`. It will then stop automatically
 pulling in extras and leave you to do it as desired.
 
-# Usage information
+## Usage information
 
 By default the test executables produced by Unity Fixtures run all tests once, but the behavior can
 be configured with command-line flags. Run the test executable with the `--help` flag for more

--- a/extras/memory/readme.md
+++ b/extras/memory/readme.md
@@ -1,49 +1,49 @@
 # Unity Memory
 
 This Framework is an optional add-on to Unity.  By including unity.h and then
-unity_memory.h, you have the added ability to track malloc and free calls. This 
+unity_memory.h, you have the added ability to track malloc and free calls. This
 addon requires that the stdlib functions be overridden by its own defines. These
 defines will still malloc / realloc / free etc, but will also track the calls
 in order to ensure that you don't have any memory leaks in your programs.
 
 Note that this is only useful in situations where a unit is in charge of both
-the allocation and deallocation of memory. When it is not symmetric, unit testing 
+the allocation and deallocation of memory. When it is not symmetric, unit testing
 can report a number of false failures. A more advanced runtime tool is required to
 track complete system memory handling.
 
-# Module API
+## Module API
 
-## `UnityMalloc_StartTest` and `UnityMalloc_EndTest`
+### `UnityMalloc_StartTest` and `UnityMalloc_EndTest`
 
 These must be called at the beginning and end of each test. For simplicity, they can
 be added to `setUp` and `tearDown` in order to do their job. When using the test
 runner generator scripts, these will be automatically added to the runner whenever
 unity_memory.h is included.
 
-## `UnityMalloc_MakeMallocFailAfterCount`
+### `UnityMalloc_MakeMallocFailAfterCount`
 
 This can be called from the tests themselves. Passing this function a number will
 force the reference counter to start keeping track of malloc calls. During that test,
-if the number of malloc calls exceeds the number given, malloc will immediately 
-start returning `NULL`. This allows you to test error conditions. Think of it as a 
+if the number of malloc calls exceeds the number given, malloc will immediately
+start returning `NULL`. This allows you to test error conditions. Think of it as a
 simplified mock.
 
-# Configuration
+## Configuration
 
-## `UNITY_MALLOC` and `UNITY_FREE`
+### `UNITY_MALLOC` and `UNITY_FREE`
 
-By default, this module tries to use the real stdlib `malloc` and `free` internally. 
-If you would prefer it to use something else, like FreeRTOS's `pvPortMalloc` and 
+By default, this module tries to use the real stdlib `malloc` and `free` internally.
+If you would prefer it to use something else, like FreeRTOS's `pvPortMalloc` and
 `pvPortFree`, then you can use these defines to make it so.
 
-## `UNITY_EXCLUDE_STDLIB_MALLOC`
+### `UNITY_EXCLUDE_STDLIB_MALLOC`
 
 If you would like this library to ignore stdlib or other heap engines completely, and
 manage the memory on its own, then define this. All memory will be handled internally
 (and at likely lower overhead). Note that this is not a very featureful memory manager,
 but is sufficient for most testing purposes.
 
-## `UNITY_INTERNAL_HEAP_SIZE_BYTES`
+### `UNITY_INTERNAL_HEAP_SIZE_BYTES`
 
 When using the built-in memory manager (see `UNITY_EXCLUDE_STDLIB_MALLOC`) this define
 allows you to set the heap size this library will use to manage the memory.

--- a/extras/memory/readme.md
+++ b/extras/memory/readme.md
@@ -1,49 +1,42 @@
 # Unity Memory
 
-This Framework is an optional add-on to Unity.  By including unity.h and then
-unity_memory.h, you have the added ability to track malloc and free calls. This
-addon requires that the stdlib functions be overridden by its own defines. These
-defines will still malloc / realloc / free etc, but will also track the calls
-in order to ensure that you don't have any memory leaks in your programs.
+This Framework is an optional add-on to Unity.
+By including unity.h and then unity_memory.h, you have the added ability to track malloc and free calls.
+This addon requires that the stdlib functions be overridden by its own defines.
+These defines will still malloc / realloc / free etc, but will also track the calls in order to ensure that you don't have any memory leaks in your programs.
 
-Note that this is only useful in situations where a unit is in charge of both
-the allocation and deallocation of memory. When it is not symmetric, unit testing
-can report a number of false failures. A more advanced runtime tool is required to
-track complete system memory handling.
+Note that this is only useful in situations where a unit is in charge of both the allocation and deallocation of memory.
+When it is not symmetric, unit testing can report a number of false failures.
+A more advanced runtime tool is required to track complete system memory handling.
 
 ## Module API
 
 ### `UnityMalloc_StartTest` and `UnityMalloc_EndTest`
 
-These must be called at the beginning and end of each test. For simplicity, they can
-be added to `setUp` and `tearDown` in order to do their job. When using the test
-runner generator scripts, these will be automatically added to the runner whenever
-unity_memory.h is included.
+These must be called at the beginning and end of each test.
+For simplicity, they can be added to `setUp` and `tearDown` in order to do their job.
+When using the test runner generator scripts, these will be automatically added to the runner whenever unity_memory.h is included.
 
 ### `UnityMalloc_MakeMallocFailAfterCount`
 
-This can be called from the tests themselves. Passing this function a number will
-force the reference counter to start keeping track of malloc calls. During that test,
-if the number of malloc calls exceeds the number given, malloc will immediately
-start returning `NULL`. This allows you to test error conditions. Think of it as a
-simplified mock.
+This can be called from the tests themselves.
+Passing this function a number will force the reference counter to start keeping track of malloc calls.
+During that test, if the number of malloc calls exceeds the number given, malloc will immediately start returning `NULL`.
+This allows you to test error conditions.
+Think of it as a simplified mock.
 
 ## Configuration
 
 ### `UNITY_MALLOC` and `UNITY_FREE`
 
 By default, this module tries to use the real stdlib `malloc` and `free` internally.
-If you would prefer it to use something else, like FreeRTOS's `pvPortMalloc` and
-`pvPortFree`, then you can use these defines to make it so.
+If you would prefer it to use something else, like FreeRTOS's `pvPortMalloc` and `pvPortFree`, then you can use these defines to make it so.
 
 ### `UNITY_EXCLUDE_STDLIB_MALLOC`
 
-If you would like this library to ignore stdlib or other heap engines completely, and
-manage the memory on its own, then define this. All memory will be handled internally
-(and at likely lower overhead). Note that this is not a very featureful memory manager,
-but is sufficient for most testing purposes.
+If you would like this library to ignore stdlib or other heap engines completely, and manage the memory on its own, then define this. All memory will be handled internally (and at likely lower overhead).
+Note that this is not a very featureful memory manager, but is sufficient for most testing purposes.
 
 ### `UNITY_INTERNAL_HEAP_SIZE_BYTES`
 
-When using the built-in memory manager (see `UNITY_EXCLUDE_STDLIB_MALLOC`) this define
-allows you to set the heap size this library will use to manage the memory.
+When using the built-in memory manager (see `UNITY_EXCLUDE_STDLIB_MALLOC`) this define allows you to set the heap size this library will use to manage the memory.


### PR DESCRIPTION
Had reason to scout the Unity docs for the first time in some time.
And my IDE screamed at me about markdown lint errors.

So here's some late-night pedantry.

I have not squashed the commits here as the later two (reference style URLS and line breaks on sentences) are stylistic only and you can take them or leave them. 
I feel they make markdown more readable when looking at raw files, and it allows IDEs to use their own configuration more easily. 
But it is somewhat subjective.