### PR TITLE
meson: Add '@EXTRA_ARGS@' to generate_test_runner arguments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,5 +76,5 @@ endif
 gen_test_runner = generator(
   find_program('auto/generate_test_runner.rb'),
   output: '@BASENAME@_Runner.c',
-  arguments: ['@INPUT@', '@OUTPUT@']
+  arguments: ['@EXTRA_ARGS@', '@INPUT@', '@OUTPUT@']
 )


### PR DESCRIPTION
Extended the argument list in meson generator for the test runner strict by adding '@EXTRA_ARGS@'. This change enables the test runner script to accept additional configuration parameters alongside '@INPUT@' and '@OUTPUT@', increasing its flexibility.