### PR TITLE
Remove test file extensions from test suite name

### DIFF
--- a/auto/stylize_as_junit.py
+++ b/auto/stylize_as_junit.py
@@ -8,6 +8,7 @@
 
 import sys
 import os
+import re
 from glob import glob
 import argparse
 
@@ -110,7 +111,7 @@ class UnityTestSummary:
                     self.test_suites[k] = [v]
         ts = []
         for suite_name in self.test_suites:
-            ts.append(TestSuite(suite_name, self.test_suites[suite_name]))
+            ts.append(TestSuite(re.sub(r'\.(testfail|testpass|testResults)$', '', suite_name), self.test_suites[suite_name]))
 
         with open(self.output, 'w') as f:
             TestSuite.to_file(f, ts, prettyprint='True', encoding='utf-8')


### PR DESCRIPTION
## What was done

Avoid test file extensions to show up in the suite name.

Example:
Replacing `<testsuite disabled="0" errors="0" failures="0" name="my_module_tests.testResults" skipped="0" tests="8" time="0">` by `<testsuite disabled="0" errors="0" failures="0" name="my_module_tests" skipped="0" tests="8" time="0">`