### PR TITLE
Fix shebang placement

### DIFF
--- a/auto/extract_version.py
+++ b/auto/extract_version.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # =========================================================================
 #   Unity - A Test Framework for C
 #   ThrowTheSwitch.org
@@ -5,7 +6,6 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
-#!/usr/bin/env python3
 import re
 import sys
 


### PR DESCRIPTION
671f8d2 introduced a license header to auto/extract_version.py before the shebang, causing builds to fail like this:
`  ../subprojects/unity/meson.build:7:0: ERROR: Failed running '/path/to/extract_version.py', binary or interpreter not executable.`