### PR TITLE
List Unity framework in PlatformIO Registry

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,15 @@
+{
+  "name": "Unity",
+  "version": "2.5.2",
+  "keywords": "unittest, tdd, unit, test",
+  "description": "Simple Unit Testing for C",
+  "homepage": "http://www.throwtheswitch.org/unity",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ThrowTheSwitch/Unity.git"
+  },
+  "frameworks": "*",
+  "platforms": "*",
+  "headers": "unity.h"
+}


### PR DESCRIPTION
In continuation to https://github.com/ThrowTheSwitch/Unity/pull/607

This PR allows PlatformIO users to use the original version of Unity. The v2.5.2 with #607 fix is already published ( https://registry.platformio.org/libraries/throwtheswitch/Unity ). We will use the official version instead of our internal in the upcoming PlatformIO Core 6.0. 