### PR TITLE
No calls to assert macros until after UnityConcludeTest clears Curren…

### DIFF
--- a/test/tests/test_unity_core.c
+++ b/test/tests/test_unity_core.c
@@ -296,8 +296,9 @@ void testFailureCountIncrementsAndIsReturnedAtEnd(void)
     Unity.CurrentTestFailed = 1;
     startPutcharSpy(); /* Suppress output */
     startFlushSpy();
-    TEST_ASSERT_EQUAL(0, getFlushSpyCalls());
+    UNITY_UINT savedGetFlushSpyCalls = getFlushSpyCalls();
     UnityConcludeTest();
+    TEST_ASSERT_EQUAL(0, savedGetFlushSpyCalls);
     endPutcharSpy();
     TEST_ASSERT_EQUAL(savedFailures + 1, Unity.TestFailures);
 #if defined(UNITY_OUTPUT_FLUSH) && defined(UNITY_OUTPUT_FLUSH_HEADER_DECLARATION)


### PR DESCRIPTION
This request fixes issue #529 
The current implementation sets CurrentTestFailed and then tries to use TEST_ASSERT_EQUAL. This results is TEST_ABORT as CurrentTestFailed is set.
The change moves the assertion to after the call to UnityConcludeTest, allowing the test to complete correctly