### PR TITLE
Declare functions static in the TEST() macro

### DIFF
--- a/extras/fixture/src/unity_fixture.h
+++ b/extras/fixture/src/unity_fixture.h
@@ -38,8 +38,8 @@ int UnityMain(int argc, const char* argv[], void (*runAllTests)(void));
 
 #define TEST(group, name) \
     void TEST_##group##_##name##_(void);\
-    void TEST_##group##_##name##_run(void);\
-    void TEST_##group##_##name##_run(void)\
+    static void TEST_##group##_##name##_run(void);\
+    static void TEST_##group##_##name##_run(void)\
     {\
         UnityTestRunner(TEST_##group##_SETUP,\
             TEST_##group##_##name##_,\


### PR DESCRIPTION
This makes it possible to use "-Wunused-function" and get a compiler warning when a test have been declared but not added to TEST_GROUP_RUNNER().