### PR TITLE
Fix UnityPrint filename escaping in test runner

### DIFF
--- a/auto/generate_test_runner.rb
+++ b/auto/generate_test_runner.rb
@@ -509,7 +509,7 @@ class UnityTestRunnerGenerator
       output.puts('  {')
       output.puts('    if (parse_status < 0)')
       output.puts('    {')
-      output.puts("      UnityPrint(\"#{filename.gsub('.c', '').gsub(/\\/, '\\\\\\')}.\");")
+      output.puts("      UnityPrint(\"#{filename.gsub(/\\/, '\\\\\\')}\");")
       output.puts('      UNITY_PRINT_EOL();')
       tests.each do |test|
         if !@options[:use_param_tests] || test[:args].nil? || test[:args].empty?


### PR DESCRIPTION
Currently created code:

```c
    if (parse_status < 0)
    {
      UnityPrint("foo/bar/more/bla"); // file extension missing
      UNITY_PRINT_EOL();
      return 0;
    }
    return parse_status;
  }
```

This is then fixed to become:

```c
    if (parse_status < 0)
    {
      UnityPrint("foo/bar/more/bla.c"); // file extension added
      UNITY_PRINT_EOL();
      return 0;
    }
    return parse_status;
  }
```

(I needed to do apply this in the GitHub UI, please verify that I did not make copy-paste error in the web UI)