### PR TITLE
Squash warnings about unhandled enumeration.

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1115,6 +1115,7 @@ void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
             is_trait = !isinf(actual) && !isnan(actual);
             break;
 
+        case UNITY_FLOAT_INVALID_TRAIT:  /* Supress warning */
         default: /* including UNITY_FLOAT_INVALID_TRAIT */
             trait_index = 0;
             trait_names[0] = UnityStrInvalidFloatTrait;
@@ -1341,6 +1342,7 @@ void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
             is_trait = !isinf(actual) && !isnan(actual);
             break;
 
+        case UNITY_FLOAT_INVALID_TRAIT:  /* Supress warning */
         default: /* including UNITY_FLOAT_INVALID_TRAIT */
             trait_index = 0;
             trait_names[0] = UnityStrInvalidFloatTrait;


### PR DESCRIPTION
from downstream user ntpsec with `--enable-warnings`
```
[119/213][55%][|][=====================================================>                                           ][1.309s]../../tests/unity/unity.c: In function ‘UnityAssertFloatSpecial’:
../../tests/unity/unity.c:984:5: warning: enumeration value ‘UNITY_FLOAT_INVALID_TRAIT’ not handled in switch [-Wswitch-enum]
  984 |     switch (style)
      |     ^~~~~~
../../tests/unity/unity.c: In function ‘UnityAssertDoubleSpecial’:
../../tests/unity/unity.c:1124:5: warning: enumeration value ‘UNITY_FLOAT_INVALID_TRAIT’ not handled in switch [-Wswitch-enum]
 1124 |     switch (style)
      |     ^~~~~~

[213/213][100%][-][===============================================================================================>][1.778s]
```