### PR TITLE
Unity color resetting was fixed for Gitlab CI

### DIFF
--- a/docs/UnityConfigurationGuide.md
+++ b/docs/UnityConfigurationGuide.md
@@ -261,7 +261,7 @@ TEST_PRINTF("Pointer   %p\n", &a);
 TEST_PRINTF("Character %c\n", 'F');
 TEST_PRINTF("String    %s\n", "My string");
 TEST_PRINTF("Percent   %%\n");
-TEST_PRINTF("Color Red \033[41mFAIL\033[00m\n");
+TEST_PRINTF("Color Red \033[41mFAIL\033[0m\n");
 TEST_PRINTF("\n");
 TEST_PRINTF("Multiple (%d) (%i) (%u) (%x)\n", -100, 0, 200, 0x12345);
 ```

--- a/src/unity.c
+++ b/src/unity.c
@@ -26,10 +26,10 @@ void UNITY_OUTPUT_CHAR(int);
 struct UNITY_STORAGE_T Unity;
 
 #ifdef UNITY_OUTPUT_COLOR
-const char PROGMEM UnityStrOk[]                            = "\033[42mOK\033[00m";
-const char PROGMEM UnityStrPass[]                          = "\033[42mPASS\033[00m";
-const char PROGMEM UnityStrFail[]                          = "\033[41mFAIL\033[00m";
-const char PROGMEM UnityStrIgnore[]                        = "\033[43mIGNORE\033[00m";
+const char PROGMEM UnityStrOk[]                            = "\033[42mOK\033[0m";
+const char PROGMEM UnityStrPass[]                          = "\033[42mPASS\033[0m";
+const char PROGMEM UnityStrFail[]                          = "\033[41mFAIL\033[0m";
+const char PROGMEM UnityStrIgnore[]                        = "\033[43mIGNORE\033[0m";
 #else
 const char PROGMEM UnityStrOk[]                            = "OK";
 const char PROGMEM UnityStrPass[]                          = "PASS";


### PR DESCRIPTION
Based on escape code from Wikipedia: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit

Gitlab CI output support standard colors printing. But prebuilt escape code `\033[00m` is not recognized & color is not reset.

After fixing the color reset code to `\033[0m` as Wikipedia described, all work nice.