### PR TITLE
Meson update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 builddir/
 test/sandbox
 .DS_Store
+examples/example_1/subprojects/unity
 examples/example_1/test1.exe
 examples/example_1/test2.exe
 examples/example_2/all_tests.exe

--- a/auto/extract_version.py
+++ b/auto/extract_version.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+ver_re = re.compile(r"^#define\s+UNITY_VERSION_(?:MAJOR|MINOR|BUILD)\s+(\d+)$")
+version = []
+
+with open(sys.argv[1], "r") as f:
+    for line in f:
+        m = ver_re.match(line)
+        if m:
+            version.append(m.group(1))
+
+print(".".join(version))
+

--- a/examples/example_1/meson.build
+++ b/examples/example_1/meson.build
@@ -1,0 +1,48 @@
+project('Unity example', 'c',
+  license: 'MIT',
+  default_options: [
+    'c_std=c99',
+    'warning_level=3',
+  ],
+  meson_version: '>= 0.49.0'
+)
+
+unity_subproject = subproject('unity')
+unity_dependency = unity_subproject.get_variable('unity_dep')
+unity_gen_runner = unity_subproject.get_variable('gen_test_runner')
+
+src1 = files([
+  'src' / 'ProductionCode.c',
+  'test' / 'TestProductionCode.c',
+])
+
+src2 = files([
+  'src' / 'ProductionCode2.c',
+  'test' / 'TestProductionCode2.c',
+])
+
+inc = include_directories('src')
+
+test1 = executable('test1',
+  sources: [
+    src1,
+    unity_gen_runner.process('test' / 'TestProductionCode.c')
+  ],
+  include_directories: [ inc ],
+  dependencies: [ unity_dependency ],
+)
+
+test('test1', test1,
+  should_fail: true)
+
+test2 = executable('test2',
+  sources: [
+    src2,
+    unity_gen_runner.process('test' / 'TestProductionCode2.c')
+  ],
+  include_directories: [ inc ],
+  dependencies: [ unity_dependency ],
+)
+
+test('test2', test2)
+

--- a/examples/example_1/readme.txt
+++ b/examples/example_1/readme.txt
@@ -2,4 +2,11 @@ Example 1
 =========
 
 Close to the simplest possible example of Unity, using only basic features.
-Run make to build & run the example tests.
+
+Build and run with Make
+---
+Just run `make`.
+
+Build and run with Meson
+---
+Run `meson setup build` to create the build directory, and then `meson test -C build` to build and run the tests.

--- a/examples/example_1/subprojects/unity.wrap
+++ b/examples/example_1/subprojects/unity.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/ThrowTheSwitch/Unity.git
+revision = head

--- a/extras/fixture/src/meson.build
+++ b/extras/fixture/src/meson.build
@@ -1,0 +1,8 @@
+unity_inc += include_directories('.')
+unity_src += files('unity_fixture.c')
+
+install_headers(
+  'unity_fixture.h',
+  'unity_fixture_internals.h',
+  subdir: meson.project_name()
+)

--- a/extras/memory/src/meson.build
+++ b/extras/memory/src/meson.build
@@ -1,0 +1,7 @@
+unity_inc += include_directories('.')
+unity_src += files('unity_memory.c')
+
+install_headers(
+  'unity_memory.h',
+  subdir: meson.project_name()
+)

--- a/meson.build
+++ b/meson.build
@@ -5,21 +5,22 @@
 # license: MIT
 #
 project('unity', 'c',
-    license: 'MIT',
-    meson_version: '>=0.37.0',
-    default_options: ['werror=true', 'c_std=c11'])
+  license: 'MIT',
+  # `meson.project_source_root()` introduced in 0.56.0
+  meson_version: '>=0.56.0',
+  default_options: [
+    'werror=true',
+    'c_std=c11'
+  ]
+)
 
 subdir('src')
 unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)
 
