### PR TITLE
Allow user to not print tests that PASS

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -545,25 +545,33 @@ static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line)
 /*-----------------------------------------------*/
 void UnityConcludeTest(void)
 {
+    bool printed_a_line = true;
     if (Unity.CurrentTestIgnored)
     {
         Unity.TestIgnores++;
     }
-    else if (!Unity.CurrentTestFailed)
+    else if (Unity.CurrentTestFailed)
     {
-        UnityTestResultsBegin(Unity.TestFile, Unity.CurrentTestLineNumber);
-        UnityPrint(UnityStrPass);
+        Unity.TestFailures++;
     }
     else
     {
-        Unity.TestFailures++;
+#ifdef UNITY_SUPPRESS_RESULT_SUCCESS
+        printed_a_line = false;
+#else
+        UnityTestResultsBegin(Unity.TestFile, Unity.CurrentTestLineNumber);
+        UnityPrint(UnityStrPass);
+#endif
     }
 
     Unity.CurrentTestFailed = 0;
     Unity.CurrentTestIgnored = 0;
-    UNITY_PRINT_EXEC_TIME();
-    UNITY_PRINT_EOL();
-    UNITY_FLUSH_CALL();
+
+    if (printed_a_line) {
+        UNITY_PRINT_EXEC_TIME();
+        UNITY_PRINT_EOL();
+        UNITY_FLUSH_CALL();
+    }
 }
 
 /*-----------------------------------------------*/


### PR DESCRIPTION
I am working on a project with around 100 unit tests and growing.  Normally all the tests pass, so most of the messages say a test's result is `PASS`.  But when one test fails, it is hard to find which one failed because Unity prints ~100 lines of passing tests now that I have written so many unit tests.

This change allows the user to define `UNITY_SUPPRESS_RESULT_SUCCESS` when compiling to suppress the printing of all the "PASS" messages.