### PR TITLE
Fix default UNITY_INCLUDE_EXEC_TIME macros

### DIFF
--- a/docs/UnityChangeLog.md
+++ b/docs/UnityChangeLog.md
@@ -13,6 +13,12 @@ Prior to 2008, the project was an internal project and not released to the publi
 
 ## Log
 
+### Unity 2.7.2
+
+Significant Bugfixes:
+
+  - Default `UNITY_INCLUDE_EXEC_TIME` macros compile as ISO C99, are statement-safe, and accept `-Wsign-conversion` (#838)
+
 ### Unity 2.7.0 (July 2026)
 
 New Features:

--- a/docs/UnityConfigurationGuide.md
+++ b/docs/UnityConfigurationGuide.md
@@ -488,6 +488,10 @@ Define this to measure and report execution time for each test in the suite. Whe
 it's best to automatically find a way to determine the time in milliseconds. On most Windows, macos, or 
 Linux environments, this is automatic. If not, you can give Unity more information.
 
+On Unix and macOS, the default uses POSIX `clock_gettime(CLOCK_MONOTONIC)` when that clock is available.
+If it is not (strict ISO C with no POSIX clocks in `<time.h>`), it falls back to the standard `clock()` function,
+which is also the Windows default.
+
 #### `UNITY_CLOCK_MS`
 
 If you're working on a system (embedded or otherwise) which has an accessible millisecond timer. You can

--- a/src/unity_internals.h
+++ b/src/unity_internals.h
@@ -395,33 +395,34 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
       !defined(UNITY_EXEC_TIME_STOP) && \
       !defined(UNITY_PRINT_EXEC_TIME) && \
       !defined(UNITY_TIME_TYPE)
-      /* If none any of these macros are defined then try to provide a default implementation */
+      /* If none of these macros are defined then try to provide a default implementation */
 
     #if defined(UNITY_CLOCK_MS)
       /* This is a simple way to get a default implementation on platforms that support getting a millisecond counter */
       #define UNITY_TIME_TYPE UNITY_UINT
       #define UNITY_EXEC_TIME_START() Unity.CurrentTestStartTime = UNITY_CLOCK_MS()
       #define UNITY_EXEC_TIME_STOP() Unity.CurrentTestStopTime = UNITY_CLOCK_MS()
-      #define UNITY_PRINT_EXEC_TIME() { \
+      #define UNITY_PRINT_EXEC_TIME() do { \
         UNITY_UINT execTimeMs = (Unity.CurrentTestStopTime - Unity.CurrentTestStartTime); \
         UnityPrint(" ("); \
         UnityPrintNumberUnsigned(execTimeMs); \
         UnityPrint(" ms)"); \
-        }
+        } while (0)
     #elif defined(_WIN32)
       #include <time.h>
       #define UNITY_TIME_TYPE clock_t
       #define UNITY_GET_TIME(t) t = (clock_t)((clock() * 1000) / CLOCKS_PER_SEC)
       #define UNITY_EXEC_TIME_START() UNITY_GET_TIME(Unity.CurrentTestStartTime)
       #define UNITY_EXEC_TIME_STOP() UNITY_GET_TIME(Unity.CurrentTestStopTime)
-      #define UNITY_PRINT_EXEC_TIME() { \
-        UNITY_UINT execTimeMs = (Unity.CurrentTestStopTime - Unity.CurrentTestStartTime); \
+      #define UNITY_PRINT_EXEC_TIME() do { \
+        UNITY_UINT execTimeMs = (UNITY_UINT)(Unity.CurrentTestStopTime - Unity.CurrentTestStartTime); \
         UnityPrint(" ("); \
         UnityPrintNumberUnsigned(execTimeMs); \
         UnityPrint(" ms)"); \
-        }
+        } while (0)
     #elif defined(__unix__) || defined(__APPLE__)
       #include <time.h>
+      #if defined(CLOCK_MONOTONIC)
       #define UNITY_TIME_TYPE struct timespec
       #define UNITY_GET_TIME(t) clock_gettime(CLOCK_MONOTONIC, &t)
       #define UNITY_EXEC_TIME_START() UNITY_GET_TIME(Unity.CurrentTestStartTime)
@@ -432,7 +433,20 @@ typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
         UnityPrint(" ("); \
         UnityPrintNumberUnsigned(execTimeMs); \
         UnityPrint(" ms)"); \
