### PR TITLE
Provide custom build configuration for the PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -11,5 +11,8 @@
   },
   "frameworks": "*",
   "platforms": "*",
-  "headers": "unity.h"
+  "headers": "unity.h",
+  "build": {
+    "extraScript": "platformio-build.py"
+  }
 }

--- a/platformio-build.py
+++ b/platformio-build.py
@@ -1,0 +1,17 @@
+import os
+
+Import("env")
+
+env.Append(CPPDEFINES=["UNITY_INCLUDE_CONFIG_H"])
+
+# import "unity_config.h" folder to the library builder
+try:
+    Import("projenv")
+
+    projenv.Append(CPPDEFINES=["UNITY_INCLUDE_CONFIG_H"])
+    for p in projenv["CPPPATH"]:
+        p = projenv.subst(p)
+        if os.path.isfile(os.path.join(p, "unity_config.h")):
+            env.Prepend(CPPPATH=[p])
+except:
+    pass


### PR DESCRIPTION
This PR allows developers to use any version of the Unity testing framework, even from Git. So, `library.json` now provides its own build configuration and we removed "hardcoded" from PlatformIO Core 6.0.3.