### PR TITLE
Support shared library build

### DIFF
--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config:
         - {
@@ -21,7 +21,7 @@ jobs:
             cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             generators: "Ninja",
-            shared_build: "OFF"
+            shared_build: false
           }
         - {
             name: "Ubuntu: GCC - Release Static",
@@ -30,7 +30,7 @@ jobs:
             cc: "gcc",
             cxx: "g++",
             generators: "Ninja",
-            shared_build: "OFF"
+            shared_build: false
           }
         - {
             name: "Apple OSX: Clang - Release Static",
@@ -39,7 +39,7 @@ jobs:
             cc: "clang",
             cxx: "clang++",
             generators: "Ninja",
-            shared_build: "OFF"
+            shared_build: false
           }
         - {
             name: "Windows: MSVC - Release Shared",
@@ -49,7 +49,7 @@ jobs:
             cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             generators: "Ninja",
-            shared_build: "ON"
+            shared_build: true
           }
         - {
             name: "Ubuntu: GCC - Release Shared",
@@ -58,7 +58,7 @@ jobs:
             cc: "gcc",
             cxx: "g++",
             generators: "Ninja",
-            shared_build: "ON"
+            shared_build: true
           }
         - {
             name: "Apple OSX: Clang - Release Shared",
@@ -67,7 +67,7 @@ jobs:
             cc: "clang",
             cxx: "clang++",
             generators: "Ninja",
-            shared_build: "ON"
+            shared_build: true
           }
 
     steps:
@@ -88,7 +88,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
             -DCMAKE_INSTALL_PREFIX:PATH=install \
-            -DBUILD_SHARED_LIBS=${{ matrix.config.shared_build }} \
+            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.config.shared_build }} \
             -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
 
       - name: CMake build

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         config:
         - {
-            name: "Windows: MSVC",
+            name: "Windows: MSVC - Release Static",
             os: windows-latest,
             build_type: "Release",
             cc: "cl",
@@ -24,7 +24,7 @@ jobs:
             shared_build: "OFF"
           }
         - {
-            name: "Ubuntu: GCC",
+            name: "Ubuntu: GCC - Release Static",
             os: ubuntu-latest,
             build_type: "Release",
             cc: "gcc",
@@ -33,13 +33,41 @@ jobs:
             shared_build: "OFF"
           }
         - {
-            name: "Apple OSX: Clang",
+            name: "Apple OSX: Clang - Release Static",
             os: macos-latest,
             build_type: "Release",
             cc: "clang",
             cxx: "clang++",
             generators: "Ninja",
             shared_build: "OFF"
+          }
+        - {
+            name: "Windows: MSVC - Release Shared",
+            os: windows-latest,
+            build_type: "Release",
+            cc: "cl",
+            cxx: "cl",
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            generators: "Ninja",
+            shared_build: "ON"
+          }
+        - {
+            name: "Ubuntu: GCC - Release Shared",
+            os: ubuntu-latest,
+            build_type: "Release",
+            cc: "gcc",
+            cxx: "g++",
+            generators: "Ninja",
+            shared_build: "ON"
+          }
+        - {
+            name: "Apple OSX: Clang - Release Shared",
+            os: macos-latest,
+            build_type: "Release",
+            cc: "clang",
+            cxx: "clang++",
+            generators: "Ninja",
+            shared_build: "ON"
           }
 
     steps:
@@ -60,7 +88,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
             -DCMAKE_INSTALL_PREFIX:PATH=install \
