### PR TITLE
Parse output color & time support with custom test suite name

### DIFF
--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -57,6 +57,10 @@ class ParseOutput
     puts 'Real test suite name will be \'' + @real_test_suite_name + '\''
   end
 
+  def xml_encode_s(s)
+    return s.encode(:xml => :attr)
+  end
+
   # If write our output to XML
   def write_xml_output
     output = File.open('report.xml', 'w')
@@ -69,7 +73,7 @@ class ParseOutput
   # Pushes the suite info as xml to the array list, which will be written later
   def push_xml_output_suite_info
     # Insert opening tag at front
-    heading = '<testsuite name="' + @real_test_suite_name + '" tests="' + @total_tests.to_s + '" failures="' + @test_failed.to_s + '"' + ' skips="' + @test_ignored.to_s + '">'
+    heading = '<testsuite name=' + xml_encode_s(@real_test_suite_name) + ' tests="' + @total_tests.to_s + '" failures="' + @test_failed.to_s + '"' + ' skips="' + @test_ignored.to_s + '">'
     @array_list.insert(0, heading)
     # Push back the closing tag
     @array_list.push '</testsuite>'
@@ -77,19 +81,19 @@ class ParseOutput
 
   # Pushes xml output data to the array list, which will be written later
   def push_xml_output_passed(test_name)
-    @array_list.push '    <testcase classname="' + @test_suite + '" name="' + test_name + '"/>'
+    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + '/>'
   end
 
   # Pushes xml output data to the array list, which will be written later
   def push_xml_output_failed(test_name, reason)
-    @array_list.push '    <testcase classname="' + @test_suite + '" name="' + test_name + '">'
+    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + '>'
     @array_list.push '        <failure type="ASSERT FAILED">' + reason + '</failure>'
     @array_list.push '    </testcase>'
   end
 
   # Pushes xml output data to the array list, which will be written later
   def push_xml_output_ignored(test_name, reason)
-    @array_list.push '    <testcase classname="' + @test_suite + '" name="' + test_name + '">'
+    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + '>'
     @array_list.push '        <skipped type="TEST IGNORED">' + reason + '</skipped>'
     @array_list.push '    </testcase>'
   end

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -169,6 +169,10 @@ class ParseOutput
 
   # Test was flagged as having passed so format the output
   def test_passed(array)
+    # ':' symbol will be valid in function args now
+    real_method_name = array[@result_usual_idx - 1..-2].join(':')
+    array = array[0..@result_usual_idx - 2] + [real_method_name] + [array[-1]]
+
     last_item = array.length - 1
     test_name = array[last_item - 1]
     test_suite_verify(array[@class_name_idx])
@@ -181,6 +185,10 @@ class ParseOutput
 
   # Test was flagged as having failed so format the line
   def test_failed(array)
+    # ':' symbol will be valid in function args now
+    real_method_name = array[@result_usual_idx - 1..-3].join(':')
+    array = array[0..@result_usual_idx - 3] + [real_method_name] + array[-2..-1]
+
     last_item = array.length - 1
     test_name = array[last_item - 2]
     reason = array[last_item].chomp.lstrip + ' at line: ' + array[last_item - 3]
@@ -204,6 +212,10 @@ class ParseOutput
 
   # Test was flagged as being ignored so format the output
   def test_ignored(array)
+    # ':' symbol will be valid in function args now
+    real_method_name = array[@result_usual_idx - 1..-3].join(':')
+    array = array[0..@result_usual_idx - 3] + [real_method_name] + array[-2..-1]
+
     last_item = array.length - 1
     test_name = array[last_item - 2]
     reason = array[last_item].chomp.lstrip
@@ -307,18 +319,18 @@ class ParseOutput
         test_ignored(line_array)
         @test_ignored += 1
       elsif line_array.size >= 4
-        # ':' symbol will be valid in function args now
-        real_method_name = line_array[@result_usual_idx - 1..-2].join(':')
-        line_array = line_array[0..@result_usual_idx - 2] + [real_method_name] + [line_array[-1]]
-
         # We will check output from color compilation
-        if line_array[@result_usual_idx].include? 'PASS'
+        if line_array[@result_usual_idx..-1].any? {|l| l.include? 'PASS'}
           test_passed(line_array)
           @test_passed += 1
-        elsif line_array[@result_usual_idx].include? 'FAIL'
+        elsif line_array[@result_usual_idx..-1].any? {|l| l.include? 'FAIL'}
           test_failed(line_array)
           @test_failed += 1
-        elsif line_array[@result_usual_idx].include? 'IGNORE'
+        elsif line_array[@result_usual_idx..-2].any? {|l| l.include? 'IGNORE'}
+          test_ignored(line_array)
+          @test_ignored += 1
+        elsif line_array[@result_usual_idx..-1].any? {|l| l.include? 'IGNORE'}
+          line_array.push('No reason given')
           test_ignored(line_array)
           @test_ignored += 1
         end

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -54,13 +54,13 @@ class ParseOutput
   end
 
   # Set the flag to indicate if there will be an XML output file or not
