### PR TITLE
Add missing NOT_EQUAL variants for strings

### DIFF
--- a/docs/UnityAssertionsReference.md
+++ b/docs/UnityAssertionsReference.md
@@ -420,18 +420,40 @@ of 7 - 13.
 
 Asserts that the pointers point to the same memory location.
 
+#### `TEST_ASSERT_NOT_EQUAL_PTR (expected, actual)`
+
+Asserts that the pointers DO NOT point to the same memory location.
+
 #### `TEST_ASSERT_EQUAL_STRING (expected, actual)`
 
-Asserts that the null terminated (`’\0’`)strings are identical. If strings are
+Asserts that the null terminated (`’\0’`) strings are identical. If strings are
 of different lengths or any portion of the strings before their terminators
 differ, the assertion fails. Two NULL strings (i.e. zero length) are considered
 equivalent.
+
+#### `TEST_ASSERT_NOT_EQUAL_STRING (expected, actual)`
+
+Asserts that the null terminated (`’\0’`) strings are NOT identical.
+
+#### `TEST_ASSERT_EQUAL_STRING_LEN (expected, actual, len)`
+
+Asserts that the null terminated (`’\0’`) strings are identical up to the specified length.
+It checks only the first `len` characters, not the entire string.
+
+#### `TEST_ASSERT_NOT_EQUAL_STRING_LEN (expected, actual, len)`
+
+Asserts that the null terminated (`’\0’`) strings are NOT identical up to the specified length.
 
 #### `TEST_ASSERT_EQUAL_MEMORY (expected, actual, len)`
 
 Asserts that the contents of the memory specified by the `expected` and `actual`
 pointers is identical. The size of the memory blocks in bytes is specified by
 the `len` parameter.
+
+#### `TEST_ASSERT_NOT_EQUAL_MEMORY (expected, actual, len)`
+
+Asserts that the contents of the memory specified by the `expected` and `actual`
+pointers is NOT identical.
 
 ### Arrays
 

--- a/src/unity.c
+++ b/src/unity.c
@@ -1850,6 +1850,179 @@ void UnityAssertEqualStringArray(UNITY_INTERNAL_PTR expected,
 }
 
 /*-----------------------------------------------*/
