### PR TITLE
Expose double support as an option.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,9 @@ project('unity', 'c',
 
 build_fixture = get_option('extension_fixture')
 build_memory = get_option('extension_memory')
+support_double = get_option('support_double')
 
+unity_args = []
 unity_src = []
 unity_inc = []
 
@@ -42,8 +44,13 @@ if build_memory
   subdir('extras/memory/src')
 endif
 
+if support_double
+  unity_args += '-DUNITY_INCLUDE_DOUBLE'
+endif
+
 unity_lib = static_library(meson.project_name(),
   sources: unity_src,
+  c_args: unity_args,
   include_directories: unity_inc,
   install: not meson.is_subproject(),
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('extension_fixture', type: 'boolean', value: 'false', description: 'Whether to enable the fixture extension.')
 option('extension_memory', type: 'boolean', value: 'false', description: 'Whether to enable the memory extension.')
+option('support_double', type: 'boolean', value: 'false', description: 'Whether to enable double precision floating point assertions.')


### PR DESCRIPTION
Without this, a parent project can set `-DUNITY_INCLUDE_DOUBLE` in their `c_args` but get link errors because it is not applied to the build of Unity (eg. `undefined reference to `UnityAssertDoublesWithin'`).

I would have added the other options but my tests don't use them and I didn't want to add them without checking.