-  def set_test_suite_name(cli_arg)
-    @real_test_suite_name = cli_arg['-suite'.length..-1]
+  def test_suite_name=(cli_arg)
+    @real_test_suite_name = cli_arg
     puts 'Real test suite name will be \'' + @real_test_suite_name + '\''
   end
 
-  def xml_encode_s(s)
-    return s.encode(:xml => :attr)
+  def xml_encode_s(str)
+    str.encode(:xml => :attr)
   end
 
   # If write our output to XML
@@ -277,7 +277,7 @@ class ParseOutput
     puts '=================== RESULTS ====================='
     puts ''
     # Apply binary encoding. Bad symbols will be unchanged
-    File.open(file_name, "rb").each do |line|
+    File.open(file_name, 'rb').each do |line|
       # Typical test lines look like these:
       # ----------------------------------------------------
       # 1. normal output:
@@ -333,16 +333,16 @@ class ParseOutput
         @test_ignored += 1
       elsif line_array.size >= 4
         # We will check output from color compilation
-        if line_array[@result_usual_idx..-1].any? {|l| l.include? 'PASS'}
+        if line_array[@result_usual_idx..-1].any? { |l| l.include? 'PASS' }
           test_passed(line_array)
           @test_passed += 1
-        elsif line_array[@result_usual_idx..-1].any? {|l| l.include? 'FAIL'}
+        elsif line_array[@result_usual_idx..-1].any? { |l| l.include? 'FAIL' }
           test_failed(line_array)
           @test_failed += 1
-        elsif line_array[@result_usual_idx..-2].any? {|l| l.include? 'IGNORE'}
+        elsif line_array[@result_usual_idx..-2].any? { |l| l.include? 'IGNORE' }
           test_ignored(line_array)
           @test_ignored += 1
-        elsif line_array[@result_usual_idx..-1].any? {|l| l.include? 'IGNORE'}
+        elsif line_array[@result_usual_idx..-1].any? { |l| l.include? 'IGNORE' }
           line_array.push('No reason given (' + get_test_time(line_array[@result_usual_idx..-1]).to_s + ' ms)')
           test_ignored(line_array)
           @test_ignored += 1
@@ -374,7 +374,7 @@ if ARGV.size >= 1
     if arg == '-xml'
       parse_my_file.set_xml_output
     elsif arg.start_with?('-suite')
-      parse_my_file.set_test_suite_name(arg)
+      parse_my_file.test_suite_name = arg.delete_prefix('-suite')
     else
       parse_my_file.process(arg)
       break

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -82,19 +82,19 @@ class ParseOutput
 
   # Pushes xml output data to the array list, which will be written later
   def push_xml_output_passed(test_name, execution_time = 0)
-    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + ' time=' + xml_encode_s(execution_time.to_s) + ' />'
+    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + ' time=' + xml_encode_s((execution_time / 1000.0).to_s) + ' />'
   end
 
   # Pushes xml output data to the array list, which will be written later
   def push_xml_output_failed(test_name, reason, execution_time = 0)
-    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + ' time=' + xml_encode_s(execution_time.to_s) + '>'
+    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + ' time=' + xml_encode_s((execution_time / 1000.0).to_s) + '>'
     @array_list.push '        <failure type="ASSERT FAILED">' + reason + '</failure>'
     @array_list.push '    </testcase>'
   end
 
   # Pushes xml output data to the array list, which will be written later
   def push_xml_output_ignored(test_name, reason, execution_time = 0)
-    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + ' time=' + xml_encode_s(execution_time.to_s) + '>'
+    @array_list.push '    <testcase classname=' + xml_encode_s(@test_suite) + ' name=' + xml_encode_s(test_name) + ' time=' + xml_encode_s((execution_time / 1000.0).to_s) + '>'
     @array_list.push '        <skipped type="TEST IGNORED">' + reason + '</skipped>'
     @array_list.push '    </testcase>'
   end
@@ -240,6 +240,7 @@ class ParseOutput
     push_xml_output_ignored(test_name, reason, test_time) if @xml_out
   end
 
+  # Test time will be in ms
   def get_test_time(value_with_time)
     test_time_array = value_with_time.scan(/\((-?\d+.?\d*) ms\)\s*$/).flatten.map do |arg_value_str|
       arg_value_str.include?('.') ? arg_value_str.to_f : arg_value_str.to_i

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -18,6 +18,9 @@
 #    To use this parser use the following command
 #    ruby parseOutput.rb [options] [file]
 #        options: -xml  : produce a JUnit compatible XML file
+#                 -suiteRequiredSuiteName
+#                       : replace default test suite name to
+#                           "RequiredSuiteName" (can be any name)
 #           file: file to scan for results
 #============================================================
 
