### PR TITLE
Fix "clobbered variable" compiler warning (`-Wclobbered`)

### DIFF
--- a/auto/run_test.erb
+++ b/auto/run_test.erb
@@ -14,7 +14,7 @@ static void run_test(UnityTestFunction func, const char* name, UNITY_LINE_TYPE l
     if (TEST_PROTECT())
     {
 <% if @options[:plugins].include?(:cexception) %>
-        CEXCEPTION_T e;
+        volatile CEXCEPTION_T e;
         Try {
             <%= @options[:setup_name] %>();
             func();


### PR DESCRIPTION
This MR adds a missing `volatile` type qualifier to fix a "clobbered variable" compiler warning (`-Wclobbered`).

Compiling the unit tests with the `-Wclobbered` compiler flag (or `-Wextra`, which includes `-Wclobbered`) produces the following warning:

```shell
warning: variable ‘e’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
```

The [CExeption README](https://github.com/throwtheswitch/cexception#local-variables) states that

> If (a) you change local (stack) variables within your Try block, and (b) wish to make use of the updated values after an exception is thrown, those variables should be made volatile.

I believe both conditions apply to the variable I added the `volatile` type qualifier to. 
This is supported by [this SO answer](https://stackoverflow.com/a/7726144) and [this SO answer](https://stackoverflow.com/a/25327028).

Now, the compiler issues no warning when compiled with the `-Wclobbered` or `-Wextra` flag.