### PR TITLE
Add EOL after test message

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -631,6 +631,7 @@ static void UnityAddMsgIfSpecified(const char* msg)
     {
         UnityPrint(UnityStrSpacer);
         UnityPrint(msg);
+        UNITY_PRINT_EOL();
     }
 }
 


### PR DESCRIPTION
If TEST_ASSERT_*_MESSAGE() is used and fails, next message is printed on the same line without EOL. This change should improve the readability of output.