### PR TITLE
fix: add cmake outputs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ examples/example_4/builddir
 Makefile
 CMakeFiles
 CMakeCache.txt
+!unityConfig.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ examples/example_2/all_tests.out
 examples/example_4/builddir
 *.sublime-project
 *.sublime-workspace
+*.cmake
+Makefile
+CMakeFiles
+CMakeCache.txt


### PR DESCRIPTION
this turned out to be problematic with my submodules, I believe it is missing.