### PR TITLE
Fix broken YAML parsing on later Rubies with Psych >=4.0

### DIFF
--- a/auto/generate_module.rb
+++ b/auto/generate_module.rb
@@ -116,8 +116,8 @@ class UnityModuleGenerator
   def self.grab_config(config_file)
     options = default_options
     unless config_file.nil? || config_file.empty?
-      require 'yaml'
-      yaml_guts = YAML.load_file(config_file)
+      require_relative 'yaml_helper'
+      yaml_guts = YamlHelper.load_file(config_file)
       options.merge!(yaml_guts[:unity] || yaml_guts[:cmock])
       raise "No :unity or :cmock section found in #{config_file}" unless options
     end

--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -51,8 +51,8 @@ class UnityTestRunnerGenerator
   def self.grab_config(config_file)
     options = default_options
     unless config_file.nil? || config_file.empty?
-      require 'yaml'
-      yaml_guts = YAML.load_file(config_file)
+      require_relative 'yaml_helper'
+      yaml_guts = YamlHelper.load_file(config_file)
       options.merge!(yaml_guts[:unity] || yaml_guts[:cmock])
       raise "No :unity or :cmock section found in #{config_file}" unless options
     end

--- a/auto/test_file_filter.rb
+++ b/auto/test_file_filter.rb
@@ -4,7 +4,7 @@
 #   [Released under MIT License. Please refer to license.txt for details]
 # ==========================================
 
-require'yaml'
+require_relative 'yaml_helper'
 
 module RakefileHelpers
   class TestFileFilter
@@ -12,9 +12,10 @@ module RakefileHelpers
       @all_files = all_files
 
       return unless @all_files
-      return unless File.exist?('test_file_filter.yml')
 
-      filters = YAML.load_file('test_file_filter.yml')
+      file = 'test_file_filter.yml'
+      return unless File.exist?(file)
+      filters = YamlHelper.load_file(file)
       @all_files = filters[:all_files]
       @only_files = filters[:only_files]
       @exclude_files = filters[:exclude_files]

--- a/auto/yaml_helper.rb
+++ b/auto/yaml_helper.rb
@@ -1,0 +1,19 @@
+# ==========================================
+#   Unity Project - A Test Framework for C
+#   Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+#   [Released under MIT License. Please refer to license.txt for details]
+# ==========================================
+
+require 'yaml'
+
+module YamlHelper
+  def self.load(body)
+    YAML.respond_to?(:unsafe_load) ?
+      YAML.unsafe_load(body) : YAML.load(body)
+  end
+
+  def self.load_file(file)
+    body = File.read(file)
+    self.load(body)
+  end
+end

--- a/examples/example_3/rakefile_helper.rb
+++ b/examples/example_3/rakefile_helper.rb
@@ -1,14 +1,19 @@
-require 'yaml'
+# ==========================================
+#   Unity Project - A Test Framework for C
+#   Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+#   [Released under MIT License. Please refer to license.txt for details]
+# ==========================================
+
 require 'fileutils'
 require_relative '../../auto/unity_test_summary'
 require_relative '../../auto/generate_test_runner'
 require_relative '../../auto/colour_reporter'
-
+require_relative '../../auto/yaml_helper'
 C_EXTENSION = '.c'.freeze
 
 def load_configuration(config_file)
   $cfg_file = config_file
-  $cfg = YAML.load(File.read($cfg_file))
+  $cfg = YamlHelper.load_file($cfg_file)
 end
 
 def configure_clean

--- a/test/rakefile_helper.rb
+++ b/test/rakefile_helper.rb
@@ -4,11 +4,11 @@
 #   [Released under MIT License. Please refer to license.txt for details]
 # ==========================================
 
-require 'yaml'
 require 'fileutils'
 require_relative '../auto/unity_test_summary'
 require_relative '../auto/generate_test_runner'
 require_relative '../auto/colour_reporter'
+require_relative '../auto/yaml_helper'
 
 module RakefileHelpers
   C_EXTENSION = '.c'.freeze
@@ -16,7 +16,7 @@ module RakefileHelpers
     return if $configured
 
     $cfg_file = "targets/#{config_file}" unless config_file =~ /[\\|\/]/
-    $cfg = YAML.load(File.read($cfg_file))
+    $cfg = YamlHelper.load_file($cfg_file)
     $colour_output = false unless $cfg['colour']
     $configured = true if config_file != DEFAULT_CONFIG_FILE
   end


### PR DESCRIPTION
YAML.load is interpreted as YAML.safe_load where Psych version >= 4.0, which breaks where the YAML file contains aliases. If we can assume our yaml files are trusted (since this a development tool), we can check for the presence of YAML.unsafe_load and use it instead if it exists.