### PR TITLE
Adding test matrix feature

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -167,7 +167,7 @@ class UnityTestRunnerGenerator
         ## Args with spaces (not strings or char sequences)
         ## String concatenations: "Hello" "World"
 
-        one_number_or_text_regex_string = /(?:[^"',\s\]](?:[^"',\]]*[^"',\s\]])*|(?:(?:\+\-)\s*)?\d+(?:'\d+)*)/.source
+        one_number_or_text_regex_string = /(?:[^"',\s\]](?:[^"',\]][^"',\s\]]?)*|(?:(?:\+\-)\s*)?\d+(?:'\d+)*)/.source
         one_arg_regex_string = /(?:(?:(?:#{one_number_or_text_regex_string}\s*|)"(?:[^"\\]|\\.)*")+|(?:#{one_number_or_text_regex_string}\s*|)'(?:[^'\\]|\\.)*'|(?:#{one_number_or_text_regex_string}|))\s*/.source
 
         arguments.scan(/\s*TEST_MATRIX\s*\((.*)\)\s*$/).flatten.each do |values|

--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -140,10 +140,10 @@ class UnityTestRunnerGenerator
 
       if @options[:use_param_tests] && !arguments.empty?
         args = []
-        arguments.scan(/\s*TEST_CASE\s*\((.*)\)\s*$/) { |a| args << a[0] }
+        arguments.scan(/\s*TEST_CASE\s*\((.*)\)\s*$/m) { |a| args << a[0] }
 
-        arguments.scan(/\s*TEST_RANGE\s*\((.*)\)\s*$/).flatten.each do |range_str|
-          args += range_str.scan(/\[\s*(-?\d+.?\d*),\s*(-?\d+.?\d*),\s*(-?\d+.?\d*)\s*\]/).map do |arg_values_str|
+        arguments.scan(/\s*TEST_RANGE\s*\((.*)\)\s*$/m).flatten.each do |range_str|
+          args += range_str.scan(/\[\s*(-?\d+.?\d*),\s*(-?\d+.?\d*),\s*(-?\d+.?\d*)\s*\]/m).map do |arg_values_str|
             arg_values_str.map do |arg_value_str|
               arg_value_str.include?('.') ? arg_value_str.to_f : arg_value_str.to_i
             end
@@ -173,10 +173,10 @@ class UnityTestRunnerGenerator
         one_char_regex_string = /'(?:[^'\\]|\\.)*'/.source
         one_arg_regex_string = /(?:(?:(?:#{one_number_or_text_regex_string}\s*)?#{one_string_regex_string})+|(?:#{one_number_or_text_regex_string}\s*)?#{one_char_regex_string}|(?:#{one_number_or_text_regex_string}))/.source
 
-        arguments.scan(/\s*TEST_MATRIX\s*\((.*)\)\s*$/).flatten.each do |values|
-          args += values.scan(/\[\s*((?:#{one_arg_regex_string}\s*,\s*)*#{one_arg_regex_string})\s*\]/).flatten.map do |one_arg_values|
+        arguments.scan(/\s*TEST_MATRIX\s*\((.*)\)\s*$/m).flatten.each do |values|
+          args += values.scan(/\[\s*((?:#{one_arg_regex_string}\s*,\s*)*#{one_arg_regex_string})\s*\]/m).flatten.map do |one_arg_values|
             # Force appending comma for usual regular matching
-            (one_arg_values + ',').scan(/(#{one_arg_regex_string})\s*,/)
+            (one_arg_values + ',').scan(/(#{one_arg_regex_string})\s*,/m)
           end.reduce do |result, arg_range_expanded|
             result.product(arg_range_expanded)
           end.map do |arg_combinations|

--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -159,12 +159,16 @@ class UnityTestRunnerGenerator
         # Based on:
         ## https://en.cppreference.com/w/cpp/language/integer_literal
         ## https://en.cppreference.com/w/cpp/language/character_literal
+        ## https://en.cppreference.com/w/cpp/language/string_literal
         ## https://en.cppreference.com/w/cpp/language/floating_literal
         ## https://en.cppreference.com/w/cpp/language/escape
         ## Strings & chars with '[', ']', '(', ')'
         ## Empty args
+        ## Args with spaces (not strings or char sequences)
+        ## String concatenations: "Hello" "World"
 
-        one_arg_regex_string = /(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^"',\s\]][^,\s\]]*|)/.source
+        one_number_or_text_regex_string = /(?:[^"',\s\]](?:[^"',\]]*[^"',\s\]])*|(?:(?:\+\-)\s*)?\d+(?:'\d+)*)/.source
+        one_arg_regex_string = /(?:(?:(?:#{one_number_or_text_regex_string}\s*|)"(?:[^"\\]|\\.)*")+|(?:#{one_number_or_text_regex_string}\s*|)'(?:[^'\\]|\\.)*'|(?:#{one_number_or_text_regex_string}|))\s*/.source
 
         arguments.scan(/\s*TEST_MATRIX\s*\((.*)\)\s*$/).flatten.each do |values|
           args += values.scan(/\[\s*((?:#{one_arg_regex_string}\s*,\s*)*#{one_arg_regex_string})\s*\]/).flatten.map do |one_arg_values|

--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -166,9 +166,12 @@ class UnityTestRunnerGenerator
         ## Empty args
         ## Args with spaces (not strings or char sequences)
         ## String concatenations: "Hello" "World"
+        # Not supported: array addressing (with [])
 
-        one_number_or_text_regex_string = /(?:[^"',\s\]](?:[^"',\]][^"',\s\]]?)*|(?:(?:\+\-)\s*)?\d+(?:'\d+)*)/.source
-        one_arg_regex_string = /(?:(?:(?:#{one_number_or_text_regex_string}\s*|)"(?:[^"\\]|\\.)*")+|(?:#{one_number_or_text_regex_string}\s*|)'(?:[^'\\]|\\.)*'|(?:#{one_number_or_text_regex_string}|))\s*/.source
+        one_number_or_text_regex_string = /[^"',\s\]](?:['\s]*[^"',\s\]])*/.source
+        one_string_regex_string = /"(?:[^"\\]|\\.)*"/.source
+        one_char_regex_string = /'(?:[^'\\]|\\.)*'/.source
+        one_arg_regex_string = /(?:(?:(?:#{one_number_or_text_regex_string}\s*)?#{one_string_regex_string})+|(?:#{one_number_or_text_regex_string}\s*)?#{one_char_regex_string}|(?:#{one_number_or_text_regex_string}))/.source
 
         arguments.scan(/\s*TEST_MATRIX\s*\((.*)\)\s*$/).flatten.each do |values|
           args += values.scan(/\[\s*((?:#{one_arg_regex_string}\s*,\s*)*#{one_arg_regex_string})\s*\]/).flatten.map do |one_arg_values|


### PR DESCRIPTION
As an analog for `TEST_CASE(...)` & `TEST_RANGE(...)`, you can use `TEST_MATRIX(...)` for defining custom test cases.

`TEST_MATRIX` macro parsing can be enabled together with `TEST_RANGE`.

Supports almost all found C & C++ literals & expressions (expect array addressing with `[]`, such as `my_arr[26]`). Also supports multiline matrixes, ranges & cases.

Examples of some tests with that usage:
```c
TEST_MATRIX([ "World", "More \"words", "than ]", "one)", NULL ], [ 5, 8, 4, 32 ])
TEST_MATRIX([
        NULL, "name",
        "name1", "2name", "33name"
    ], [4])
void test_nothing(const char *s, uint32_t b)
{
    TEST_ASSERT_NOT_NULL_MESSAGE(s, "Bad string");
    TEST_ASSERT_NOT_EQUAL_UINT32_MESSAGE(0, b, "Number is zero");
}
```