### PR TITLE
Make PROGMEM configurable // Resolve #606, Resolve #482

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -7,10 +7,8 @@
 #include "unity.h"
 #include <stddef.h>
 
-#ifdef AVR
-#include <avr/pgmspace.h>
-#else
-#define PROGMEM
+#ifndef UNITY_PROGMEM
+#define UNITY_PROGMEM
 #endif
 
 /* If omitted from header, declare overrideable prototypes here so they're ready for use */
@@ -26,50 +24,50 @@ void UNITY_OUTPUT_CHAR(int);
 struct UNITY_STORAGE_T Unity;
 
 #ifdef UNITY_OUTPUT_COLOR
-const char PROGMEM UnityStrOk[]                            = "\033[42mOK\033[0m";
-const char PROGMEM UnityStrPass[]                          = "\033[42mPASS\033[0m";
-const char PROGMEM UnityStrFail[]                          = "\033[41mFAIL\033[0m";
-const char PROGMEM UnityStrIgnore[]                        = "\033[43mIGNORE\033[0m";
+const char UNITY_PROGMEM UnityStrOk[]                            = "\033[42mOK\033[0m";
+const char UNITY_PROGMEM UnityStrPass[]                          = "\033[42mPASS\033[0m";
+const char UNITY_PROGMEM UnityStrFail[]                          = "\033[41mFAIL\033[0m";
+const char UNITY_PROGMEM UnityStrIgnore[]                        = "\033[43mIGNORE\033[0m";
 #else
-const char PROGMEM UnityStrOk[]                            = "OK";
-const char PROGMEM UnityStrPass[]                          = "PASS";
-const char PROGMEM UnityStrFail[]                          = "FAIL";
-const char PROGMEM UnityStrIgnore[]                        = "IGNORE";
+const char UNITY_PROGMEM UnityStrOk[]                            = "OK";
+const char UNITY_PROGMEM UnityStrPass[]                          = "PASS";
+const char UNITY_PROGMEM UnityStrFail[]                          = "FAIL";
+const char UNITY_PROGMEM UnityStrIgnore[]                        = "IGNORE";
 #endif
-static const char PROGMEM UnityStrNull[]                   = "NULL";
-static const char PROGMEM UnityStrSpacer[]                 = ". ";
-static const char PROGMEM UnityStrExpected[]               = " Expected ";
-static const char PROGMEM UnityStrWas[]                    = " Was ";
-static const char PROGMEM UnityStrGt[]                     = " to be greater than ";
-static const char PROGMEM UnityStrLt[]                     = " to be less than ";
-static const char PROGMEM UnityStrOrEqual[]                = "or equal to ";
-static const char PROGMEM UnityStrNotEqual[]               = " to be not equal to ";
-static const char PROGMEM UnityStrElement[]                = " Element ";
-static const char PROGMEM UnityStrByte[]                   = " Byte ";
-static const char PROGMEM UnityStrMemory[]                 = " Memory Mismatch.";
-static const char PROGMEM UnityStrDelta[]                  = " Values Not Within Delta ";
-static const char PROGMEM UnityStrPointless[]              = " You Asked Me To Compare Nothing, Which Was Pointless.";
-static const char PROGMEM UnityStrNullPointerForExpected[] = " Expected pointer to be NULL";
-static const char PROGMEM UnityStrNullPointerForActual[]   = " Actual pointer was NULL";
+static const char UNITY_PROGMEM UnityStrNull[]                   = "NULL";
+static const char UNITY_PROGMEM UnityStrSpacer[]                 = ". ";
+static const char UNITY_PROGMEM UnityStrExpected[]               = " Expected ";
+static const char UNITY_PROGMEM UnityStrWas[]                    = " Was ";
+static const char UNITY_PROGMEM UnityStrGt[]                     = " to be greater than ";
+static const char UNITY_PROGMEM UnityStrLt[]                     = " to be less than ";
+static const char UNITY_PROGMEM UnityStrOrEqual[]                = "or equal to ";
+static const char UNITY_PROGMEM UnityStrNotEqual[]               = " to be not equal to ";
+static const char UNITY_PROGMEM UnityStrElement[]                = " Element ";
+static const char UNITY_PROGMEM UnityStrByte[]                   = " Byte ";
+static const char UNITY_PROGMEM UnityStrMemory[]                 = " Memory Mismatch.";
+static const char UNITY_PROGMEM UnityStrDelta[]                  = " Values Not Within Delta ";
+static const char UNITY_PROGMEM UnityStrPointless[]              = " You Asked Me To Compare Nothing, Which Was Pointless.";
+static const char UNITY_PROGMEM UnityStrNullPointerForExpected[] = " Expected pointer to be NULL";
+static const char UNITY_PROGMEM UnityStrNullPointerForActual[]   = " Actual pointer was NULL";
 #ifndef UNITY_EXCLUDE_FLOAT
