### PR TITLE
Use __attribute__((__noreturn__)) instead of __attribute__((noreturn))

### DIFF
--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -77,7 +77,7 @@
   #endif
 #endif
 #ifndef UNITY_NORETURN
-  #define UNITY_NORETURN UNITY_FUNCTION_ATTR(noreturn)
+  #define UNITY_NORETURN UNITY_FUNCTION_ATTR(__noreturn__)
 #endif
 
 /*-------------------------------------------------------


### PR DESCRIPTION
See https://github.com/ThrowTheSwitch/Unity/issues/663