### PR TITLE
Don't install anything when building as subproject

### DIFF
--- a/extras/fixture/src/meson.build
+++ b/extras/fixture/src/meson.build
@@ -1,8 +1,10 @@
 unity_inc += include_directories('.')
 unity_src += files('unity_fixture.c')
 
-install_headers(
-  'unity_fixture.h',
-  'unity_fixture_internals.h',
-  subdir: meson.project_name()
-)
+if not meson.is_subproject()
+  install_headers(
+    'unity_fixture.h',
+    'unity_fixture_internals.h',
+    subdir: meson.project_name()
+  )
+endif

--- a/extras/memory/src/meson.build
+++ b/extras/memory/src/meson.build
@@ -1,7 +1,9 @@
 unity_inc += include_directories('.')
 unity_src += files('unity_memory.c')
 
-install_headers(
-  'unity_memory.h',
-  subdir: meson.project_name()
-)
+if not meson.is_subproject()
+  install_headers(
+    'unity_memory.h',
+    subdir: meson.project_name()
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,7 @@ endif
 unity_lib = static_library(meson.project_name(),
   sources: unity_src,
   include_directories: unity_inc,
-  install: true
+  install: not meson.is_subproject(),
 )
 
 unity_dep = declare_dependency(
@@ -54,13 +54,15 @@ unity_dep = declare_dependency(
 )
 
 # Generate pkg-config file.
-pkg = import('pkgconfig')
-pkg.generate(
-  name: meson.project_name(),
-  version: meson.project_version(),
-  libraries: [ unity_lib ],
-  description: 'C Unit testing framework.'
-)
+if not meson.is_subproject()
+  pkg = import('pkgconfig')
+  pkg.generate(
+    name: meson.project_name(),
+    version: meson.project_version(),
+    libraries: [ unity_lib ],
+    description: 'C Unit testing framework.'
+  )
+endif
 
 # Create a generator that can be used by consumers of our build system to generate
 # test runners.

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,8 +8,10 @@
 unity_inc += include_directories('.')
 unity_src += files('unity.c')
 
-install_headers(
-  'unity.h',
-  'unity_internals.h',
-  subdir: meson.project_name()
-)
+if not meson.is_subproject()
+  install_headers(
+    'unity.h',
+    'unity_internals.h',
+    subdir: meson.project_name()
+  )
+endif


### PR DESCRIPTION
When a project is consuming unity as as subproject, unity headers, static library and pkg config files are installed by `meson install`.

This can be fixed by using `meson install --skip-subprojects`, but this must be repeated in all the distros packaging a project.

Fixed by disabling install when building as a subproject.

Fixes: #661