### PR TITLE
Switch to `#!/usr/bin/env ruby`

### DIFF
--- a/auto/generate_module.rb
+++ b/auto/generate_module.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # =========================================================================
 #   Unity - A Test Framework for C
 #   ThrowTheSwitch.org

--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # =========================================================================
 #   Unity - A Test Framework for C

--- a/auto/parse_output.rb
+++ b/auto/parse_output.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # =========================================================================
 #   Unity - A Test Framework for C
 #   ThrowTheSwitch.org

--- a/auto/stylize_as_junit.rb
+++ b/auto/stylize_as_junit.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # =========================================================================
 #   Unity - A Test Framework for C
 #   ThrowTheSwitch.org
@@ -5,7 +7,6 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
-#!/usr/bin/ruby
 #
 # unity_to_junit.rb
 #

--- a/auto/unity_test_summary.rb
+++ b/auto/unity_test_summary.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # =========================================================================
 #   Unity - A Test Framework for C
 #   ThrowTheSwitch.org
@@ -5,7 +7,6 @@
 #   SPDX-License-Identifier: MIT
 # =========================================================================
 
-# !/usr/bin/ruby
 #
 # unity_test_summary.rb
 #


### PR DESCRIPTION
If, for some reasons, there is no `/usr/bin/ruby` (... Because it is located somewhere else), then auto-generation of tests with `generate_test_runner.rb` (used directly as an executable) fails because of ``#!/usr/bin/ruby`. Thus, I propose to use `#!/usr/bin/env ruby` instead :)


More context for those interested: on a supercomputer, more or less nothing (except the very basic commands) is at its standard location, but rather loaded on the fly using modules ;)