-static const char PROGMEM UnityStrNot[]                    = "Not ";
-static const char PROGMEM UnityStrInf[]                    = "Infinity";
-static const char PROGMEM UnityStrNegInf[]                 = "Negative Infinity";
-static const char PROGMEM UnityStrNaN[]                    = "NaN";
-static const char PROGMEM UnityStrDet[]                    = "Determinate";
-static const char PROGMEM UnityStrInvalidFloatTrait[]      = "Invalid Float Trait";
+static const char UNITY_PROGMEM UnityStrNot[]                    = "Not ";
+static const char UNITY_PROGMEM UnityStrInf[]                    = "Infinity";
+static const char UNITY_PROGMEM UnityStrNegInf[]                 = "Negative Infinity";
+static const char UNITY_PROGMEM UnityStrNaN[]                    = "NaN";
+static const char UNITY_PROGMEM UnityStrDet[]                    = "Determinate";
+static const char UNITY_PROGMEM UnityStrInvalidFloatTrait[]      = "Invalid Float Trait";
 #endif
-const char PROGMEM UnityStrErrShorthand[]                  = "Unity Shorthand Support Disabled";
-const char PROGMEM UnityStrErrFloat[]                      = "Unity Floating Point Disabled";
-const char PROGMEM UnityStrErrDouble[]                     = "Unity Double Precision Disabled";
-const char PROGMEM UnityStrErr64[]                         = "Unity 64-bit Support Disabled";
-static const char PROGMEM UnityStrBreaker[]                = "-----------------------";
-static const char PROGMEM UnityStrResultsTests[]           = " Tests ";
-static const char PROGMEM UnityStrResultsFailures[]        = " Failures ";
-static const char PROGMEM UnityStrResultsIgnored[]         = " Ignored ";
+const char UNITY_PROGMEM UnityStrErrShorthand[]                  = "Unity Shorthand Support Disabled";
+const char UNITY_PROGMEM UnityStrErrFloat[]                      = "Unity Floating Point Disabled";
+const char UNITY_PROGMEM UnityStrErrDouble[]                     = "Unity Double Precision Disabled";
+const char UNITY_PROGMEM UnityStrErr64[]                         = "Unity 64-bit Support Disabled";
+static const char UNITY_PROGMEM UnityStrBreaker[]                = "-----------------------";
+static const char UNITY_PROGMEM UnityStrResultsTests[]           = " Tests ";
+static const char UNITY_PROGMEM UnityStrResultsFailures[]        = " Failures ";
+static const char UNITY_PROGMEM UnityStrResultsIgnored[]         = " Ignored ";
 #ifndef UNITY_EXCLUDE_DETAILS
-static const char PROGMEM UnityStrDetail1Name[]            = UNITY_DETAIL1_NAME " ";
-static const char PROGMEM UnityStrDetail2Name[]            = " " UNITY_DETAIL2_NAME " ";
+static const char UNITY_PROGMEM UnityStrDetail1Name[]            = UNITY_DETAIL1_NAME " ";
+static const char UNITY_PROGMEM UnityStrDetail2Name[]            = " " UNITY_DETAIL2_NAME " ";
 #endif
 /*-----------------------------------------------
  * Pretty Printers & Test Result Output Handlers
@@ -587,9 +585,9 @@ static void UnityAddMsgIfSpecified(const char* msg)
             UnityPrint(Unity.CurrentDetail2);
         }
     }
-#endif    
+#endif
     if (msg)
-    {        
+    {
         UnityPrint(UnityStrSpacer);
         UnityPrint(msg);
     }
@@ -853,7 +851,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
             default: /* default is length 4 bytes */
             case 4:
                 expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)expected;
-                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)actual;    
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)actual;
 #ifdef UNITY_SUPPORT_64
                 if (style & (UNITY_DISPLAY_RANGE_UINT | UNITY_DISPLAY_RANGE_HEX))
                 {


### PR DESCRIPTION
Hi,

Firstly, a big THANK YOU for the amazing unit testing framework! Over 2,000,000 embedded developers benefit from it using [PlatformIO Unit Testing](https://docs.platformio.org/en/latest/plus/unit-testing.html) engine. Historically, we used our forked patched version of Unity. The original version has never worked normally on the hardware due to PROGMEM issues which are mostly related to the toolchains.

This PR gives end developers the ability to re-configure `UNITY_PROGMEM` from `unit_config.h`. So, they can personally decide where to keep Unity stuff on the target device.

Thanks in advance! Would be happy to use the master branch in production 🚀 