### PR TITLE
Update generate test runner to leverage custom UNITY_END()

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -450,10 +450,10 @@ class UnityTestRunnerGenerator
       if @options[:omit_begin_end]
         output.puts('  (void) suite_teardown(0);')
       else
-        output.puts('  return suiteTearDown(UnityEnd());')
+        output.puts('  return suiteTearDown(UNITY_END());')
       end
     else
-      output.puts('  return UnityEnd();') unless @options[:omit_begin_end]
+      output.puts('  return UNITY_END();') unless @options[:omit_begin_end]
     end
     output.puts('}')
   end
@@ -529,7 +529,7 @@ if $0 == __FILE__
           '    --suite_setup=""      - code to execute for setup of entire suite',
           '    --suite_teardown=""   - code to execute for teardown of entire suite',
           '    --use_param_tests=1   - enable parameterized tests (disabled by default)',
-          '    --omit_begin_end=1    - omit calls to UnityBegin and UnityEnd (disabled by default)',
+          '    --omit_begin_end=1    - omit calls to UnityBegin and UNITY_END (disabled by default)',
           '    --header_file=""      - path/name of test header file to generate too'].join("\n")
     exit 1
   end


### PR DESCRIPTION
Hi, I am looking to leverage a custom UNITY_END() and still use the test runner generator script.
- Changed reference in `generate_test_runner.rb` from `UnityEnd()` -> `UNITY_END()`

Thanks