### PR TITLE
Rely on `stddef.h` from `unity_internals.h`

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -5,7 +5,6 @@
 ============================================================================ */
 
 #include "unity.h"
-#include <stddef.h>
 
 #ifndef UNITY_PROGMEM
 #define UNITY_PROGMEM


### PR DESCRIPTION
I removed the `stddef.h` include from `unity.c` as it needs to be guarded, which it is in the `unity_internal.h` header file.