### PR TITLE
Fix custom suite teardown with omitted begin/end

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -533,7 +533,7 @@ class UnityTestRunnerGenerator
     output.puts('  CMock_Guts_MemFreeFinal();') unless used_mocks.empty?
     if @options[:has_suite_teardown]
       if @options[:omit_begin_end]
-        output.puts('  (void) suite_teardown(0);')
+        output.puts('  (void) suiteTearDown(0);')
       else
         output.puts('  return suiteTearDown(UNITY_END());')
       end

--- a/docs/UnityChangeLog.md
+++ b/docs/UnityChangeLog.md
@@ -30,6 +30,7 @@ Significant Bugfixes:
   - display of failures fixed on ARM processors, particularly with arrays (#807)
   - fixed each-equal assertion for memory (#797)
   - fix many warnings.
+  - Test runner generator calls custom suite teardown when begin/end calls are omitted. @94xhn
 
 Other:
 

--- a/test/tests/test_generate_test_runner.rb
+++ b/test/tests/test_generate_test_runner.rb
@@ -1303,6 +1303,26 @@ def verify_number(expected, expression, output)
   end
 end
 
+should 'GenerateSuiteTeardownWhenBeginAndEndAreOmitted' do
+  runner_name = OUT_FILE + 'SuiteTeardownWithoutBeginEnd_runner.c'
+  UnityTestRunnerGenerator.new(
+    :test_prefix => 'test',
+    :suite_teardown => '  return num_failures;',
+    :omit_begin_end => true,
+  ).run('testdata/testRunnerGenerator.c', runner_name)
+
+  runner = File.read(runner_name)
+  correct_call = runner.include?('(void) suiteTearDown(0);')
+  incorrect_call = runner.include?('(void) suite_teardown(0);')
+  if correct_call && !incorrect_call
+    report 'Runner_GenerateSuiteTeardownWhenBeginAndEndAreOmitted:PASS'
+  else
+    report 'Runner_GenerateSuiteTeardownWhenBeginAndEndAreOmitted:FAIL'
+    $generate_test_runner_failures += 1
+  end
+  $generate_test_runner_tests += 1
+end
+
 RUNNER_TESTS.each do |testset|
   basename = File.basename(testset[:testfile], C_EXTENSION)
   testset_name = "Runner_#{basename}_#{testset[:name]}"


### PR DESCRIPTION
:pineapple:

## Problem

When `omit_begin_end` and a custom `suite_teardown` are enabled together, the generated runner defines `suiteTearDown()` but calls `suite_teardown(0)`. Strict C99 compilation then fails because the called function does not exist.

## Fix

Call the emitted `suiteTearDown()` hook in the omit-begin/end path and add a generator regression test for this option combination.

## Verification

- New targeted generator regression passes.
- The baseline generated runner fails `-Werror=implicit-function-declaration`; the fixed runner compiles.
- A fixed generated runner executes one test with `1 Tests 0 Failures 0 Ignored`.
- Ruby syntax checks and `git diff --check` pass.

The full script suite passed the new regression and its first 38 existing cases before this Windows environment returned `EACCES` while launching an existing generated executable.