@@ -33,6 +36,9 @@ class ParseOutput
     @array_list = false
 
     # current suite name and statistics
+    ## testsuite name
+    @real_test_suite_name = 'Unity'
+    ## classname for testcase
     @test_suite = nil
     @total_tests = 0
     @test_passed = 0
@@ -43,6 +49,12 @@ class ParseOutput
   # Set the flag to indicate if there will be an XML output file or not
   def set_xml_output
     @xml_out = true
+  end
+
+  # Set the flag to indicate if there will be an XML output file or not
+  def set_test_suite_name(cli_arg)
+    @real_test_suite_name = cli_arg['-suite'.length..-1]
+    puts 'Real test suite name will be \'' + @real_test_suite_name + '\''
   end
 
   # If write our output to XML
@@ -57,7 +69,7 @@ class ParseOutput
   # Pushes the suite info as xml to the array list, which will be written later
   def push_xml_output_suite_info
     # Insert opening tag at front
-    heading = '<testsuite name="Unity" tests="' + @total_tests.to_s + '" failures="' + @test_failed.to_s + '"' + ' skips="' + @test_ignored.to_s + '">'
+    heading = '<testsuite name="' + @real_test_suite_name + '" tests="' + @total_tests.to_s + '" failures="' + @test_failed.to_s + '"' + ' skips="' + @test_ignored.to_s + '">'
     @array_list.insert(0, heading)
     # Push back the closing tag
     @array_list.push '</testsuite>'
@@ -325,6 +337,8 @@ if ARGV.size >= 1
   ARGV.each do |arg|
     if arg == '-xml'
       parse_my_file.set_xml_output
+    elsif arg.start_with?('-suite')
+      parse_my_file.set_test_suite_name(arg)
     else
       parse_my_file.process(arg)
       break

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -288,6 +288,17 @@ class ParseOutput
         line_array.push('No reason given')
         test_ignored(line_array)
         @test_ignored += 1
+      elsif line_array.size >= 4
+        if line_array[3].include? 'PASS'
+          test_passed(line_array)
+          @test_passed += 1
+        elsif line_array[3].include? 'FAIL'
+          test_failed(line_array)
+          @test_failed += 1
+        elsif line_array[3].include? 'IGNORE:'
+          test_ignored(line_array)
+          @test_ignored += 1
+        end
       end
       @total_tests = @test_passed + @test_failed + @test_ignored
     end

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -250,7 +250,7 @@ class ParseOutput
     puts ''
     puts '=================== RESULTS ====================='
     puts ''
-    File.open(file_name).each do |line|
+    File.open(file_name, :encoding => "UTF-8").each do |line|
       # Typical test lines look like these:
       # ----------------------------------------------------
       # 1. normal output:

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -14,6 +14,7 @@
 #    - normal output (raw unity)
 #    - fixture output (unity_fixture.h/.c)
 #    - fixture output with verbose flag set ("-v")
+#    - time output flag set (UNITY_INCLUDE_EXEC_TIME define enabled with milliseconds output)
 #
 #    To use this parser use the following command
 #    ruby parseOutput.rb [options] [file]

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -29,6 +29,7 @@ class ParseOutput
   def initialize
     # internal data
     @class_name_idx = 0
+    @result_usual_idx = 3
     @path_delim = nil
 
     # xml output related
@@ -250,7 +251,8 @@ class ParseOutput
     puts ''
     puts '=================== RESULTS ====================='
     puts ''
-    File.open(file_name, :encoding => "UTF-8").each do |line|
+    # Apply binary encoding. Bad symbols will be unchanged
+    File.open(file_name, "rb").each do |line|
       # Typical test lines look like these:
       # ----------------------------------------------------
       # 1. normal output:
@@ -305,13 +307,18 @@ class ParseOutput
         test_ignored(line_array)
         @test_ignored += 1
       elsif line_array.size >= 4
-        if line_array[3].include? 'PASS'
+        # ':' symbol will be valid in function args now
+        real_method_name = line_array[@result_usual_idx - 1..-2].join(':')
+        line_array = line_array[0..@result_usual_idx - 2] + [real_method_name] + [line_array[-1]]
+
+        # We will check output from color compilation
+        if line_array[@result_usual_idx].include? 'PASS'
           test_passed(line_array)
           @test_passed += 1
-        elsif line_array[3].include? 'FAIL'
+        elsif line_array[@result_usual_idx].include? 'FAIL'
           test_failed(line_array)
           @test_failed += 1
-        elsif line_array[3].include? 'IGNORE:'
+        elsif line_array[@result_usual_idx].include? 'IGNORE'
           test_ignored(line_array)
           @test_ignored += 1
         end


### PR DESCRIPTION
1) Adding support for colorful Unity output (with defined `UNITY_OUTPUT_COLOR` value)
2) Adding the possibility for defining custom test suite name for generated JUnit report.
3) Adding support for non-ASCII characters for correct output with other languages.
4) Adding support for test execution time parsing