### PR TITLE
Enable Bazel test filtering in Unity command-line args

### DIFF
--- a/docs/UnityChangeLog.md
+++ b/docs/UnityChangeLog.md
@@ -18,6 +18,7 @@ Prior to 2008, the project was an internal project and not released to the publi
 New Features:
   
   - Add `-n` comand line option as strict matcher again
+  - Support `TESTBRIDGE_TEST_ONLY` for Bazel `--test_filter` when `UNITY_USE_COMMAND_LINE_ARGS` is enabled
 
 Significant Bugfixes:
 

--- a/docs/UnityHelperScriptsGuide.md
+++ b/docs/UnityHelperScriptsGuide.md
@@ -233,8 +233,6 @@ These are the available options:
 
 Unity also supports the `TESTBRIDGE_TEST_ONLY` environment variable (used by
 Bazel's `--test_filter`) when `UNITY_USE_COMMAND_LINE_ARGS` is enabled.
-If you prefer to avoid including `<stdlib.h>`, define `UNITY_GETENV` to your
-own `getenv`-compatible function (for example, via `unity_config.h`).
 
 ##### `:setup_name`
 
@@ -382,11 +380,11 @@ tests/test_unity_parameterizedDemo.c:14:test_demoParamFunction(4, 6, 30):PASS
 
 As we can see:
 
-| Parameter | Format | Possible values | Total of values | Format number |
-|---|---|---|---|---|
-| `a` | `[3, 4, 1]` | `3`, `4` | 2 | Format 1 |
-| `b` | `[10, 5, -2]` | `10`, `8`, `6` | 3 | Format 1, negative step, end number is not included |
-| `c` | `<30, 31, 1>` | `30` | 1 | Format 2 |
+| Parameter | Format        | Possible values | Total of values | Format number                                       |
+| --------- | ------------- | --------------- | --------------- | --------------------------------------------------- |
+| `a`       | `[3, 4, 1]`   | `3`, `4`        | 2               | Format 1                                            |
+| `b`       | `[10, 5, -2]` | `10`, `8`, `6`  | 3               | Format 1, negative step, end number is not included |
+| `c`       | `<30, 31, 1>` | `30`            | 1               | Format 2                                            |
 
 _Note_, that format 2 also supports negative step.
 
@@ -453,11 +451,11 @@ tests/test_unity_parameterizedDemo.c:18:test_demoParamFunction(7, 1, 20.0f):PASS
 
 As we can see:
 
-| Parameter | Format | Count of values |
-|---|---|---|
-| `a` | `[3, 4, 7]` | 3 |
-| `b` | `[10, 8, 2, 1]` | 4 |
-| `c` | `[30u, 20.0f]` | 2 |
+| Parameter | Format          | Count of values |
+| --------- | --------------- | --------------- |
+| `a`       | `[3, 4, 7]`     | 3               |
+| `b`       | `[10, 8, 2, 1]` | 4               |
+| `c`       | `[30u, 20.0f]`  | 2               |
 
 We totally have 3 * 4 * 2 = 24 equal test cases, that can be written as following:
 

--- a/docs/UnityHelperScriptsGuide.md
+++ b/docs/UnityHelperScriptsGuide.md
@@ -231,6 +231,11 @@ These are the available options:
 | `-v`      | increase Verbosity                                |
 | `-x NAME` | eXclude tests whose name includes NAME            |
 
+Unity also supports the `TESTBRIDGE_TEST_ONLY` environment variable (used by
+Bazel's `--test_filter`) when `UNITY_USE_COMMAND_LINE_ARGS` is enabled.
+If you prefer to avoid including `<stdlib.h>`, define `UNITY_GETENV` to your
+own `getenv`-compatible function (for example, via `unity_config.h`).
+
 ##### `:setup_name`
 
 Override the default test `setUp` function name.

--- a/src/unity.c
+++ b/src/unity.c
@@ -2413,9 +2413,21 @@ int UnityStrictMatch          = 0;
 int UnityParseOptions(int argc, char** argv)
 {
     int i;
+    const char* testbridge_filter = NULL;
     UnityOptionIncludeNamed = NULL;
     UnityOptionExcludeNamed = NULL;
     UnityStrictMatch = 0;
+
+#ifndef UNITY_GETENV
+/*Allow Bazel test filtering via TESTBRIDGE_TEST_ONLY*/
+extern char* getenv(const char* name);
+#define UNITY_GETENV(name) getenv(name)
+#endif
+    testbridge_filter = UNITY_GETENV("TESTBRIDGE_TEST_ONLY");
+    if (testbridge_filter && testbridge_filter[0] != 0)
+    {
+        UnityOptionIncludeNamed = (char*)testbridge_filter;
+    }
 
     for (i = 1; i < argc; i++)
     {

--- a/src/unity.c
+++ b/src/unity.c
@@ -2404,7 +2404,7 @@ void UnityPopDetail(UNITY_DETAIL_LABEL_TYPE label, UNITY_DETAIL_VALUE_TYPE value
  *-----------------------------------------------*/
 #ifdef UNITY_USE_COMMAND_LINE_ARGS
 
-char* UnityOptionIncludeNamed = NULL;
+const char* UnityOptionIncludeNamed = NULL;
 char* UnityOptionExcludeNamed = NULL;
 int UnityVerbosity            = 1;
 int UnityStrictMatch          = 0;
@@ -2426,7 +2426,7 @@ extern char* getenv(const char* name);
     testbridge_filter = UNITY_GETENV("TESTBRIDGE_TEST_ONLY");
     if (testbridge_filter && testbridge_filter[0] != 0)
     {
-        UnityOptionIncludeNamed = (char*)testbridge_filter;
+        UnityOptionIncludeNamed = testbridge_filter;
     }
 
     for (i = 1; i < argc; i++)

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,6 +22,7 @@ CFLAGS += -Wbad-function-cast -Wcast-qual -Wold-style-definition -Wshadow -Wstri
 CFLAGS += $(DEBUG)
 UNITY_SUPPORT_64 = -D UNITY_SUPPORT_64
 UNITY_INCLUDE_DOUBLE = -D UNITY_INCLUDE_DOUBLE
+UNITY_USE_COMMAND_LINE_ARGS = -D UNITY_USE_COMMAND_LINE_ARGS
 DEFINES =  -D UNITY_OUTPUT_CHAR=putcharSpy
 DEFINES += -D UNITY_OUTPUT_CHAR_HEADER_DECLARATION=putcharSpy\(int\)
 DEFINES += -D UNITY_OUTPUT_FLUSH=flushSpy
@@ -53,7 +54,7 @@ coverage: $(SRC1) $(SRC2) $(SRC3) $(SRC4) $(SRC5) $(SRC6) $(SRC7) $(SRC8)
 	gcov unity.c | head -3
 	grep '###' $(BUILD_DIR)/unity.c.gcov -C2 || true
 	cd $(BUILD_DIR) && \
-	$(CC) $(CFLAGS) $(DEFINES) $(foreach i,$(SRC2), ../$i) $(COV_FLAGS) -o ../$(TARGET)
+	$(CC) $(CFLAGS) $(DEFINES) $(UNITY_USE_COMMAND_LINE_ARGS) $(foreach i,$(SRC2), ../$i) $(COV_FLAGS) -o ../$(TARGET)
 	rm -f $(BUILD_DIR)/*.gcda
 	./$(TARGET) | grep 'Tests\|]]]' -A1
 	cd $(BUILD_DIR) && \
@@ -105,7 +106,7 @@ coverage: $(SRC1) $(SRC2) $(SRC3) $(SRC4) $(SRC5) $(SRC6) $(SRC7) $(SRC8)
 test: $(SRC1) $(SRC2) $(SRC3) $(SRC4) $(SRC5) $(SRC6) $(SRC7) $(SRC8)
 	$(CC) $(CFLAGS) $(DEFINES) $(INC_DIR) $(SRC1) -o $(TARGET)
 	./$(TARGET)
-	$(CC) $(CFLAGS) $(DEFINES) $(INC_DIR) $(SRC2) -o $(TARGET)
+	$(CC) $(CFLAGS) $(DEFINES) $(UNITY_USE_COMMAND_LINE_ARGS) $(INC_DIR) $(SRC2) -o $(TARGET)
 	./$(TARGET)
 	$(CC) $(CFLAGS) $(DEFINES) $(INC_DIR) $(SRC3) -o $(TARGET)
 	./$(TARGET)

--- a/test/rakefile_helper.rb
+++ b/test/rakefile_helper.rb
@@ -310,7 +310,7 @@ module RakefileHelpers
 
       report "\nRunning Tests in #{test}"
       obj_list = []
-      test_defines = []
+      test_defines = File.basename(test) == 'test_unity_core.c' ? ['UNITY_USE_COMMAND_LINE_ARGS'] : []
 
       # Detect dependencies and build required modules
       extract_headers(test).each do |header|

--- a/test/tests/test_unity_core.c
+++ b/test/tests/test_unity_core.c
@@ -6,6 +6,10 @@
 ========================================================================= */
 
 #include "unity.h"
+#ifdef UNITY_USE_COMMAND_LINE_ARGS
+#include "unity_internals.h"
+#include <stdlib.h>
+#endif
 #define TEST_INSTANCES
 #include "self_assessment_utils.h"
 
@@ -188,6 +192,67 @@ void testFail(void)
     TEST_FAIL_MESSAGE("Expected for testing");
     VERIFY_FAILS_END
 }
+
+#ifdef UNITY_USE_COMMAND_LINE_ARGS
+static void UnitySetTestbridgeFilter(const char* value)
+{
+#if defined(_WIN32) || defined(_MSC_VER)
+    if (value)
+    {
+        _putenv_s("TESTBRIDGE_TEST_ONLY", value);
+    }
+    else
+    {
+        _putenv_s("TESTBRIDGE_TEST_ONLY", "");
+    }
+#else
+    if (value)
+    {
+        setenv("TESTBRIDGE_TEST_ONLY", value, 1);
+    }
+    else
+    {
+        unsetenv("TESTBRIDGE_TEST_ONLY");
+    }
+#endif
+}
+
+static void UnitySetTestContext(const char* testfile, const char* testname)
+{
+    Unity.TestFile = testfile;
+    Unity.CurrentTestName = testname;
+}
+
+void testUnityParseOptionsUsesTestbridgeFilter(void)
+{
+    char* argv[] = { (char*)"prog", NULL };
+
+    UnitySetTestbridgeFilter("test_my_function");
+    UnityParseOptions(1, argv);
+
+    UnitySetTestContext("file.c", "test_my_function");
+    TEST_ASSERT_TRUE(UnityTestMatches());
+    UnitySetTestContext("file.c", "other");
+    TEST_ASSERT_FALSE(UnityTestMatches());
+
+    UnitySetTestbridgeFilter(NULL);
+}
+
+void testUnityParseOptionsArgsOverrideTestbridgeFilter(void)
+{
+    char* argv[] = { (char*)"prog", (char*)"-n", (char*)"other", NULL };
+
+    UnitySetTestbridgeFilter("test_my_function");
+    UnityParseOptions(3, argv);
+
+    UnitySetTestContext("file.c", "other");
+    TEST_ASSERT_TRUE(UnityTestMatches());
+    UnitySetTestContext("file.c", "test_my_function");
+    TEST_ASSERT_FALSE(UnityTestMatches());
+
+    UnitySetTestbridgeFilter(NULL);
+}
+#endif
 
 void testIsNull(void)
 {

--- a/test/tests/test_unity_core.c
+++ b/test/tests/test_unity_core.c
@@ -5,6 +5,10 @@
     SPDX-License-Identifier: MIT
 ========================================================================= */
 
+#if defined(UNITY_USE_COMMAND_LINE_ARGS) && !defined(_WIN32) && !defined(_MSC_VER) && !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200112L
+#endif
+
 #include "unity.h"
 #ifdef UNITY_USE_COMMAND_LINE_ARGS
 #include "unity_internals.h"
@@ -226,6 +230,8 @@ static void UnitySetTestContext(const char* testfile, const char* testname)
 void testUnityParseOptionsUsesTestbridgeFilter(void)
 {
     char* argv[] = { (char*)"prog", NULL };
+    const char* testfile = Unity.TestFile;
+    const char* testname = Unity.CurrentTestName;
 
     UnitySetTestbridgeFilter("test_my_function");
     UnityParseOptions(1, argv);
@@ -236,11 +242,15 @@ void testUnityParseOptionsUsesTestbridgeFilter(void)
     TEST_ASSERT_FALSE(UnityTestMatches());
 
     UnitySetTestbridgeFilter(NULL);
+    UnityParseOptions(1, argv);
+    UnitySetTestContext(testfile, testname);
 }
 
 void testUnityParseOptionsArgsOverrideTestbridgeFilter(void)
 {
     char* argv[] = { (char*)"prog", (char*)"-n", (char*)"other", NULL };
+    const char* testfile = Unity.TestFile;
+    const char* testname = Unity.CurrentTestName;
 
     UnitySetTestbridgeFilter("test_my_function");
     UnityParseOptions(3, argv);
@@ -251,6 +261,8 @@ void testUnityParseOptionsArgsOverrideTestbridgeFilter(void)
     TEST_ASSERT_FALSE(UnityTestMatches());
 
     UnitySetTestbridgeFilter(NULL);
+    UnityParseOptions(1, argv);
+    UnitySetTestContext(testfile, testname);
 }
 #endif
 


### PR DESCRIPTION
:pineapple:

## Summary
Add Bazel test filtering support via TESTBRIDGE_TEST_ONLY when UNITY_USE_COMMAND_LINE_ARGS is enabled, plus core tests and docs.

## Why
Bazel’s --test_filter sets TESTBRIDGE_TEST_ONLY. Unity previously ignored this, so single‑test runs were not possible.

## What Changed
Support TESTBRIDGE_TEST_ONLY in UnityParseOptions
Add Unity core tests for env‑based filtering and CLI override
Document new behavior and note UNITY_GETENV override option
Update UnityChangeLog.md

## Notes
Requires UNITY_USE_COMMAND_LINE_ARGS