### PR TITLE
extras/fixture: add missing C++ include guards

### DIFF
--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -9,12 +9,19 @@
 #define UNITY_FIXTURE_H_
 
 #include "unity.h"
-#include "unity_internals.h"
 #include "unity_fixture_internals.h"
 
 #ifndef UNITY_FIXTURE_NO_EXTRAS
 #include "unity_memory.h"
 #endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "unity_internals.h"
+
 
 int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
 
@@ -78,6 +85,10 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
 #define LONGS_EQUAL(expected, actual)                  TEST_ASSERT_EQUAL_INT((expected), (actual))
 #define STRCMP_EQUAL(expected, actual)                 TEST_ASSERT_EQUAL_STRING((expected), (actual))
 #define DOUBLES_EQUAL(expected, actual, delta)         TEST_ASSERT_DOUBLE_WITHIN((delta), (expected), (actual))
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* UNITY_FIXTURE_H_ */


### PR DESCRIPTION
This fixes linking errors related to `UnityMain` when test cases based on Unity fixture are defined in a .cpp file.

`unity_internals.h` doesn't have C++ guards, and is currently included from `unity.h` from within C++ header guard block. 
I followed the same approach in `unity_fixture.h` moving it into the guarded block, to make the changes in this PR minimal.

It would be slightly cleaner, although more intrusive, to add C++ guards to `unity_internals.h` and keep it outside of the C++ guarded block in both `unity.h` and `unity_fixture.h`. Please let me know if you prefer this approach, I can update the PR.