+void UnityAssertNotEqualString(const char* expected,
+                               const char* actual,
+                               const char* msg,
+                               const UNITY_LINE_TYPE lineNumber)
+{
+    UNITY_UINT32 i;
+    
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    /* If both pointers are null or same pointer, they are equal (FAIL) */
+    if (expected == actual)
+    {
+        Unity.CurrentTestFailed = 1;
+    }
+    /* If only one is null, they are not equal (PASS) */
+    else if ((expected == NULL) || (actual == NULL))
+    {
+        return;
+    }
+    else
+    {
+        for (i = 0; expected[i] || actual[i]; i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                return; /* Strings are different (PASS) */
+            }
+        }
+
+        /* Strings are equal (FAIL) */
+        Unity.CurrentTestFailed = 1;
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+
+        if (msg)
+        {
+            UnityAddMsgIfSpecified(msg);
+        }
+        else
+        {
+            UnityPrint(" Expected strings to be different");
+        }
+
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertNotEqualStringLen(const char* expected,
+                                  const char* actual,
+                                  const UNITY_UINT32 length,
+                                  const char* msg,
+                                  const UNITY_LINE_TYPE lineNumber)
+{
+    UNITY_UINT32 i;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (length == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    /* If both pointers are same (including both NULL), they are equal (FAIL) */
+    if (expected == actual)
+    {
+        Unity.CurrentTestFailed = 1;
+    }
+    /* If only one is null, they are not equal (PASS) */
+    else if ((expected == NULL) || (actual == NULL))
+    {
+        return;
+    }
+    else
+    {
+        for (i = 0; (i < length) && (expected[i] || actual[i]); i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                return; /* Strings are different (PASS) */
+            }
+        }
+
+        /* Strings are equal within length (FAIL) */
+        Unity.CurrentTestFailed = 1;
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrintExpectedAndActualStringsLen(expected, actual, length);
+
+        if (msg)
+        {
+            UnityAddMsgIfSpecified(msg);
+        }
+        else
+        {
+            UnityPrint(" Expected strings to be different");
+        }
+        
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertNotEqualMemory(UNITY_INTERNAL_PTR expected,
+                               UNITY_INTERNAL_PTR actual,
+                               const UNITY_UINT32 length,
+                               const char* msg,
+                               const UNITY_LINE_TYPE lineNumber)
+{
+    UNITY_PTR_ATTRIBUTE const unsigned char* ptr_exp = (UNITY_PTR_ATTRIBUTE const unsigned char*)expected;
+    UNITY_PTR_ATTRIBUTE const unsigned char* ptr_act = (UNITY_PTR_ATTRIBUTE const unsigned char*)actual;
+    UNITY_UINT32 bytes;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (length == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        /* Both are NULL or same pointer (FAIL) */
+        Unity.CurrentTestFailed = 1;
+    }
+    else if (expected == NULL || actual == NULL)
+    {
+        /* One is NULL and other is not (PASS) */
+        return;
+    }
+    else
+    {
+        bytes = length;
+        while (bytes--)
+        {
+            if (*ptr_exp != *ptr_act)
+            {
+                return; /* Memory is different (PASS) */
+            }
+            ptr_exp++;
+            ptr_act++;
+        }
+
+        /* Memory is equal (PASS) */
+        Unity.CurrentTestFailed = 1;
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrMemory);
+
+        if (msg)
+        {
+            UnityAddMsgIfSpecified(msg);
+        }
+        else
+        {
+            UnityPrint(" Expected memory to be different");
+        }
+
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
 void UnityAssertEqualMemory(UNITY_INTERNAL_PTR expected,
                             UNITY_INTERNAL_PTR actual,
                             const UNITY_UINT32 length,

--- a/src/unity.h
+++ b/src/unity.h
@@ -302,6 +302,12 @@ void verifyTest(void);
 #define TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len)                                        UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)                                            UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, NULL)
 
+/* Structs and Strings Not Equal To */
+#define TEST_ASSERT_NOT_EQUAL_PTR(expected, actual)                                                UNITY_TEST_ASSERT_NOT_EQUAL_PTR((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_STRING(expected, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_STRING((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_STRING_LEN(expected, actual, len)                                    UNITY_TEST_ASSERT_NOT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_MEMORY(expected, actual, len)                                        UNITY_TEST_ASSERT_NOT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, NULL)
+
 /* Arrays */
 #define TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_INT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
 #define TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
@@ -584,6 +590,12 @@ void verifyTest(void);
 #define TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_STRING((expected), (actual), __LINE__, (message))
 #define TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                       UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, (message))
 #define TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                           UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, (message))
+
+/* Structs and Strings Not Equal To */
+#define TEST_ASSERT_NOT_EQUAL_PTR_MESSAGE(expected, actual, message)                               UNITY_TEST_ASSERT_NOT_EQUAL_PTR((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_STRING_MESSAGE(expected, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_STRING((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                   UNITY_TEST_ASSERT_NOT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                       UNITY_TEST_ASSERT_NOT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, (message))
 
 /* Arrays */
 #define TEST_ASSERT_EQUAL_INT_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_INT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -718,6 +718,17 @@ void UnityAssertEqualStringLen(const char* expected,
                             const char* msg,
                             const UNITY_LINE_TYPE lineNumber);
 
+void UnityAssertNotEqualString(const char* expected,
+                               const char* actual,
+                               const char* msg,
+                               const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertNotEqualStringLen(const char* expected,
+                                  const char* actual,
+                                  const UNITY_UINT32 length,
+                                  const char* msg,
+                                  const UNITY_LINE_TYPE lineNumber);
+
 void UnityAssertEqualStringArray( UNITY_INTERNAL_PTR expected,
                                   const char** actual,
                                   const UNITY_UINT32 num_elements,
@@ -732,6 +743,12 @@ void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
                              const char* msg,
                              const UNITY_LINE_TYPE lineNumber,
                              const UNITY_FLAGS_T flags);
+
+void UnityAssertNotEqualMemory(UNITY_INTERNAL_PTR expected,
+                               UNITY_INTERNAL_PTR actual,
+                               const UNITY_UINT32 length,
+                               const char* msg,
+                               const UNITY_LINE_TYPE lineNumber);
 
 void UnityAssertIntNumbersWithin(const UNITY_UINT delta,
                                  const UNITY_INT expected,
@@ -1084,6 +1101,11 @@ int UnityTestMatches(void);
 #define UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, line, message)                          UnityAssertEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)(line))
 #define UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, line, message)                 UnityAssertEqualStringLen((const char*)(expected), (const char*)(actual), (UNITY_UINT32)(len), (message), (UNITY_LINE_TYPE)(line))
 #define UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, line, message)                     UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), 1, (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+
+#define UNITY_TEST_ASSERT_NOT_EQUAL_PTR(expected, actual, line, message)                         UnityAssertIntGreaterOrLessOrEqualNumber((UNITY_PTR_TO_INT)(expected), (UNITY_PTR_TO_INT)(actual), UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_STRING(expected, actual, line, message)                      UnityAssertNotEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_NOT_EQUAL_STRING_LEN(expected, actual, len, line, message)             UnityAssertNotEqualStringLen((const char*)(expected), (const char*)(actual), (UNITY_UINT32)(len), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_NOT_EQUAL_MEMORY(expected, actual, len, line, message)                 UnityAssertNotEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), (message), (UNITY_LINE_TYPE)(line))
 
 #define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT,     UNITY_ARRAY_TO_ARRAY)
 #define UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8,    UNITY_ARRAY_TO_ARRAY)


### PR DESCRIPTION
Closes #811 

Added:

- `TEST_ASSERT_NOT_EQUAL_PTR`
- `TEST_ASSERT_NOT_EQUAL_STRING`
- `TEST_ASSERT_NOT_EQUAL_STRING_LEN`
- `TEST_ASSERT_NOT_EQUAL_MEMORY`
- `TEST_ASSERT_NOT_EQUAL_PTR_MESSAGE`
- `TEST_ASSERT_NOT_EQUAL_STRING_MESSAGE`
- `TEST_ASSERT_NOT_EQUAL_STRING_LEN_MESSAGE`
- `TEST_ASSERT_NOT_EQUAL_MEMORY_MESSAGE`

Also added missing documentation for  `TEST_ASSERT_EQUAL_STRING_LEN (expected, actual, len)`