### PR TITLE
meson: restore extension_memory as feature (fixes #829)

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('extension_fixture', type: 'boolean', value: false, description: 'Whether to enable the fixture extension.')
-option('extension_memory', type: 'boolean', value: false, description: 'Whether to enable the memory extension.')
+option('extension_memory', type: 'feature', value: 'auto', description: 'Whether to enable the memory extension. By default this is automatically enabled when extension_fixture is enabled.')
 option('support_double', type: 'boolean', value: false, description: 'Whether to enable double precision floating point assertions.')
 option('support_int64', type: 'boolean', value: false, description: 'Whether to enable support for 64bit integers. false means autodetect.')
 option('fixture_help_message', type: 'string', description: 'If the fixture extension is enabled, this allows a custom help message to be defined.')


### PR DESCRIPTION
Fixes #829.

### The bug

`meson setup` fails on current master:

```
meson.build:45:16: ERROR: Unknown method "enabled" in object
<[BooleanHolder] holds [bool]: False> of type BooleanHolder.
```

### Root cause

Commit `29451d6c` changed `extension_memory` from `type: 'feature'` to
`type: 'boolean'` - but that branch was PR #764 ("Fix: update meson options
to avoid deprecation warnings"), whose actual diff just removed quotes from
boolean values (Meson 1.1 deprecation fix). The PR branch was based on an
older master where `extension_memory` was still boolean. When the PR was
merged into master (commit `6502a671`), the conflict resolution kept the
PR's stale `boolean` version instead of master's current `feature` version.

`meson.build` still calls `build_memory.enabled()` and `build_memory.auto()`,
which are feature-option methods; on a boolean option they don't exist.

### The fix

Restore extension_memory to its feature type in `meson_options.txt`:

```diff
-option('extension_memory', type: 'boolean', value: false, description: 'Whether to enable the memory extension.')
+option('extension_memory', type: 'feature', value: 'auto', description: 'Whether to enable the memory extension. By default this is automatically enabled when extension_fixture is enabled.')
```

`meson.build` is UNCHANGED - its use of `enabled()` and `auto()` is
correct for a feature option and preserves the original "memory extension
automatically enabled when fixture is enabled" semantic.

### Verification

```
meson setup build                        # OK (pre-fix: ERROR)
meson configure build -Dextension_memory=enabled  # OK
ninja -C build                           # builds libunity.a + memory
```

Dropping the fix (`git stash`) reproduces the original error verbatim.

### No user-facing change

Users who were explicitly passing `-Dextension_memory=false` can now use
`-Dextension_memory=disabled` (feature semantic). The default ('auto')
matches the pre-breakage default, so unconfigured builds are unchanged.

(Credit to the issue reporter for diagnosing the accidental type change.)