### PR TITLE
Add UNITY_OUTPUT_START/COMPLETE_HEADER_DECLARATION macros (closes #799).

### DIFF
--- a/examples/unity_config.h
+++ b/examples/unity_config.h
@@ -228,8 +228,10 @@
 /* #define UNITY_OUTPUT_CHAR_HEADER_DECLARATION    RS232_putc(int) */
 /* #define UNITY_OUTPUT_FLUSH()                    RS232_flush() */
 /* #define UNITY_OUTPUT_FLUSH_HEADER_DECLARATION   RS232_flush(void) */
-/* #define UNITY_OUTPUT_START()                    RS232_config(115200,1,8,0) */
-/* #define UNITY_OUTPUT_COMPLETE()                 RS232_close() */
+/* #define UNITY_OUTPUT_START()                       RS232_config(115200,1,8,0) */
+/* #define UNITY_OUTPUT_START_HEADER_DECLARATION       RS232_config(int,int,int,int) */
+/* #define UNITY_OUTPUT_COMPLETE()                    RS232_close() */
+/* #define UNITY_OUTPUT_COMPLETE_HEADER_DECLARATION    RS232_close(void) */
 
 /* Some compilers require a custom attribute to be assigned to pointers, like
  * `near` or `far`. In these cases, you can give Unity a safe default for these

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -363,10 +363,20 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
 
 #ifndef UNITY_OUTPUT_START
 #define UNITY_OUTPUT_START()
+#else
+  /* If defined as something else, make sure we declare it here so it's ready for use */
+  #ifdef UNITY_OUTPUT_START_HEADER_DECLARATION
+    extern void UNITY_OUTPUT_START_HEADER_DECLARATION;
+  #endif
 #endif
 
 #ifndef UNITY_OUTPUT_COMPLETE
 #define UNITY_OUTPUT_COMPLETE()
+#else
+  /* If defined as something else, make sure we declare it here so it's ready for use */
+  #ifdef UNITY_OUTPUT_COMPLETE_HEADER_DECLARATION
+    extern void UNITY_OUTPUT_COMPLETE_HEADER_DECLARATION;
+  #endif
 #endif
 
 #ifdef UNITY_INCLUDE_EXEC_TIME


### PR DESCRIPTION
Closes #799.

### The gap

`UNITY_OUTPUT_CHAR` and `UNITY_OUTPUT_FLUSH` each have a `*_HEADER_DECLARATION` companion macro so users can override the output hook with their own function and have Unity emit the matching `extern` prototype automatically (see `src/unity_internals.h:333-335` and `:349-351`).

`UNITY_OUTPUT_START` and `UNITY_OUTPUT_COMPLETE` only had the override macro — no `_HEADER_DECLARATION` companion. A user wanting to install init / deinit hooks (e.g. serial-port open + close, RTT/JTAG bring-up, Segger RTT setup as reported by @MaxFlatline in #799) had no Unity-sanctioned way to declare the function prototype, so they had to either declare it ahead of including Unity or fork the project.

### The fix

Mirror the FLUSH pattern verbatim for both START and COMPLETE in `src/unity_internals.h`:

```diff
 #ifndef UNITY_OUTPUT_START
 #define UNITY_OUTPUT_START()
+#else
+  /* If defined as something else, make sure we declare it here so it's ready for use */
+  #ifdef UNITY_OUTPUT_START_HEADER_DECLARATION
+    extern void UNITY_OUTPUT_START_HEADER_DECLARATION;
+  #endif
 #endif
```

…and the same for `UNITY_OUTPUT_COMPLETE`.

Add the matching commented-out documentation lines to `examples/unity_config.h` so users discover the new option in the same place they discover the CHAR/FLUSH variants.

### Scope

Strictly additive. The new code path is gated by `#ifdef UNITY_OUTPUT_START_HEADER_DECLARATION` (or `_COMPLETE_…`), so:

- Users who haven't defined the new macro see zero behavioural difference.
- Users who haven't defined `UNITY_OUTPUT_START` / `_COMPLETE` see zero behavioural difference (the existing `#ifndef … #define … #endif` paths are unchanged).
- The new prototype is only emitted when the user has explicitly opted in to *both* the override and the declaration, matching the existing CHAR/FLUSH contract.

### Files touched

- `src/unity_internals.h` — 10 lines added (the two `#else / #ifdef / extern / #endif` blocks).
- `examples/unity_config.h` — 2 lines added (the new commented documentation entries).

### Why no tests

The existing CHAR/FLUSH `_HEADER_DECLARATION` macros are exercised by the test suite via the spy infrastructure in `test/tests/self_assessment_utils.h` (`startPutcharSpy / startFlushSpy / getFlushSpyCalls`) wired through `test/Makefile:25-28`. Adding equivalent spy infrastructure for START/COMPLETE would mean new spy globals + enable/disable helpers + test cases that exercise `UnityBegin` / `UnityEnd` — significantly larger scope than the missing-declaration gap this PR fills. Happy to follow up with a spy + test PR if you'd like that as a separate change.

### Why no doc-guide update

The existing `docs/UnityConfigurationGuide.md` documents the override macros (`UNITY_OUTPUT_CHAR/FLUSH/START/COMPLETE`) but does **not** currently document the `_HEADER_DECLARATION` companions for any of them — the declaration variants live exclusively in `examples/unity_config.h` and `src/unity_internals.h`. To stay symmetric with the existing pattern, this PR leaves the user guide untouched. Again, happy to add a separate docs PR if you'd prefer the guide to surface this feature.

### Credit

Thanks to @MaxFlatline for filing #799 and giving the exact context (Segger RTT init/deinit hooks).
