### PR TITLE
Update detail-stack implementation after #784

### DIFF
--- a/examples/example_5/test/TestProductionCode.c
+++ b/examples/example_5/test/TestProductionCode.c
@@ -33,7 +33,7 @@ void test_BitExtractor(void)
 {
   const test_vector_t test_vectors[] = {
     {__LINE__, 7, BIT_DIRECTION_UP, {1,1,1,0,0,0,0,0}},
-    {__LINE__, 7, BIT_DIRECTION_DOWN, {0,0,0,0,0,1,0,1}},
+    {__LINE__, 7, BIT_DIRECTION_DOWN, {0,0,0,0,0,1,0,1}},  /* intentionally wrong to demonstrate detail output */
     {0}
   };
   const test_vector_t* tv;

--- a/src/unity.c
+++ b/src/unity.c
@@ -601,7 +601,11 @@ static void UnityAddMsgIfSpecified(const char* msg)
             if ((label[0] == '#') && (label[1] != 0)) {
                 UnityPrint(label + 2);
                 UNITY_OUTPUT_CHAR(' ');
-                UnityPrintNumberByStyle(Unity.CurrentDetailStackValues[c], label[1]);
+                if ((label[1] & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT) {
+                    UnityPrintIntNumberByStyle((UNITY_INT)Unity.CurrentDetailStackValues[c], label[1]);
+                } else {
+                    UnityPrintUintNumberByStyle((UNITY_UINT)Unity.CurrentDetailStackValues[c], label[1]);
+                }
             } else if (Unity.CurrentDetailStackValues[c] != 0){
                 UnityPrint(label);
                 UNITY_OUTPUT_CHAR(' ');


### PR DESCRIPTION
#784 (which split `UnityPrintNumberByStyle`) was developed in parallel to #775 (which added another use of `UnityPrintNumberByStyle`), so when both were merged, the optional detail-stack no longer worked.

This was noticed by @joukewitteveen [here](https://github.com/ThrowTheSwitch/Unity/pull/775#discussion_r2259832320).

This updates the implementation of the detail-stack.

I considered (re)adding `UnityPrintNumberByStyle` as a wrapper to support either uint or int, but I think that would defeat the point of the split.