### PR TITLE
Fix build when UNITY_USE_COMMAND_LINE_ARGS is enabled

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -2351,7 +2351,7 @@ int UnityParseOptions(int argc, char** argv)
 }
 
 /*-----------------------------------------------*/
-int IsStringInBiggerString(const char* longstring, const char* shortstring)
+static int IsStringInBiggerString(const char* longstring, const char* shortstring)
 {
     const char* lptr = longstring;
     const char* sptr = shortstring;
@@ -2396,7 +2396,7 @@ int IsStringInBiggerString(const char* longstring, const char* shortstring)
 }
 
 /*-----------------------------------------------*/
-int UnityStringArgumentMatches(const char* str)
+static int UnityStringArgumentMatches(const char* str)
 {
     int retval;
     const char* ptr1;


### PR DESCRIPTION
Turning on UNITY_USE_COMMAND_LINE_ARGS includes some new functions:

- `IsStringInBiggerString`
- `UnityStringArgumentMatches`

These functions don't have prototypes other than where they are defined. Because `-Werror` is enabled, this results in `-Werror=missing-declarations` failing the build.

Because these functions aren't used outside this file, the don't need prototypes and can just be declared static.

All the tests passed for me after this change.

Fixes https://github.com/ThrowTheSwitch/Unity/issues/727
