### PR TITLE
Add changelog entry for `NOT` float/double tests

### DIFF
--- a/docs/UnityChangeLog.md
+++ b/docs/UnityChangeLog.md
@@ -24,6 +24,7 @@ New Features:
   - Add Unity BDD plugin
   - Add `UNITY_INCLUDE_EXEC_TIME` option to report test times
   - Allow user to override test abort underlying mechanism
+  - Add `NOT_EQUAL*` and `NOT_WITHIN*` checks for floats and doubles 
 
 Significant Bugfixes:
 


### PR DESCRIPTION
This adds a changelog entry for `NOT_EQUAL*` and `NOT_WITHIN*` checks for floats and doubles, being from https://github.com/ThrowTheSwitch/Unity/commit/244edf6c1692515936cdb94c68c865299a896e09, a new feature in v2.6.0.