### PR TITLE
Cast line_num to allow compilation with `-WConversion`

### DIFF
--- a/auto/run_test.erb
+++ b/auto/run_test.erb
@@ -2,7 +2,7 @@
 static void run_test(UnityTestFunction func, const char* name, UNITY_LINE_TYPE line_num)
 {
     Unity.CurrentTestName = name;
-    Unity.CurrentTestLineNumber = line_num;
+    Unity.CurrentTestLineNumber = (UNITY_UINT) line_num;
 #ifdef UNITY_USE_COMMAND_LINE_ARGS
     if (!UnityTestMatches())
         return;


### PR DESCRIPTION
I wanted to compile my unit tests with `-WConversion` but it failed with:

```
...
MyRunner_Runner.c:95:35: error: conversion to ‘UNITY_UINT’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Werror=sign-conversion]
   95 |     Unity.CurrentTestLineNumber = line_num;
      |                                   ^~~~~~~~
```

Adding an explicit cast before fixes the problem.