### PR TITLE
Fix call to ERB.new to avoid deprecation warnings.

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -345,7 +345,8 @@ class UnityTestRunnerGenerator
 
   def create_run_test(output)
     require 'erb'
-    template = ERB.new(File.read(File.join(__dir__, 'run_test.erb')), nil, '<>')
+    file = File.read(File.join(__dir__, 'run_test.erb'))
+    template = ERB.new(file, trim_mode: '<>')
     output.puts("\n" + template.result(binding))
   end
 


### PR DESCRIPTION
On later Rubies calling create_run_test() causes the generation of warnings of the following form:

warning: Passing safe_level with the 2nd argument of ERB.new is deprecated...
warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated...

This patch removes the noise.