### PR TITLE
meson: allow passing arguments to `generate_test_runner.rb`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -84,5 +84,5 @@ endif
 gen_test_runner = generator(
   find_program('auto/generate_test_runner.rb'),
   output: '@BASENAME@_Runner.c',
-  arguments: ['@INPUT@', '@OUTPUT@']
+  arguments: ['@INPUT@', '@EXTRA_ARGS@', '@OUTPUT@']
 )


### PR DESCRIPTION
This change enables a user to configure the test generation, e.g. enable parametrized tests like so:

```meson
gen_test_runner.process(
      'test_platform.c' , extra_args: ['--use_param_tests=1']
```

This feature is documented [here](https://mesonbuild.com/Reference-manual_returned_generator.html#generatorprocess) in the meson documentation.

Btw. thanks for the great library. :) 