### PR TITLE
Parse test execution time in unity fixture output

### DIFF
--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -131,10 +131,11 @@ class ParseOutput
   def test_passed_unity_fixture(array)
     class_name = array[0]
     test_name  = array[1]
+    test_time = get_test_time(array[array.length - 1])
     test_suite_verify(class_name)
-    printf "%-40s PASS\n", test_name
+    printf "%-40s PASS %10d ms\n", test_name, test_time
 
-    push_xml_output_passed(test_name) if @xml_out
+    push_xml_output_passed(test_name, test_time) if @xml_out
   end
 
   # Test was flagged as having failed so format the output.

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -143,13 +143,14 @@ class ParseOutput
   def test_failed_unity_fixture(array)
     class_name = array[0]
     test_name  = array[1]
+    test_time = get_test_time(array[array.length - 1])
     test_suite_verify(class_name)
     reason_array = array[2].split(':')
     reason = reason_array[-1].lstrip.chomp + ' at line: ' + reason_array[-4]
 
-    printf "%-40s FAILED\n", test_name
+    printf "%-40s FAILED %10d ms\n", test_name, test_time
 
-    push_xml_output_failed(test_name, reason) if @xml_out
+    push_xml_output_failed(test_name, reason, test_time) if @xml_out
   end
 
   # Test was flagged as being ignored so format the output.
@@ -157,6 +158,7 @@ class ParseOutput
   def test_ignored_unity_fixture(array)
     class_name = array[0]
     test_name  = array[1]
+    test_time = get_test_time(array[array.length - 1])
     reason = 'No reason given'
     if array.size > 2
       reason_array = array[2].split(':')
@@ -164,9 +166,9 @@ class ParseOutput
       reason = tmp_reason == 'IGNORE' ? 'No reason given' : tmp_reason
     end
     test_suite_verify(class_name)
-    printf "%-40s IGNORED\n", test_name
+    printf "%-40s IGNORED %10d ms\n", test_name, test_time
 
-    push_xml_output_ignored(test_name, reason) if @xml_out
+    push_xml_output_ignored(test_name, reason, test_time) if @xml_out
   end
 
   # Test was flagged as having passed so format the output

--- a/extras/fixture/src/unity_fixture.c
+++ b/extras/fixture/src/unity_fixture.c
@@ -124,6 +124,9 @@ void UnityIgnoreTest(const char* printableName, const char* group, const char* n
         if (UnityFixture.Verbose)
         {
             UnityPrint(printableName);
+            UNITY_EXEC_TIME_START();
+            UNITY_EXEC_TIME_STOP();
+            UNITY_PRINT_EXEC_TIME();
             UNITY_PRINT_EOL();
         }
         else if (UnityFixture.Silent)
@@ -286,6 +289,8 @@ void UnityConcludeFixtureTest(void)
     if (Unity.CurrentTestIgnored)
     {
         Unity.TestIgnores++;
+        UNITY_EXEC_TIME_STOP();
+        UNITY_PRINT_EXEC_TIME();
         UNITY_PRINT_EOL();
     }
     else if (!Unity.CurrentTestFailed)
@@ -302,6 +307,8 @@ void UnityConcludeFixtureTest(void)
     else /* Unity.CurrentTestFailed */
     {
         Unity.TestFailures++;
+        UNITY_EXEC_TIME_STOP();
+        UNITY_PRINT_EXEC_TIME();
         UNITY_PRINT_EOL();
     }
 


### PR DESCRIPTION
When using unity fixture with time output flag set, `parse_output.rb` did not parse the execution time.