-        } while(0)
+        } while (0)
+      #else
+      /* CLOCK_MONOTONIC is POSIX, not ISO C. Fall back so -std=c99 still compiles. */
+      #define UNITY_TIME_TYPE clock_t
+      #define UNITY_GET_TIME(t) t = (clock_t)((clock() * 1000) / CLOCKS_PER_SEC)
+      #define UNITY_EXEC_TIME_START() UNITY_GET_TIME(Unity.CurrentTestStartTime)
+      #define UNITY_EXEC_TIME_STOP() UNITY_GET_TIME(Unity.CurrentTestStopTime)
+      #define UNITY_PRINT_EXEC_TIME() do { \
+        UNITY_UINT execTimeMs = (UNITY_UINT)(Unity.CurrentTestStopTime - Unity.CurrentTestStartTime); \
+        UnityPrint(" ("); \
+        UnityPrintNumberUnsigned(execTimeMs); \
+        UnityPrint(" ms)"); \
+        } while (0)
+      #endif
     #endif
   #endif
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -43,7 +43,7 @@ TARGET = build/testunity-cov.exe
 # To generate coverage, call 'make -s', the default target runs.
 # For verbose output of all the tests, run 'make test'.
 default: test
-.PHONY: default coverage test clean
+.PHONY: default coverage test clean intDetection execTimeDetection
 coverage: $(SRC1) $(SRC2) $(SRC3) $(SRC4) $(SRC5) $(SRC6) $(SRC7) $(SRC8)
 	cd $(BUILD_DIR) && \
 	$(CC) $(CFLAGS) $(DEFINES) $(foreach i,$(SRC1), ../$i) $(COV_FLAGS) -o ../$(TARGET)
@@ -122,9 +122,16 @@ test: $(SRC1) $(SRC2) $(SRC3) $(SRC4) $(SRC5) $(SRC6) $(SRC7) $(SRC8)
 
 # Compile only, for testing that preprocessor detection works
 UNITY_C_ONLY =-c ../src/unity.c -o $(BUILD_DIR)/unity.o
-intDetection:
+intDetection: | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INC_DIR) $(UNITY_C_ONLY) -D UNITY_EXCLUDE_STDINT_H
 	$(CC) $(CFLAGS) $(INC_DIR) $(UNITY_C_ONLY) -D UNITY_EXCLUDE_LIMITS_H
+
+# UNITY_INCLUDE_EXEC_TIME is optional and was historically untested, so the
+# default timer macros could rot. Compile them with Unity's own warning flags
+# and with -Wsign-conversion (the failure reported in #838).
+execTimeDetection: | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INC_DIR) $(UNITY_C_ONLY) -D UNITY_INCLUDE_EXEC_TIME
+	$(CC) $(CFLAGS) -Wsign-conversion $(INC_DIR) $(UNITY_C_ONLY) -D UNITY_INCLUDE_EXEC_TIME
 
 $(BUILD_DIR)/test_unity_arraysRunner.c: tests/test_unity_arrays.c | $(BUILD_DIR)
 	awk $(AWK_SCRIPT) tests/test_unity_arrays.c > $@

--- a/test/rakefile_helper.rb
+++ b/test/rakefile_helper.rb
@@ -407,6 +407,7 @@ module RakefileHelpers
     combined_output = ''
     [ "make -s",                 # test with all defaults
       "make -s coverage",        # test with coverage
+      "make -s execTimeDetection", # compile default UNITY_INCLUDE_EXEC_TIME macros
       "cd #{File.join("..","extras","fixture",'test')} && make -s default noStdlibMalloc",
       "cd #{File.join("..","extras","fixture",'test')} && make -s C89",
       "cd #{File.join("..","extras","memory",'test')} && make -s default noStdlibMalloc",


### PR DESCRIPTION
:pineapple:

## Problem

`UNITY_INCLUDE_EXEC_TIME` cannot be used with `-Werror=sign-conversion`. On Windows the default `UNITY_PRINT_EXEC_TIME` assigns a signed `clock_t` delta to `UNITY_UINT`. Two of the three print macros are also brace blocks rather than statements, so `MACRO();` is not `if`/`else` safe. CI never compiled this optional path, so it could rot.

Unix already uses `clock_gettime(CLOCK_MONOTONIC)` (with casts and `do/while`) when that clock exists. That path is unchanged.

## Fix

- Cast signed time deltas to `UNITY_UINT` and use `do { } while (0)` on the Windows and `UNITY_CLOCK_MS` print macros.
- If Unix/macOS has no `CLOCK_MONOTONIC` in `<time.h>`, fall back to ISO C `clock()`.
- Add `make execTimeDetection` and run it from `rake ci`.

Closes #838.

## Verification

- `unity.c` compiles with MSVC with and without `-DUNITY_INCLUDE_EXEC_TIME`.
- This environment has no gcc/make, so `make test` / `rake ci` were not run locally. GitHub Actions `rake ci` now includes `execTimeDetection`.
