### PR TITLE
Convert C++ comments to ANSI C style

### DIFF
--- a/src/unity.c
+++ b/src/unity.c
@@ -2037,7 +2037,7 @@ static enum UnityLengthModifier UnityLengthModifierGet(const char *pch, int *len
             }
         case 'h':
             {
-                // short and char are converted to int
+                /* short and char are converted to int */
                 length_mod = UNITY_LENGTH_MODIFIER_NONE;
                 if (pch[1] == 'h')
                 {
@@ -2054,7 +2054,7 @@ static enum UnityLengthModifier UnityLengthModifierGet(const char *pch, int *len
         case 't':
         case 'L':
             {
-                // Not supported, but should gobble up the length specifier anyway
+                /* Not supported, but should gobble up the length specifier anyway */
                 length_mod = UNITY_LENGTH_MODIFIER_NONE;
                 *length = 1;
                 break;
@@ -2515,7 +2515,7 @@ static int IsStringInBiggerString(const char* longstring, const char* shortstrin
             }
         }
 
-        // If we didn't match and we're on strict matching, we already know we failed
+        /* If we didn't match and we're on strict matching, we already know we failed */
         if (UnityStrictMatch)
         {
             return 0;


### PR DESCRIPTION
🍍

This PR converts C++ comments (`//`) to ANSI C comments (`/* */`) for better C89 compatibility.

This PR doesn't affect Unity's behavior in any way, no comments were removed, and ANSI C-style comments could already be found throughout the source code.

I am submitting this PR because C++-style comments were causing me compiler warnings during the development of my [dynamic C vector single-header library](https://github.com/RolandMarchand/vector.h).

```
[  7%] Building C object test/unity/CMakeFiles/unity.dir/unity.c.o
/home/roland/Programming/c/vector/test/unity/unity.c:1940:17: warning: C++ style comments are not allowed in ISO C90
 1940 |                 // short and char are converted to int
      |                 ^
/home/roland/Programming/c/vector/test/unity/unity.c:1940:17: note: (this will be reported only once per input file)
```