-            -DBUILD_SHARED_LIBS=${{ matrix.config.shared_build }}
+            -DBUILD_SHARED_LIBS=${{ matrix.config.shared_build }} \
+            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
 
       - name: CMake build
         shell: bash

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -1,0 +1,90 @@
+---
+name: Build Unity library
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+        - {
+            name: "Windows: MSVC",
+            os: windows-latest,
+            build_type: "Release",
+            cc: "cl",
+            cxx: "cl",
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            generators: "Ninja",
+            shared_build: "OFF"
+          }
+        - {
+            name: "Ubuntu: GCC",
+            os: ubuntu-latest,
+            build_type: "Release",
+            cc: "gcc",
+            cxx: "g++",
+            generators: "Ninja",
+            shared_build: "OFF"
+          }
+        - {
+            name: "Apple OSX: Clang",
+            os: macos-latest,
+            build_type: "Release",
+            cc: "clang",
+            cxx: "clang++",
+            generators: "Ninja",
+            shared_build: "OFF"
+          }
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies on Windows
+        if: startsWith(matrix.config.os, 'windows')
+        run: |
+          choco install ninja cmake
+          ninja --version
+          cmake --version
+
+      - name: Install dependencies on Ubuntu
+        if: startsWith(matrix.config.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install ninja-build cmake
+          ninja --version
+          cmake --version
+          gcc --version
+      - name: Install dependencies on OSX
+        if: startsWith(matrix.config.os, 'macos')
+        run: |
+          brew install cmake ninja
+          ninja --version
+          cmake --version
+          clang --version
+
+      - name: CMake configure
+        shell: bash
+        run: |
+          cmake \
+            -S . \
+            -B build \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=install \
+            -DBUIlD_SHARED_LIBS=${{ matrix.config.shared_build }}
+
+      - name: CMake build
+        shell: bash
+        run: cmake --build build --config ${{ matrix.config.build_type }}
+
+      - name: CMake install
+        shell: bash
+        run: cmake --build build --config ${{ matrix.config.build_type }} --target install

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -3,9 +3,7 @@ name: Build Unity library
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -44,29 +44,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
-      - name: Install dependencies on Windows
-        if: startsWith(matrix.config.os, 'windows')
-        run: |
-          choco install ninja cmake
-          ninja --version
-          cmake --version
-
-      - name: Install dependencies on Ubuntu
-        if: startsWith(matrix.config.os, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install ninja-build cmake
-          ninja --version
-          cmake --version
-          gcc --version
-      - name: Install dependencies on OSX
-        if: startsWith(matrix.config.os, 'macos')
-        run: |
-          brew install cmake ninja
-          ninja --version
-          cmake --version
-          clang --version
+      - name: Install dependencies
+        run: pip install cmake ninja
 
       - name: CMake configure
         shell: bash
@@ -77,7 +60,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
             -DCMAKE_INSTALL_PREFIX:PATH=install \
-            -DBUIlD_SHARED_LIBS=${{ matrix.config.shared_build }}
+            -DBUILD_SHARED_LIBS=${{ matrix.config.shared_build }}
 
       - name: CMake build
         shell: bash

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -95,7 +95,8 @@ jobs:
             -DBUILD_SHARED_LIBS:BOOL=${{ matrix.config.shared_build }} \
             -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
             -DUNITY_EXTENSION_FIXTURES:BOOL=ON \
-            -DUNITY_EXTENSION_MEMORY:BOOL=ON
+            -DUNITY_EXTENSION_MEMORY:BOOL=ON \
+            -DCMAKE_C_FLAGS="-DUNITY_SKIP_DEFAULT_RUNNER"
 
       - name: CMake build
         shell: bash

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -20,7 +20,7 @@ jobs:
             cc: "cl",
             cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-            generators: "Ninja",
+            generators: "Visual Studio 17 2022",
             shared_build: false
           }
         - {
@@ -48,7 +48,7 @@ jobs:
             cc: "cl",
             cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-            generators: "Ninja",
+            generators: "Visual Studio 17 2022",
             shared_build: true
           }
         - {

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -93,7 +93,9 @@ jobs:
             -G "${{ matrix.config.generators }}" \
             -DCMAKE_INSTALL_PREFIX:PATH=install \
             -DBUILD_SHARED_LIBS:BOOL=${{ matrix.config.shared_build }} \
-            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
+            -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+            -DUNITY_EXTENSION_FIXTURES:BOOL=ON \
+            -DUNITY_EXTENSION_MEMORY:BOOL=ON
 
       - name: CMake build
         shell: bash

--- a/.github/workflows/build_library.yml
+++ b/.github/workflows/build_library.yml
@@ -19,7 +19,7 @@ jobs:
             build_type: "Release",
             cc: "cl",
             cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             generators: "Ninja",
             shared_build: false
           }
@@ -47,7 +47,7 @@ jobs:
             build_type: "Release",
             cc: "cl",
             cxx: "cl",
-            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             generators: "Ninja",
             shared_build: true
           }
