### PR TITLE
fix: fixes TEST_PRINTF() expansion error #691

### DIFF
--- a/src/unity.h
+++ b/src/unity.h
@@ -105,7 +105,7 @@ void verifyTest(void);
 #define TEST_MESSAGE(message)                                                                      UnityMessage((message), __LINE__)
 #define TEST_ONLY()
 #ifdef UNITY_INCLUDE_PRINT_FORMATTED
-#define TEST_PRINTF(message, ...)                                                                  UnityPrintF(__LINE__, (message), __VA_ARGS__)
+#define TEST_PRINTF(message, ...)                                                                  UnityPrintF(__LINE__, (message), ##__VA_ARGS__)
 #endif
 
 /* It is not necessary for you to call PASS. A PASS condition is assumed if nothing fails.


### PR DESCRIPTION
fixes TEST_PRINTF() expansion error when no variadic arguments are passed.

I want to use TEST_PRINTF(), so I set `-D UNITY_INCLUDE_PRINT_FORMATTED` in my compilation flags.
I got a compile time error:
```
PS C:\Users\pasca\src\spaiot-lib> pio test -f test_10_controlpanel -v
Collected 11 tests (test_01_blink, test_02_bussettings, test_03_ledsettings, test_04_buttonsettings, test_05_type_name, test_06_hardwaresettings, test_07_multiplexer, test_07_pcf8574mux, test_08_button, test_09_framedecoder, test_10_controlpanel)

Processing test_10_controlpanel in spaiot_shield_s3_4051_debug environment
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Building & Uploading...
In file included from test/spaiot_test.h:4,
                 from test/test_10_controlpanel/main.cpp:5:
test/test_10_controlpanel/main.cpp: In function 'void test_constructor()':
.pio/libdeps/spaiot_shield_s3_4051_debug/Unity/src/unity.h:108:144: error: expected primary-expression before ')' token
 #define TEST_PRINTF(message, ...)                                                                  UnityPrintF(__LINE__, (message), __VA_ARGS__)
                                                                                                                                                ^
test/test_10_controlpanel/main.cpp:43:3: note: in expansion of macro 'TEST_PRINTF'
   TEST_PRINTF ("---> test_constructor <---\n");
   ^~~~~~~~~~~
test/test_10_controlpanel/main.cpp: In function 'void test_getters()':
.pio/libdeps/spaiot_shield_s3_4051_debug/Unity/src/unity.h:108:144: error: expected primary-expression before ')' token
 #define TEST_PRINTF(message, ...)                                                                  UnityPrintF(__LINE__, (message), __VA_ARGS__)
                                                                                                                                                ^
test/test_10_controlpanel/main.cpp:52:3: note: in expansion of macro 'TEST_PRINTF'
   TEST_PRINTF ("---> test_getters <---\n");
   ^~~~~~~~~~~
```
The compiler reports an error after `__VA_ARGS__`.
The problem is that `TEST_PRINTF()` is defined as a variadic macro, but I'm not passing any variadic argument. Sure, i may use `TEST_MESSAGE()` instead, but if someone wants to use `TEST_PRINTF()` it should work.

I read this document: https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html
and I modified the macro `TEST_PRINTF()` in the following way:

```c	
#define TEST_PRINTF(message, ...) UnityPrintF(__LINE__, (message), ##__VA_ARGS__)
```

So everything works:
```
PS C:\Users\pasca\src\spaiot-lib> pio test -f test_10_controlpanel -v
Collected 11 tests (test_01_blink, test_02_bussettings, test_03_ledsettings, test_04_buttonsettings, test_05_type_name, test_06_hardwaresettings, test_07_multiplexer, test_07_pcf8574mux, test_08_button, test_09_framedecoder, test_10_controlpanel)

Processing test_10_controlpanel in spaiot_shield_s3_4051_debug environment
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Building & Uploading...

Testing...
If you don't see any output for the first 10 secs, please reset board (press reset button)

test/test_10_controlpanel/main.cpp:43:test_constructor:INFO: ---> test_constructor <---
test/test_10_controlpanel/main.cpp:287:test_constructor:PASS
test/test_10_controlpanel/main.cpp:50:test_getters:INFO: ---> test_getters <---
test/test_10_controlpanel/main.cpp:288:test_getters:PASS
test/test_10_controlpanel/main.cpp:96:test_begin:INFO: ---> test_begin <---
test/test_10_controlpanel/main.cpp:290:test_begin:PASS
test/test_10_controlpanel/main.cpp:143:test_power_on:INFO: ---> test_power_on <---
test/test_10_controlpanel/main.cpp:150:test_power_on:INFO: Set power on !
test/test_10_controlpanel/main.cpp:293:test_power_on:PASS
test/test_10_controlpanel/main.cpp:216:test_watertemp:INFO: ---> test_watertemp <---
test/test_10_controlpanel/main.cpp:223:test_watertemp:INFO: waterTemp: 20'C (response time 8900 ms)
test/test_10_controlpanel/main.cpp:296:test_watertemp:PASS
test/test_10_controlpanel/main.cpp:229:test_get_desiredtemp:INFO: ---> test_get_desiredtemp <---
test/test_10_controlpanel/main.cpp:237:test_get_desiredtemp:INFO: desiredTemp: 22'C (response time 700 ms)
test/test_10_controlpanel/main.cpp:299:test_get_desiredtemp:PASS
test/test_10_controlpanel/main.cpp:246:test_set_desiredtemp:INFO: ---> test_set_desiredtemp <---
test/test_10_controlpanel/main.cpp:300:test_set_desiredtemp:PASS
test/test_10_controlpanel/main.cpp:156:test_filter:INFO: ---> test_filter <---
test/test_10_controlpanel/main.cpp:164:test_filter:INFO: Set filter on !
test/test_10_controlpanel/main.cpp:168:test_filter:INFO: Set filter off !
test/test_10_controlpanel/main.cpp:303:test_filter:PASS
test/test_10_controlpanel/main.cpp:174:test_bubble:INFO: ---> test_bubble <---
test/test_10_controlpanel/main.cpp:181:test_bubble:INFO: Set bubble on !
test/test_10_controlpanel/main.cpp:185:test_bubble:INFO: Set bubble off !
test/test_10_controlpanel/main.cpp:306:test_bubble:PASS
test/test_10_controlpanel/main.cpp:192:test_heater:INFO: ---> test_heater <---
test/test_10_controlpanel/main.cpp:199:test_heater:INFO: Set heater on !
test/test_10_controlpanel/main.cpp:202:test_heater:INFO: execution time: 300
test/test_10_controlpanel/main.cpp:206:test_heater:INFO: Set heater off !
test/test_10_controlpanel/main.cpp:209:test_heater:INFO: execution time: 300
test/test_10_controlpanel/main.cpp:211:test_heater:INFO: Set filter off !
test/test_10_controlpanel/main.cpp:309:test_heater:PASS
test/test_10_controlpanel/main.cpp:265:test_power_off:INFO: ---> test_power_off <---
test/test_10_controlpanel/main.cpp:267:test_power_off:INFO: Set heater off !
test/test_10_controlpanel/main.cpp:312:test_power_off:PASS

-----------------------
11 Tests 0 Failures 0 Ignored
OK

----------------------------------------------------- spaiot_shield_s3_4051_debug:test_10_controlpanel [PASSED] Took 115.46 seconds ----------------------------------------------------- 

======================================================================================== SUMMARY ======================================================================================== 
Environment                     Test                      Status    Duration
------------------------------  ------------------------  --------  ------------
spaiot_shield_s3_4051_debug     test_10_controlpanel      PASSED    00:01:55.456
====================================================================== 11 test cases: 11 succeeded in 00:01:55.456 ====================================================================== 
```