-
-# Get the generate_test_runner script relative to itself or the parent project if it is being used as a subproject
-# NOTE: This could be (and probably is) a complete hack - but I haven't yet been able to find a better way....
-if meson.is_subproject()
-gen_test_runner_path = find_program(meson.source_root() / 'subprojects/unity/auto/generate_test_runner.rb')
-else
-gen_test_runner_path = find_program('subprojects/unity/auto/generate_test_runner.rb')
-endif
-
-# Create a generator that we can access from the parent project
-gen_test_runner = generator(gen_test_runner_path, output: '@BASENAME@_Runner.c', arguments: ['@INPUT@', '@OUTPUT@'] )
+# Create a generator that can be used by consumers of our build system to generate
+# test runners.
+gen_test_runner = generator(
+  find_program(meson.project_source_root() / 'auto' / 'generate_test_runner.rb'),
+  output: '@BASENAME@_Runner.c',
+  arguments: ['@INPUT@', '@OUTPUT@']
+)

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,17 @@
 #
 project('unity', 'c',
   license: 'MIT',
+
+  # Set project version to value extracted from unity.h header
+  version: run_command(
+    [
+      find_program('python', 'python3'),
+      'auto' / 'extract_version.py',
+      'src' / 'unity.h'
+    ],
+    check: true
+  ).stdout().strip(),
+
   # `meson.project_source_root()` introduced in 0.56.0
   meson_version: '>=0.56.0',
   default_options: [
@@ -14,8 +25,41 @@ project('unity', 'c',
   ]
 )
 
+build_fixture = get_option('extension_fixture').enabled()
+build_memory = get_option('extension_memory').enabled()
+
+unity_src = []
+unity_inc = []
+
 subdir('src')
-unity_dep = declare_dependency(link_with: unity_lib, include_directories: unity_dir)
+
+if build_fixture
+  # Building the fixture extension implies building the memory
+  # extension.
+  build_memory = true
+  subdir('extras/fixture/src')
+endif
+
+if build_memory
+  subdir('extras/memory/src')
+endif
+
+unity_lib = static_library(meson.project_name(),
+  sources: unity_src,
+  include_directories: unity_inc,
+  install: true
+)
+
+unity_dep = declare_dependency(
+  link_with: unity_lib,
+  include_directories: unity_inc
+)
+
+# Generate pkg-config file.
+pkg = import('pkgconfig')
+pkg.generate(unity_lib,
+  description: 'C Unit testing framework.'
+)
 
 # Create a generator that can be used by consumers of our build system to generate
 # test runners.
@@ -23,4 +67,14 @@ gen_test_runner = generator(
   find_program(meson.project_source_root() / 'auto' / 'generate_test_runner.rb'),
   output: '@BASENAME@_Runner.c',
   arguments: ['@INPUT@', '@OUTPUT@']
+)
+
+# Summarize.
+summary(
+  {
+    'Fixture extension': build_fixture,
+    'Memory extension': build_memory,
+  },
+  section: 'Extensions',
+  bool_yn: true
 )

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ project('unity', 'c',
     check: true
   ).stdout().strip(),
 
-  meson_version: '>=0.37.0',
+  meson_version: '>=0.47.0',
   default_options: [
     'werror=true',
     'c_std=c11'

--- a/meson.build
+++ b/meson.build
@@ -10,23 +10,21 @@ project('unity', 'c',
   # Set project version to value extracted from unity.h header
   version: run_command(
     [
-      find_program('python', 'python3'),
-      'auto' / 'extract_version.py',
-      'src' / 'unity.h'
+      'auto/extract_version.py',
+      'src/unity.h'
     ],
     check: true
   ).stdout().strip(),
 
-  # `meson.project_source_root()` introduced in 0.56.0
-  meson_version: '>=0.56.0',
+  meson_version: '>=0.37.0',
   default_options: [
     'werror=true',
     'c_std=c11'
   ]
 )
 
-build_fixture = get_option('extension_fixture').enabled()
-build_memory = get_option('extension_memory').enabled()
+build_fixture = get_option('extension_fixture')
+build_memory = get_option('extension_memory')
 
 unity_src = []
 unity_inc = []
@@ -57,24 +55,17 @@ unity_dep = declare_dependency(
 
 # Generate pkg-config file.
 pkg = import('pkgconfig')
-pkg.generate(unity_lib,
+pkg.generate(
+  name: meson.project_name(),
+  version: meson.project_version(),
+  libraries: [ unity_lib ],
   description: 'C Unit testing framework.'
 )
 
 # Create a generator that can be used by consumers of our build system to generate
 # test runners.
 gen_test_runner = generator(
-  find_program(meson.project_source_root() / 'auto' / 'generate_test_runner.rb'),
+  find_program('auto/generate_test_runner.rb'),
   output: '@BASENAME@_Runner.c',
   arguments: ['@INPUT@', '@OUTPUT@']
-)
-
-# Summarize.
-summary(
-  {
-    'Fixture extension': build_fixture,
-    'Memory extension': build_memory,
-  },
-  section: 'Extensions',
-  bool_yn: true
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('extension_fixture', type: 'feature', value: 'disabled', description: 'Whether to use the fixture extension.')
+option('extension_memory', type: 'feature', value: 'disabled', description: 'Whether to use the memory extension.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
-option('extension_fixture', type: 'feature', value: 'disabled', description: 'Whether to use the fixture extension.')
-option('extension_memory', type: 'feature', value: 'disabled', description: 'Whether to use the memory extension.')
+option('extension_fixture', type: 'boolean', value: 'false', description: 'Whether to enable the fixture extension.')
+option('extension_memory', type: 'boolean', value: 'false', description: 'Whether to enable the memory extension.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,10 +4,12 @@
 #
 # license: MIT
 #
-unity_dir = include_directories('.')
 
-unity_lib = static_library(meson.project_name(),
-    'unity.c',
-    include_directories: unity_dir,
-    native: true
+unity_inc += include_directories('.')
+unity_src += files('unity.c')
+
+install_headers(
+  'unity.h',
+  'unity_internals.h',
+  subdir: meson.project_name()
 )


### PR DESCRIPTION
This PR is heavily based on existing work by Owen Torres (@optorres) in #546. I aim to get his excellent work merged. 

As stated by @optorres in #546 : 

> This updates the meson build scripts to bring them more-or-less up to parity with the CMake script and adds a meson build script to one of the project examples.
> 
> Build script additions:
> 
> Library version is now retrieved from `unity.h` instead of being left as undefined.
> Extensions (`fixture` and `memory`) are now supported.
> The library, headers, and package configuration files (using `pkg-config` instead of CMake's config format) are now installed with `ninja install` / `meson compile install`.

My additions to his work are mainly around hygiene for Meson.  I try to use the cross-platform `/` operator to join paths, which was introduced in version '0.49.0' and use `meson.project_source_root()` which is introduced in Meson version `0.56.0` in place of the deprecated function `meson.source_root()`.