### PR TITLE
config: Add UNITY_IS_PRINTABLE_CHAR function macro

### DIFF
--- a/examples/unity_config.h
+++ b/examples/unity_config.h
@@ -250,4 +250,12 @@
  */
 /* #define UNITY_INCLUDE_EXEC_TIME */
 
+/* Define this macro to redefine what the UnityPrintChar() function considers
+ * a printable character.
+ *
+ * Example, for printing UTF-8:
+ * #define UNITY_IS_PRINTABLE_CHAR(c) ((128 <= (c)) && ((c) <= 255))
+*/
+/* #define UNITY_IS_PRINTABLE_CHAR(c) ((32 <= (c)) && ((c) <= 126)) */
+
 #endif /* UNITY_CONFIG_H */

--- a/src/unity.c
+++ b/src/unity.c
@@ -7,6 +7,8 @@
 
 #include "unity.h"
 
+#include <stdbool.h>
+
 #ifndef UNITY_PROGMEM
 #define UNITY_PROGMEM
 #endif
@@ -88,8 +90,14 @@ static const char UNITY_PROGMEM UnityStrDetail2Name[]            = " " UNITY_DET
 /* Local helper function to print characters. */
 static void UnityPrintChar(const char* pch)
 {
+#ifdef UNITY_IS_PRINTABLE_CHAR
+    const bool isPrintable = UNITY_IS_PRINTABLE_CHAR(*pch);
+#else
+    const bool isPrintable = ((32 <= *pch) && (*pch <= 126));
+#endif  // UNITY_IS_PRINTABLE_CHAR
+
     /* printable characters plus CR & LF are printed */
-    if ((*pch <= 126) && (*pch >= 32))
+    if (isPrintable)
     {
         UNITY_OUTPUT_CHAR(*pch);
     }


### PR DESCRIPTION
This allows other charsets, such as UTF-8, to be printed properly without escaping.