@@ -78,6 +78,10 @@ jobs:
 
       - name: Install dependencies
         run: pip install cmake ninja
+
+      - name: Prepare Visual Studio environment
+        if: startsWith(matrix.config.os, 'windows')
+        run: cmd "${{ matrix.config.environment_script }}"
 
       - name: CMake configure
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_minimum_required(VERSION 3.12)
 # Read src/unity.h file and get project version from it
 set(UNITY_HEADER "src/unity.h")
 
-file(STRINGS "${UNITY_HEADER}" UNITY_HEADER_CONTENT 
+file(STRINGS "${UNITY_HEADER}" UNITY_HEADER_CONTENT
     REGEX "^#define UNITY_VERSION_(MAJOR|MINOR|BUILD) +[0-9]+$"
 )
 
@@ -24,8 +24,8 @@ set(UNITY_HEADER_VERSION_BUILD 0)
 
 foreach(VERSION_LINE IN LISTS UNITY_HEADER_CONTENT)
     foreach(VERSION_PART MAJOR MINOR BUILD)
-        string(CONCAT REGEX_STRING "#define UNITY_VERSION_" 
-                                   "${VERSION_PART}" 
+        string(CONCAT REGEX_STRING "#define UNITY_VERSION_"
+                                   "${VERSION_PART}"
                                    " +([0-9]+)"
         )
 
@@ -57,7 +57,7 @@ if(${UNITY_EXTENSION_MEMORY})
 endif()
 
 # Main target ------------------------------------------------------------------
-add_library(${PROJECT_NAME} STATIC)
+add_library(${PROJECT_NAME})
 add_library(${PROJECT_NAME}::framework ALIAS ${PROJECT_NAME})
 
 # Includes ---------------------------------------------------------------------
@@ -89,12 +89,13 @@ set(${PROJECT_NAME}_PUBLIC_HEADERS
 )
 
 set_target_properties(${PROJECT_NAME}
-    PROPERTIES 
+    PROPERTIES
         C_STANDARD          11
         C_STANDARD_REQUIRED ON
         C_EXTENSIONS        OFF
         PUBLIC_HEADER       "${${PROJECT_NAME}_PUBLIC_HEADERS}"
         EXPORT_NAME         framework
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
 
 target_compile_options(${PROJECT_NAME}
@@ -104,7 +105,7 @@ target_compile_options(${PROJECT_NAME}
             -Wcast-align
             -Wcast-qual
             -Wconversion
-            -Wexit-time-destructors                            
+            -Wexit-time-destructors
             -Wglobal-constructors
             -Wmissing-noreturn
             -Wmissing-prototypes
@@ -116,7 +117,7 @@ target_compile_options(${PROJECT_NAME}
             -Wall
             $<$<VERSION_GREATER_EQUAL:$<C_COMPILER_VERSION>,8.0.0>:-Wextra-semi-stmt>
         >
-        
+
         # GCC
         $<$<C_COMPILER_ID:GNU>:
             -Waddress
@@ -146,7 +147,7 @@ target_compile_options(${PROJECT_NAME}
 
 write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake
     VERSION       ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion 
+    COMPATIBILITY SameMajorVersion
 )
 
 ## Target installation
@@ -154,6 +155,7 @@ install(TARGETS   ${PROJECT_NAME}
     EXPORT        ${PROJECT_NAME}Targets
     ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME       DESTINATION ${CMAKE_INSTALL_BINDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
     COMPONENT     library
 )


### PR DESCRIPTION
So far is only possible to build Unity as static library, but actually it would be nice if was possible to not enforce only static, but enabling both configurations.

This pull request removes the STATIC directive from `add_library` and exports all symbols when building on Windows, only when as shared.

Plus, I added an entire workflow to validate Unity with CMake, building as static and shared library.