### PR TITLE
Fix meson pkg-config generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,7 @@ if not meson.is_subproject()
     name: meson.project_name(),
     version: meson.project_version(),
     libraries: [ unity_lib ],
+    subdirs: 'unity',
     description: 'C Unit testing framework.'
   )
 endif


### PR DESCRIPTION
The pkg-config file does not include the subdir in its build flags, so files will fail to find the Unity headers. Basically the previous file looked like this:

```pkgconfig
prefix=/usr/lib/unity-test-2.6.1
includedir=${prefix}/include
libdir=${prefix}/lib

Name: unity
Description: C Unit testing framework.
Version: 2.6.1
Libs: -L${libdir} -lunity
Cflags: -I${includedir}
```
The new one looks like this
```pkgconf
prefix=/usr/lib/unity-test-2.6.1
includedir=${prefix}/include
libdir=${prefix}/lib

Name: unity
Description: C Unit testing framework.
Version: 2.6.1
Libs: -L${libdir} -lunity
Cflags: -I${includedir}/unity
```
Notice the Cflags variable.