### PR TITLE
Fix failed build with compile flag: -Werror=float-equal (#741)

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -337,10 +337,12 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
     static const int sig_digits = 9;
     static const UNITY_INT32 min_scaled = 100000000;
     static const UNITY_INT32 max_scaled = 1000000000;
+    static const UNITY_DOUBLE epsilon = UNITY_DOUBLE_PRECISION;
 #else
     static const int sig_digits = 7;
     static const UNITY_INT32 min_scaled = 1000000;
     static const UNITY_INT32 max_scaled = 10000000;
+    static const UNITY_DOUBLE epsilon = UNITY_FLOAT_PRECISION;
 #endif
 
     UNITY_DOUBLE number = input_number;
@@ -353,7 +355,7 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
     }
 
     /* handle zero, NaN, and +/- infinity */
-    if (number == 0.0f)
+    if (UNITY_ABS(number) < epsilon)
     {
         UnityPrint("0");
     }
@@ -420,7 +422,7 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
 
 #ifndef UNITY_ROUND_TIES_AWAY_FROM_ZERO
         /* round to even if exactly between two integers */
-        if ((n & 1) && (((UNITY_DOUBLE)n - number) == 0.5f))
+        if ((n & 1) && (UNITY_ABS((UNITY_DOUBLE)n - number - 0.5f) < epsilon))
             n--;
 #endif
 

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -259,8 +259,14 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
 #ifndef UNITY_IS_NAN
 #ifndef isnan
 /* NaN is the only floating point value that does NOT equal itself.
- * Therefore if n != n, then it is NaN. */
-#define UNITY_IS_NAN(n) ((n != n) ? 1 : 0)
+ * Therefore if n != n, then it is NaN.
+ *
+ * Another way to define NaN is to check whether the number belongs
+ * simultaneously to the set of negative and positive numbers, including 0.
+ * Therefore if ((n >= 0) == (n < 0)), then it is NaN.
+ * This implementation will not cause an error with the compilation flag:
+ * -Werror=float-equal */
+#define UNITY_IS_NAN(n) ((((n) >= 0.0f) == ((n) < 0.0f)) ? 1 : 0)
 #else
 #define UNITY_IS_NAN(n) isnan(n)
 #endif
@@ -274,6 +280,11 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
 #else
 #define UNITY_IS_INF(n) isinf(n)
 #endif
+#endif
+
+/* Calculates the absolute value of the given number */
+#ifndef UNITY_ABS
+  #define UNITY_ABS(n) (((n) < 0) ? -(n) : (n))
 #endif
 
 #endif


### PR DESCRIPTION
This is the fix for issue #741.

Briefly, compilation with the `-Werror=float-equal` flag **failed**.

The cause of the errors was the direct comparison of a floating-point number to another number in three places in the source, two of which are listed in the issue #741. The third error location is the implementation of the number check for NaN - `UNITY_IS_NAN(n)`. In fact, a check of the form `n != n` allows us to determine whether a number `n` is a NaN when there is no way to use `isnan()`. In this case, a direct comparison of a floating-point number is acceptable because the number is being compared to itself, but the compiler flag does not make an exception in this case, so the implementation of the NaN check has been changed.

Elsewhere in the code, the value `epsilon` was introduced to solve the problem. `epsilon` is the error by which one number can be equal to another number. This error occurs because of the finite precision of the computer system's representation of real numbers. For this reason, floating point numbers cannot be directly compared using the `==` and `!=` operators. The numerical `epsilon` corresponds to the precision of the representation of floating point numbers, which is determined by the data type (`float` or `double`). 

The presence of the problem was verified as follows:
1. in the `examples/example_1/makefile` I added the line `CFLAGS += -Werror=float-equal`;
2. ran make in the directory `examples/example_1/`;
3. saw that the build failed with the errors described in the issue #741.

After making the changes to the code, I repeated step 2 and checked that there were no more build errors.