### PR TITLE
Use null check instead of pointer comparison

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -1609,8 +1609,8 @@ void UnityAssertEqualString(const char* expected,
         }
     }
     else
-    { /* handle case of one pointers being null (if both null, test should pass) */
-        if (expected != actual)
+    { /* fail if either null but not if both */
+        if (expected || actual)
         {
             Unity.CurrentTestFailed = 1;
         }
@@ -1649,8 +1649,8 @@ void UnityAssertEqualStringLen(const char* expected,
         }
     }
     else
-    { /* handle case of one pointers being null (if both null, test should pass) */
-        if (expected != actual)
+    { /* fail if either null but not if both */
+        if (expected || actual)
         {
             Unity.CurrentTestFailed = 1;
         }


### PR DESCRIPTION
The original code worked for xc8 v1.44, but does not compile with v2.45. I think the compiler failure is correct. In general, from what I understand of the C standard, it's not allowed to compare pointers unless they are to the same array or structure. I don't know how the compiler would know that and don't fully understand the reasoning for the rule, but maybe it's due to segmented memory addressing.

Anyway, the change I made should be logically equivalent; comparing both expected and actual against null rather than comparing them with each other.

Also, the comment above the change line was confusing so I re-wrote it.

This change fixes the issue I added last week, #700 